### PR TITLE
chore: add Claude Code session-start hook for remote environments

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# Install npm dependencies
+npm install
+
+# Set up .env if it doesn't exist
+if [ ! -f .env ]; then
+  echo 'DATABASE_URL="file:./prisma/dev.db"' > .env
+fi
+
+# Generate Prisma client
+npx prisma generate
+
+# Run database migrations
+npx prisma migrate deploy

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs npm dependencies, sets up .env with default DATABASE_URL, generates the Prisma client, and applies migrations on session start.

https://claude.ai/code/session_01Uzhe5Knjfc3qoUgtpcvCUd