### PR TITLE
Fix build: wrap photo modal JSX in fragment on detail pages

### DIFF
--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -174,6 +174,7 @@ export default function AccessoryDetailPage() {
   }
 
   return (
+    <>
     <div className="min-h-full">
       {/* Header with image */}
       <div className="relative h-44 bg-vault-bg overflow-hidden">
@@ -505,5 +506,6 @@ export default function AccessoryDetailPage() {
         </div>
       </div>
     )}
+    </>
   );
 }

--- a/src/app/vault/[id]/page.tsx
+++ b/src/app/vault/[id]/page.tsx
@@ -230,6 +230,7 @@ export default function FirearmDetailPage() {
   }
 
   return (
+    <>
     <div className="min-h-full flex flex-col lg:flex-row">
       {/* Main content */}
       <div className="flex-1 min-w-0">
@@ -657,7 +658,6 @@ export default function FirearmDetailPage() {
         )}
       </div>
     </div>
-
     {/* Photo upload modal */}
     {photoModalOpen && (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ backgroundColor: "rgba(5,7,9,0.85)" }}>
@@ -682,5 +682,6 @@ export default function FirearmDetailPage() {
         </div>
       </div>
     )}
+    </>
   );
 }


### PR DESCRIPTION
The photo upload modal was placed as a sibling to the root element inside the return statement, causing a JSX parse error. Wrapped both returns in a fragment to fix the Docker build failure.

https://claude.ai/code/session_01Uzhe5Knjfc3qoUgtpcvCUd