### PR TITLE
feat: add full training & range session suite

### DIFF
--- a/prisma/migrations/20260305181147_add_training_features/migration.sql
+++ b/prisma/migrations/20260305181147_add_training_features/migration.sql
@@ -1,0 +1,72 @@
+-- AlterTable
+ALTER TABLE "RangeSession" ADD COLUMN "environment" TEXT;
+ALTER TABLE "RangeSession" ADD COLUMN "groupNotes" TEXT;
+ALTER TABLE "RangeSession" ADD COLUMN "groupSizeIn" REAL;
+ALTER TABLE "RangeSession" ADD COLUMN "groupSizeMoa" REAL;
+ALTER TABLE "RangeSession" ADD COLUMN "humidity" REAL;
+ALTER TABLE "RangeSession" ADD COLUMN "lightCondition" TEXT;
+ALTER TABLE "RangeSession" ADD COLUMN "numberOfGroups" INTEGER;
+ALTER TABLE "RangeSession" ADD COLUMN "targetDistanceYd" REAL;
+ALTER TABLE "RangeSession" ADD COLUMN "temperatureF" REAL;
+ALTER TABLE "RangeSession" ADD COLUMN "weatherNotes" TEXT;
+ALTER TABLE "RangeSession" ADD COLUMN "windDirection" TEXT;
+ALTER TABLE "RangeSession" ADD COLUMN "windSpeedMph" REAL;
+
+-- CreateTable
+CREATE TABLE "DrillTemplate" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "category" TEXT NOT NULL DEFAULT 'CUSTOM',
+    "scoringType" TEXT NOT NULL DEFAULT 'NOTES_ONLY',
+    "parTime" REAL,
+    "maxScore" INTEGER,
+    "isBuiltIn" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "SessionDrill" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sessionId" TEXT NOT NULL,
+    "templateId" TEXT,
+    "drillName" TEXT NOT NULL,
+    "timeSeconds" REAL,
+    "hits" INTEGER,
+    "totalShots" INTEGER,
+    "accuracy" REAL,
+    "score" REAL,
+    "notes" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SessionDrill_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "RangeSession" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SessionDrill_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "DrillTemplate" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "SessionAmmoLink" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sessionId" TEXT NOT NULL,
+    "transactionId" TEXT NOT NULL,
+    CONSTRAINT "SessionAmmoLink_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "RangeSession" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SessionAmmoLink_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "AmmoTransaction" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "DrillTemplate_category_idx" ON "DrillTemplate"("category");
+
+-- CreateIndex
+CREATE INDEX "SessionDrill_sessionId_idx" ON "SessionDrill"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "SessionDrill_templateId_idx" ON "SessionDrill"("templateId");
+
+-- CreateIndex
+CREATE INDEX "SessionAmmoLink_sessionId_idx" ON "SessionAmmoLink"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "SessionAmmoLink_transactionId_idx" ON "SessionAmmoLink"("transactionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SessionAmmoLink_sessionId_transactionId_key" ON "SessionAmmoLink"("sessionId", "transactionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,11 +144,83 @@ model RangeSession {
   rangeLocation String?
   notes         String?
 
+  // ── Environment / Weather ─────────────────────────────
+  environment    String?   // "INDOOR" | "OUTDOOR"
+  temperatureF   Float?    // degrees Fahrenheit
+  windSpeedMph   Float?    // mph
+  windDirection  String?   // e.g. "NW", "Headwind", "Crosswind"
+  humidity       Float?    // 0-100 percentage
+  lightCondition String?   // "BRIGHT" | "OVERCAST" | "LOW_LIGHT" | "NIGHT"
+  weatherNotes   String?
+
+  // ── Shot Group Data ───────────────────────────────────
+  targetDistanceYd Float?  // yards
+  groupSizeIn      Float?  // best group in inches
+  groupSizeMoa     Float?  // MOA (best group)
+  numberOfGroups   Int?
+  groupNotes       String?
+
+  // ── Relations ─────────────────────────────────────────
+  sessionDrills  SessionDrill[]
+  ammoLinks      SessionAmmoLink[]
+
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
   @@index([firearmId])
   @@index([date])
+}
+
+model DrillTemplate {
+  id          String         @id @default(cuid())
+  name        String
+  description String?
+  // category: "ACCURACY" | "SPEED" | "TACTICAL" | "FUNDAMENTALS" | "CUSTOM"
+  category    String         @default("CUSTOM")
+  // scoringType: "TIME" | "SCORE" | "TIME_AND_SCORE" | "PASS_FAIL" | "NOTES_ONLY"
+  scoringType String         @default("NOTES_ONLY")
+  parTime     Float?         // par time in seconds
+  maxScore    Int?
+  isBuiltIn   Boolean        @default(false)
+
+  sessionDrills SessionDrill[]
+
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  @@index([category])
+}
+
+model SessionDrill {
+  id          String         @id @default(cuid())
+  sessionId   String
+  session     RangeSession   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  templateId  String?
+  template    DrillTemplate? @relation(fields: [templateId], references: [id], onDelete: SetNull)
+  drillName   String         // denormalized; preserved if template is deleted
+  timeSeconds Float?
+  hits        Int?
+  totalShots  Int?
+  accuracy    Float?         // 0-100 percentage
+  score       Float?
+  notes       String?
+  sortOrder   Int            @default(0)
+  createdAt   DateTime       @default(now())
+
+  @@index([sessionId])
+  @@index([templateId])
+}
+
+model SessionAmmoLink {
+  id            String          @id @default(cuid())
+  sessionId     String
+  session       RangeSession    @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  transactionId String
+  transaction   AmmoTransaction @relation(fields: [transactionId], references: [id], onDelete: Cascade)
+
+  @@unique([sessionId, transactionId])
+  @@index([sessionId])
+  @@index([transactionId])
 }
 
 // ─── MAINTENANCE NOTES ────────────────────────────────────────
@@ -205,6 +277,8 @@ model AmmoTransaction {
   newQty       Int
   note         String?
   transactedAt DateTime @default(now())
+
+  sessionLinks SessionAmmoLink[]
 
   @@index([stockId])
   @@index([transactedAt])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -332,6 +332,84 @@ async function main() {
   const ammoCount = await prisma.ammoStock.count();
   console.log(`  Ammo stocks: ${ammoCount} records in table`);
 
+  // ─── DRILL TEMPLATES ──────────────────────────────────────────
+  const drillTemplates = [
+    {
+      name: "Bill Drill",
+      description: "Draw and fire 6 rounds at 7 yards as fast as possible while maintaining accuracy (A-zone hits).",
+      category: "SPEED",
+      scoringType: "TIME",
+      parTime: 2.0,
+      isBuiltIn: true,
+    },
+    {
+      name: "FAST Test",
+      description: "Draw, fire 2 rounds to body, slide lock reload, fire 1 round to body, 1 round to head at 7 yards.",
+      category: "SPEED",
+      scoringType: "TIME_AND_SCORE",
+      parTime: 5.0,
+      isBuiltIn: true,
+    },
+    {
+      name: "El Presidente",
+      description: "3 targets at 10 yards, start facing uprange. Turn, draw, fire 2 rounds each, reload, fire 2 rounds each.",
+      category: "TACTICAL",
+      scoringType: "TIME",
+      parTime: 10.0,
+      isBuiltIn: true,
+    },
+    {
+      name: "Failure to Stop",
+      description: "Fire 2 rounds to body, 1 round to head (Mozambique Drill). Tests controlled pair + precision shot.",
+      category: "TACTICAL",
+      scoringType: "PASS_FAIL",
+      isBuiltIn: true,
+    },
+    {
+      name: "25yd Zero Check",
+      description: "5 rounds slow-fire at 25 yards from a supported position. Verify zero and group consistency.",
+      category: "ACCURACY",
+      scoringType: "SCORE",
+      maxScore: 50,
+      isBuiltIn: true,
+    },
+    {
+      name: "1-Reload-1",
+      description: "Fire 1 round, perform an emergency reload, fire 1 round. Measures reload speed and consistency.",
+      category: "FUNDAMENTALS",
+      scoringType: "TIME",
+      parTime: 4.0,
+      isBuiltIn: true,
+    },
+    {
+      name: "Dot Torture",
+      description: "50-round accuracy drill on 10 small dots at 3-5 yards. Tests trigger control and accuracy fundamentals.",
+      category: "ACCURACY",
+      scoringType: "SCORE",
+      maxScore: 50,
+      isBuiltIn: true,
+    },
+    {
+      name: "Cold Bore Shot",
+      description: "First round of the session from position. Records where the cold bore shot impacts vs. zero.",
+      category: "FUNDAMENTALS",
+      scoringType: "NOTES_ONLY",
+      isBuiltIn: true,
+    },
+  ];
+
+  for (const tpl of drillTemplates) {
+    const existing = await prisma.drillTemplate.findFirst({
+      where: { name: tpl.name, isBuiltIn: true },
+    });
+    if (!existing) {
+      await prisma.drillTemplate.create({ data: tpl });
+    }
+  }
+
+  const drillCount = await prisma.drillTemplate.count();
+  console.log(`  Drill templates: ${drillCount} records in table`);
+
   console.log("Seed complete.");
 }
 

--- a/src/app/api/drill-templates/[id]/route.ts
+++ b/src/app/api/drill-templates/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// PUT /api/drill-templates/[id]
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { name, description, category, scoringType, parTime, maxScore } = body;
+
+    const existing = await prisma.drillTemplate.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
+    if (existing.isBuiltIn) {
+      return NextResponse.json({ error: "Cannot modify built-in templates" }, { status: 403 });
+    }
+
+    const template = await prisma.drillTemplate.update({
+      where: { id },
+      data: {
+        name: typeof name === "string" ? name.slice(0, 200) : undefined,
+        description: typeof description === "string" ? description.slice(0, 1000) : null,
+        category: typeof category === "string" ? category : undefined,
+        scoringType: typeof scoringType === "string" ? scoringType : undefined,
+        parTime: parTime != null ? parseFloat(String(parTime)) : null,
+        maxScore: maxScore != null ? parseInt(String(maxScore), 10) : null,
+      },
+    });
+
+    return NextResponse.json(template);
+  } catch (error) {
+    console.error("PUT /api/drill-templates/[id] error:", error);
+    return NextResponse.json({ error: "Failed to update drill template" }, { status: 500 });
+  }
+}
+
+// DELETE /api/drill-templates/[id]
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const existing = await prisma.drillTemplate.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
+    if (existing.isBuiltIn) {
+      return NextResponse.json({ error: "Cannot delete built-in templates" }, { status: 403 });
+    }
+
+    await prisma.drillTemplate.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/drill-templates/[id] error:", error);
+    return NextResponse.json({ error: "Failed to delete drill template" }, { status: 500 });
+  }
+}

--- a/src/app/api/drill-templates/route.ts
+++ b/src/app/api/drill-templates/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// GET /api/drill-templates - List all drill templates
+export async function GET() {
+  try {
+    const templates = await prisma.drillTemplate.findMany({
+      orderBy: [{ category: "asc" }, { name: "asc" }],
+    });
+    return NextResponse.json(templates);
+  } catch (error) {
+    console.error("GET /api/drill-templates error:", error);
+    return NextResponse.json({ error: "Failed to fetch drill templates" }, { status: 500 });
+  }
+}
+
+// POST /api/drill-templates - Create a custom drill template
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, description, category, scoringType, parTime, maxScore } = body;
+
+    if (!name) {
+      return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+
+    const template = await prisma.drillTemplate.create({
+      data: {
+        name: String(name).slice(0, 200),
+        description: typeof description === "string" && description ? description.slice(0, 1000) : null,
+        category: typeof category === "string" ? category : "CUSTOM",
+        scoringType: typeof scoringType === "string" ? scoringType : "NOTES_ONLY",
+        parTime: parTime != null ? parseFloat(String(parTime)) : null,
+        maxScore: maxScore != null ? parseInt(String(maxScore), 10) : null,
+        isBuiltIn: false,
+      },
+    });
+
+    return NextResponse.json(template, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/drill-templates error:", error);
+    return NextResponse.json({ error: "Failed to create drill template" }, { status: 500 });
+  }
+}

--- a/src/app/api/range-sessions/[id]/drills/[drillId]/route.ts
+++ b/src/app/api/range-sessions/[id]/drills/[drillId]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// PUT /api/range-sessions/[id]/drills/[drillId]
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; drillId: string }> }
+) {
+  try {
+    const { drillId } = await params;
+    const body = await request.json();
+    const { drillName, timeSeconds, hits, totalShots, accuracy, score, notes, sortOrder, templateId } = body;
+
+    const parseFloat_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseFloat(String(v));
+      return Number.isFinite(n) ? n : null;
+    };
+    const parseInt_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseInt(String(v), 10);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    const drill = await prisma.sessionDrill.update({
+      where: { id: drillId },
+      data: {
+        templateId: templateId !== undefined ? (templateId || null) : undefined,
+        drillName: typeof drillName === "string" ? drillName.slice(0, 200) : undefined,
+        timeSeconds: parseFloat_(timeSeconds),
+        hits: parseInt_(hits),
+        totalShots: parseInt_(totalShots),
+        accuracy: parseFloat_(accuracy),
+        score: parseFloat_(score),
+        notes: typeof notes === "string" && notes ? notes.slice(0, 2000) : null,
+        sortOrder: parseInt_(sortOrder) ?? undefined,
+      },
+      include: { template: true },
+    });
+
+    return NextResponse.json(drill);
+  } catch (error) {
+    console.error("PUT /api/range-sessions/[id]/drills/[drillId] error:", error);
+    return NextResponse.json({ error: "Failed to update drill" }, { status: 500 });
+  }
+}
+
+// DELETE /api/range-sessions/[id]/drills/[drillId]
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; drillId: string }> }
+) {
+  try {
+    const { drillId } = await params;
+    await prisma.sessionDrill.delete({ where: { id: drillId } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/range-sessions/[id]/drills/[drillId] error:", error);
+    return NextResponse.json({ error: "Failed to delete drill" }, { status: 500 });
+  }
+}

--- a/src/app/api/range-sessions/[id]/drills/route.ts
+++ b/src/app/api/range-sessions/[id]/drills/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// POST /api/range-sessions/[id]/drills - Add a drill result to a session
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: sessionId } = await params;
+    const body = await request.json();
+    const {
+      templateId,
+      drillName,
+      timeSeconds,
+      hits,
+      totalShots,
+      accuracy,
+      score,
+      notes,
+      sortOrder,
+    } = body;
+
+    if (!drillName) {
+      return NextResponse.json({ error: "drillName is required" }, { status: 400 });
+    }
+
+    const parseFloat_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseFloat(String(v));
+      return Number.isFinite(n) ? n : null;
+    };
+    const parseInt_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseInt(String(v), 10);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    const drill = await prisma.sessionDrill.create({
+      data: {
+        sessionId,
+        templateId: templateId || null,
+        drillName: String(drillName).slice(0, 200),
+        timeSeconds: parseFloat_(timeSeconds),
+        hits: parseInt_(hits),
+        totalShots: parseInt_(totalShots),
+        accuracy: parseFloat_(accuracy),
+        score: parseFloat_(score),
+        notes: typeof notes === "string" && notes ? notes.slice(0, 2000) : null,
+        sortOrder: parseInt_(sortOrder) ?? 0,
+      },
+      include: { template: true },
+    });
+
+    return NextResponse.json(drill, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/range-sessions/[id]/drills error:", error);
+    return NextResponse.json({ error: "Failed to add drill" }, { status: 500 });
+  }
+}

--- a/src/app/api/range-sessions/[id]/route.ts
+++ b/src/app/api/range-sessions/[id]/route.ts
@@ -1,6 +1,143 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+// GET /api/range-sessions/[id]
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const session = await prisma.rangeSession.findUnique({
+      where: { id },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+        build: { select: { id: true, name: true } },
+        sessionDrills: {
+          include: { template: true },
+          orderBy: { sortOrder: "asc" },
+        },
+        ammoLinks: {
+          include: {
+            transaction: {
+              include: {
+                stock: { select: { caliber: true, brand: true, grainWeight: true, bulletType: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(session);
+  } catch (error) {
+    console.error("GET /api/range-sessions/[id] error:", error);
+    return NextResponse.json({ error: "Failed to fetch session" }, { status: 500 });
+  }
+}
+
+// PUT /api/range-sessions/[id]
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const {
+      buildId,
+      roundsFired,
+      rangeName,
+      rangeLocation,
+      notes,
+      date,
+      environment,
+      temperatureF,
+      windSpeedMph,
+      windDirection,
+      humidity,
+      lightCondition,
+      weatherNotes,
+      targetDistanceYd,
+      groupSizeIn,
+      groupSizeMoa,
+      numberOfGroups,
+      groupNotes,
+      ammoTransactionIds,
+    } = body;
+
+    const parseFloat_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseFloat(String(v));
+      return Number.isFinite(n) ? n : null;
+    };
+    const parseInt_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseInt(String(v), 10);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    const session = await prisma.$transaction(async (tx) => {
+      const updated = await tx.rangeSession.update({
+        where: { id },
+        data: {
+          buildId: buildId !== undefined ? (buildId || null) : undefined,
+          roundsFired: roundsFired !== undefined ? parseInt(String(roundsFired), 10) : undefined,
+          rangeName: typeof rangeName === "string" ? rangeName.slice(0, 200) : null,
+          rangeLocation: typeof rangeLocation === "string" ? rangeLocation.slice(0, 200) : null,
+          notes: typeof notes === "string" ? notes.slice(0, 5000) : null,
+          date: date ? new Date(date) : undefined,
+          environment: typeof environment === "string" ? environment : null,
+          temperatureF: parseFloat_(temperatureF),
+          windSpeedMph: parseFloat_(windSpeedMph),
+          windDirection: typeof windDirection === "string" && windDirection ? windDirection : null,
+          humidity: parseFloat_(humidity),
+          lightCondition: typeof lightCondition === "string" ? lightCondition : null,
+          weatherNotes: typeof weatherNotes === "string" && weatherNotes ? weatherNotes.slice(0, 1000) : null,
+          targetDistanceYd: parseFloat_(targetDistanceYd),
+          groupSizeIn: parseFloat_(groupSizeIn),
+          groupSizeMoa: parseFloat_(groupSizeMoa),
+          numberOfGroups: parseInt_(numberOfGroups),
+          groupNotes: typeof groupNotes === "string" && groupNotes ? groupNotes.slice(0, 1000) : null,
+        },
+        include: {
+          firearm: { select: { id: true, name: true, caliber: true } },
+          build: { select: { id: true, name: true } },
+          sessionDrills: { include: { template: true }, orderBy: { sortOrder: "asc" } },
+          ammoLinks: {
+            include: {
+              transaction: {
+                include: {
+                  stock: { select: { caliber: true, brand: true, grainWeight: true, bulletType: true } },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      // Update ammo links if provided
+      if (Array.isArray(ammoTransactionIds)) {
+        await tx.sessionAmmoLink.deleteMany({ where: { sessionId: id } });
+        for (const transactionId of ammoTransactionIds as string[]) {
+          await tx.sessionAmmoLink.create({ data: { sessionId: id, transactionId } });
+        }
+      }
+
+      return updated;
+    });
+
+    return NextResponse.json(session);
+  } catch (error) {
+    console.error("PUT /api/range-sessions/[id] error:", error);
+    return NextResponse.json({ error: "Failed to update session" }, { status: 500 });
+  }
+}
+
 // DELETE /api/range-sessions/[id]
 export async function DELETE(
   _request: NextRequest,

--- a/src/app/api/range-sessions/route.ts
+++ b/src/app/api/range-sessions/route.ts
@@ -1,19 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
-// GET /api/range-sessions - List range sessions, optional ?firearmId= filter
+// GET /api/range-sessions - List range sessions, optional ?firearmId= filter, ?include=analytics
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const firearmId = searchParams.get("firearmId");
     const limitRaw = parseInt(searchParams.get("limit") ?? "", 10);
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : undefined;
+    const includeAnalytics = searchParams.get("include") === "analytics";
 
     const sessions = await prisma.rangeSession.findMany({
       where: firearmId ? { firearmId } : undefined,
       include: {
-        firearm: { select: { id: true, name: true } },
+        firearm: { select: { id: true, name: true, caliber: true } },
         build: { select: { id: true, name: true } },
+        _count: { select: { sessionDrills: true } },
+        ...(includeAnalytics
+          ? {
+              sessionDrills: {
+                select: { accuracy: true, drillName: true, templateId: true, timeSeconds: true, score: true },
+              },
+            }
+          : {}),
       },
       orderBy: { date: "desc" },
       take: limit,
@@ -30,7 +39,31 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { firearmId, buildId, roundsFired, rangeName, rangeLocation, notes, date } = body;
+    const {
+      firearmId,
+      buildId,
+      roundsFired,
+      rangeName,
+      rangeLocation,
+      notes,
+      date,
+      // Environment
+      environment,
+      temperatureF,
+      windSpeedMph,
+      windDirection,
+      humidity,
+      lightCondition,
+      weatherNotes,
+      // Shot groups
+      targetDistanceYd,
+      groupSizeIn,
+      groupSizeMoa,
+      numberOfGroups,
+      groupNotes,
+      // Ammo links
+      ammoTransactionIds,
+    } = body;
 
     if (!firearmId || roundsFired === undefined || roundsFired === null) {
       return NextResponse.json(
@@ -44,20 +77,59 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "roundsFired must be a non-negative integer" }, { status: 400 });
     }
 
-    const session = await prisma.rangeSession.create({
-      data: {
-        firearmId,
-        buildId: buildId || null,
-        roundsFired: rounds,
-        rangeName: typeof rangeName === "string" ? rangeName.slice(0, 200) : null,
-        rangeLocation: typeof rangeLocation === "string" ? rangeLocation.slice(0, 200) : null,
-        notes: typeof notes === "string" ? notes.slice(0, 5000) : null,
-        date: date ? new Date(date) : new Date(),
-      },
-      include: {
-        firearm: { select: { id: true, name: true } },
-        build: { select: { id: true, name: true } },
-      },
+    const parseFloat_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseFloat(String(v));
+      return Number.isFinite(n) ? n : null;
+    };
+    const parseInt_ = (v: unknown) => {
+      if (v === null || v === undefined || v === "") return null;
+      const n = parseInt(String(v), 10);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    const session = await prisma.$transaction(async (tx) => {
+      const created = await tx.rangeSession.create({
+        data: {
+          firearmId,
+          buildId: buildId || null,
+          roundsFired: rounds,
+          rangeName: typeof rangeName === "string" ? rangeName.slice(0, 200) : null,
+          rangeLocation: typeof rangeLocation === "string" ? rangeLocation.slice(0, 200) : null,
+          notes: typeof notes === "string" ? notes.slice(0, 5000) : null,
+          date: date ? new Date(date) : new Date(),
+          // environment
+          environment: typeof environment === "string" ? environment : null,
+          temperatureF: parseFloat_(temperatureF),
+          windSpeedMph: parseFloat_(windSpeedMph),
+          windDirection: typeof windDirection === "string" && windDirection ? windDirection : null,
+          humidity: parseFloat_(humidity),
+          lightCondition: typeof lightCondition === "string" ? lightCondition : null,
+          weatherNotes: typeof weatherNotes === "string" && weatherNotes ? weatherNotes.slice(0, 1000) : null,
+          // shot groups
+          targetDistanceYd: parseFloat_(targetDistanceYd),
+          groupSizeIn: parseFloat_(groupSizeIn),
+          groupSizeMoa: parseFloat_(groupSizeMoa),
+          numberOfGroups: parseInt_(numberOfGroups),
+          groupNotes: typeof groupNotes === "string" && groupNotes ? groupNotes.slice(0, 1000) : null,
+        },
+        include: {
+          firearm: { select: { id: true, name: true, caliber: true } },
+          build: { select: { id: true, name: true } },
+        },
+      });
+
+      if (Array.isArray(ammoTransactionIds) && ammoTransactionIds.length > 0) {
+        for (const transactionId of ammoTransactionIds as string[]) {
+          await tx.sessionAmmoLink.upsert({
+            where: { sessionId_transactionId: { sessionId: created.id, transactionId } },
+            create: { sessionId: created.id, transactionId },
+            update: {},
+          });
+        }
+      }
+
+      return created;
     });
 
     return NextResponse.json(session, { status: 201 });

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -6,6 +6,8 @@ import { prisma } from "@/lib/prisma";
 //          total investment value, recent items
 export async function GET() {
   try {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
     const [
       firearmCount,
       accessoryCount,
@@ -15,6 +17,9 @@ export async function GET() {
       recentFirearms,
       recentAccessories,
       recentAmmo,
+      rangeSessionAggregate,
+      rangeSessionsLast30,
+      lastRangeSession,
     ] = await Promise.all([
       // Total firearms
       prisma.firearm.count(),
@@ -93,6 +98,29 @@ export async function GET() {
           brand: true,
           quantity: true,
           updatedAt: true,
+        },
+      }),
+
+      // Range session totals
+      prisma.rangeSession.aggregate({
+        _sum: { roundsFired: true },
+        _count: { id: true },
+      }),
+
+      // Sessions in last 30 days
+      prisma.rangeSession.count({
+        where: { date: { gte: thirtyDaysAgo } },
+      }),
+
+      // Most recent session
+      prisma.rangeSession.findFirst({
+        orderBy: { date: "desc" },
+        select: {
+          id: true,
+          date: true,
+          rangeName: true,
+          roundsFired: true,
+          firearm: { select: { name: true } },
         },
       }),
     ]);
@@ -188,6 +216,20 @@ export async function GET() {
         firearms: recentFirearms,
         accessories: recentAccessories,
         ammo: recentAmmo,
+      },
+      rangeSessions: {
+        count: rangeSessionAggregate._count.id,
+        totalRounds: rangeSessionAggregate._sum.roundsFired ?? 0,
+        sessionsLast30Days: rangeSessionsLast30,
+        lastSession: lastRangeSession
+          ? {
+              id: lastRangeSession.id,
+              date: lastRangeSession.date,
+              rangeName: lastRangeSession.rangeName,
+              roundsFired: lastRangeSession.roundsFired,
+              firearmName: lastRangeSession.firearm.name,
+            }
+          : null,
       },
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import { PageHeader } from "@/components/shared/PageHeader";
 import { DashboardClient } from "@/components/dashboard/DashboardClient";
 
 async function getDashboardData() {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
   const [
     firearmCount,
     accessoryCount,
@@ -10,6 +12,9 @@ async function getDashboardData() {
     firearms,
     accessories,
     recentFirearms,
+    rangeSessionAggregate,
+    rangeSessionsLast30,
+    lastRangeSession,
   ] = await Promise.all([
     prisma.firearm.count(),
     prisma.accessory.count(),
@@ -46,6 +51,23 @@ async function getDashboardData() {
         createdAt: true,
       },
     }),
+    prisma.rangeSession.aggregate({
+      _sum: { roundsFired: true },
+      _count: { id: true },
+    }),
+    prisma.rangeSession.count({
+      where: { date: { gte: thirtyDaysAgo } },
+    }),
+    prisma.rangeSession.findFirst({
+      orderBy: { date: "desc" },
+      select: {
+        id: true,
+        date: true,
+        rangeName: true,
+        roundsFired: true,
+        firearm: { select: { name: true } },
+      },
+    }),
   ]);
 
   const totalAmmoRounds = ammoStocks.reduce((sum, s) => sum + s.quantity, 0);
@@ -65,6 +87,20 @@ async function getDashboardData() {
     lowStockItems,
     recentFirearms,
     ammoStocks,
+    rangeStats: {
+      count: rangeSessionAggregate._count.id,
+      totalRounds: rangeSessionAggregate._sum.roundsFired ?? 0,
+      sessionsLast30Days: rangeSessionsLast30,
+      lastSession: lastRangeSession
+        ? {
+            id: lastRangeSession.id,
+            date: lastRangeSession.date,
+            rangeName: lastRangeSession.rangeName,
+            roundsFired: lastRangeSession.roundsFired,
+            firearmName: lastRangeSession.firearm.name,
+          }
+        : null,
+    },
   };
 }
 

--- a/src/app/range/[id]/page.tsx
+++ b/src/app/range/[id]/page.tsx
@@ -1,0 +1,746 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { formatNumber } from "@/lib/utils";
+import {
+  Target,
+  ArrowLeft,
+  Thermometer,
+  Wind,
+  Cloud,
+  Droplets,
+  Sun,
+  Crosshair,
+  PackageCheck,
+  Loader2,
+  AlertCircle,
+  Pencil,
+  Trash2,
+  Plus,
+  Check,
+  X,
+  ChevronDown,
+  Timer,
+  Award,
+  BookOpen,
+  ListChecks,
+} from "lucide-react";
+
+const INPUT_CLASS =
+  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
+const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+
+interface DrillTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  scoringType: string;
+  parTime: number | null;
+  maxScore: number | null;
+  isBuiltIn: boolean;
+}
+
+interface SessionDrill {
+  id: string;
+  drillName: string;
+  templateId: string | null;
+  template: DrillTemplate | null;
+  timeSeconds: number | null;
+  hits: number | null;
+  totalShots: number | null;
+  accuracy: number | null;
+  score: number | null;
+  notes: string | null;
+  sortOrder: number;
+}
+
+interface AmmoLink {
+  id: string;
+  transaction: {
+    id: string;
+    type: string;
+    quantity: number;
+    transactedAt: string;
+    stock: {
+      caliber: string;
+      brand: string;
+      grainWeight: number | null;
+      bulletType: string | null;
+    };
+  };
+}
+
+interface RangeSession {
+  id: string;
+  date: string;
+  roundsFired: number;
+  rangeName: string | null;
+  rangeLocation: string | null;
+  notes: string | null;
+  environment: string | null;
+  temperatureF: number | null;
+  windSpeedMph: number | null;
+  windDirection: string | null;
+  humidity: number | null;
+  lightCondition: string | null;
+  weatherNotes: string | null;
+  targetDistanceYd: number | null;
+  groupSizeIn: number | null;
+  groupSizeMoa: number | null;
+  numberOfGroups: number | null;
+  groupNotes: string | null;
+  firearm: { id: string; name: string; caliber: string };
+  build: { id: string; name: string } | null;
+  sessionDrills: SessionDrill[];
+  ammoLinks: AmmoLink[];
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  ACCURACY: "text-[#00C853] border-[#00C853]/30 bg-[#00C853]/10",
+  SPEED: "text-[#F5A623] border-[#F5A623]/30 bg-[#F5A623]/10",
+  TACTICAL: "text-[#E53935] border-[#E53935]/30 bg-[#E53935]/10",
+  FUNDAMENTALS: "text-[#00C2FF] border-[#00C2FF]/30 bg-[#00C2FF]/10",
+  CUSTOM: "text-vault-text-muted border-vault-border bg-vault-surface",
+};
+
+const SCORING_FIELDS: Record<string, string[]> = {
+  TIME: ["timeSeconds"],
+  SCORE: ["score", "hits", "totalShots"],
+  TIME_AND_SCORE: ["timeSeconds", "score", "hits", "totalShots"],
+  PASS_FAIL: ["hits", "totalShots"],
+  NOTES_ONLY: [],
+};
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    weekday: "long", year: "numeric", month: "long", day: "numeric",
+  });
+}
+
+function DrillCard({ drill, onEdit, onDelete }: {
+  drill: SessionDrill;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const par = drill.template?.parTime;
+  const underPar = par && drill.timeSeconds && drill.timeSeconds < par;
+  const overPar = par && drill.timeSeconds && drill.timeSeconds > par;
+
+  return (
+    <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-vault-text text-sm">{drill.drillName}</span>
+            {drill.template && (
+              <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono ${CATEGORY_COLORS[drill.template.category] ?? CATEGORY_COLORS.CUSTOM}`}>
+                {drill.template.category}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <button onClick={onEdit} className="p-1.5 rounded hover:bg-vault-border/40 text-vault-text-faint hover:text-vault-text transition-colors">
+            <Pencil className="w-3.5 h-3.5" />
+          </button>
+          <button onClick={onDelete} className="p-1.5 rounded hover:bg-[#E53935]/10 text-vault-text-faint hover:text-[#E53935] transition-colors">
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        {drill.timeSeconds != null && (
+          <div className="flex items-center gap-1.5">
+            <Timer className="w-3.5 h-3.5 text-vault-text-faint" />
+            <span className={`text-sm font-mono font-bold ${underPar ? "text-[#00C853]" : overPar ? "text-[#E53935]" : "text-vault-text"}`}>
+              {drill.timeSeconds.toFixed(2)}s
+            </span>
+            {par && (
+              <span className="text-xs text-vault-text-faint">/ par {par}s</span>
+            )}
+          </div>
+        )}
+        {drill.hits != null && (
+          <div className="flex items-center gap-1.5">
+            <Target className="w-3.5 h-3.5 text-vault-text-faint" />
+            <span className="text-sm font-mono text-vault-text">
+              {drill.hits}{drill.totalShots != null ? `/${drill.totalShots}` : ""} hits
+            </span>
+          </div>
+        )}
+        {drill.accuracy != null && (
+          <div className="flex items-center gap-1.5">
+            <Crosshair className="w-3.5 h-3.5 text-vault-text-faint" />
+            <span className={`text-sm font-mono font-bold ${drill.accuracy >= 90 ? "text-[#00C853]" : drill.accuracy >= 70 ? "text-[#F5A623]" : "text-[#E53935]"}`}>
+              {drill.accuracy.toFixed(1)}%
+            </span>
+          </div>
+        )}
+        {drill.score != null && (
+          <div className="flex items-center gap-1.5">
+            <Award className="w-3.5 h-3.5 text-vault-text-faint" />
+            <span className="text-sm font-mono text-vault-text">
+              {drill.score}{drill.template?.maxScore != null ? `/${drill.template.maxScore}` : ""}
+              {drill.template?.maxScore != null && (
+                <span className="text-vault-text-faint text-xs ml-1">
+                  ({((drill.score / drill.template.maxScore) * 100).toFixed(0)}%)
+                </span>
+              )}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {drill.notes && (
+        <p className="text-xs text-vault-text-muted mt-2 border-t border-vault-border pt-2">{drill.notes}</p>
+      )}
+    </div>
+  );
+}
+
+function DrillForm({ templates, initialValues, onSubmit, onCancel, submitting }: {
+  templates: DrillTemplate[];
+  initialValues?: Partial<SessionDrill>;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+  onCancel: () => void;
+  submitting: boolean;
+}) {
+  const [templateId, setTemplateId] = useState(initialValues?.templateId ?? "");
+  const [drillName, setDrillName] = useState(initialValues?.drillName ?? "");
+  const [timeSeconds, setTimeSeconds] = useState(initialValues?.timeSeconds?.toString() ?? "");
+  const [hits, setHits] = useState(initialValues?.hits?.toString() ?? "");
+  const [totalShots, setTotalShots] = useState(initialValues?.totalShots?.toString() ?? "");
+  const [accuracy, setAccuracy] = useState(initialValues?.accuracy?.toString() ?? "");
+  const [score, setScore] = useState(initialValues?.score?.toString() ?? "");
+  const [notes, setNotes] = useState(initialValues?.notes ?? "");
+
+  const selectedTemplate = templates.find((t) => t.id === templateId);
+  const activeFields = selectedTemplate
+    ? SCORING_FIELDS[selectedTemplate.scoringType] ?? []
+    : ["timeSeconds", "hits", "totalShots", "accuracy", "score"];
+
+  // Auto-compute accuracy from hits/totalShots
+  const computedAccuracy =
+    hits && totalShots && parseFloat(totalShots) > 0
+      ? ((parseFloat(hits) / parseFloat(totalShots)) * 100).toFixed(1)
+      : accuracy;
+
+  function handleTemplateChange(id: string) {
+    setTemplateId(id);
+    const tpl = templates.find((t) => t.id === id);
+    if (tpl && !initialValues?.drillName) {
+      setDrillName(tpl.name);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await onSubmit({
+      templateId: templateId || null,
+      drillName,
+      timeSeconds: timeSeconds ? parseFloat(timeSeconds) : null,
+      hits: hits ? parseInt(hits) : null,
+      totalShots: totalShots ? parseInt(totalShots) : null,
+      accuracy: computedAccuracy ? parseFloat(computedAccuracy) : null,
+      score: score ? parseFloat(score) : null,
+      notes: notes || null,
+    });
+  }
+
+  const byCategory: Record<string, DrillTemplate[]> = {};
+  for (const t of templates) {
+    if (!byCategory[t.category]) byCategory[t.category] = [];
+    byCategory[t.category].push(t);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-vault-surface border border-[#00C2FF]/30 rounded-lg p-4 space-y-4">
+      <div className="flex items-center gap-2 mb-1">
+        <ListChecks className="w-4 h-4 text-[#00C2FF]" />
+        <span className="text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+          {initialValues?.id ? "Edit Drill" : "Add Drill"}
+        </span>
+      </div>
+
+      {/* Template picker */}
+      <div>
+        <label className={LABEL_CLASS}>
+          <BookOpen className="w-3 h-3 inline mr-1" />
+          Drill Template (or enter custom name below)
+        </label>
+        <div className="relative">
+          <select value={templateId} onChange={(e) => handleTemplateChange(e.target.value)} className={INPUT_CLASS}>
+            <option value="">Custom / No Template</option>
+            {Object.entries(byCategory).map(([cat, tpls]) => (
+              <optgroup key={cat} label={cat}>
+                {tpls.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}{t.parTime ? ` (par ${t.parTime}s)` : ""}{t.maxScore ? ` (max ${t.maxScore})` : ""}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+          <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+        </div>
+        {selectedTemplate?.description && (
+          <p className="text-xs text-vault-text-faint mt-1">{selectedTemplate.description}</p>
+        )}
+      </div>
+
+      {/* Drill name */}
+      <div>
+        <label className={LABEL_CLASS}>Drill Name <span className="text-[#E53935]">*</span></label>
+        <input required type="text" value={drillName} onChange={(e) => setDrillName(e.target.value)}
+          placeholder="e.g. Bill Drill, Custom Transition..." className={INPUT_CLASS} />
+      </div>
+
+      {/* Scored fields — shown based on template scoring type */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {(activeFields.includes("timeSeconds") || !selectedTemplate) && (
+          <div>
+            <label className={LABEL_CLASS}>
+              <Timer className="w-3 h-3 inline mr-1" />
+              Time (sec){selectedTemplate?.parTime ? ` · par ${selectedTemplate.parTime}s` : ""}
+            </label>
+            <input type="number" min={0} step={0.01} value={timeSeconds} onChange={(e) => setTimeSeconds(e.target.value)}
+              placeholder="2.45" className={INPUT_CLASS} />
+          </div>
+        )}
+        {(activeFields.includes("hits") || !selectedTemplate) && (
+          <div>
+            <label className={LABEL_CLASS}>Hits</label>
+            <input type="number" min={0} value={hits} onChange={(e) => setHits(e.target.value)}
+              placeholder="6" className={INPUT_CLASS} />
+          </div>
+        )}
+        {(activeFields.includes("totalShots") || !selectedTemplate) && (
+          <div>
+            <label className={LABEL_CLASS}>Total Shots</label>
+            <input type="number" min={0} value={totalShots} onChange={(e) => setTotalShots(e.target.value)}
+              placeholder="6" className={INPUT_CLASS} />
+          </div>
+        )}
+        {(activeFields.includes("score") || !selectedTemplate) && (
+          <div>
+            <label className={LABEL_CLASS}>
+              Score{selectedTemplate?.maxScore ? ` / ${selectedTemplate.maxScore}` : ""}
+            </label>
+            <input type="number" min={0} value={score} onChange={(e) => setScore(e.target.value)}
+              placeholder={selectedTemplate?.maxScore ? `0–${selectedTemplate.maxScore}` : "pts"} className={INPUT_CLASS} />
+          </div>
+        )}
+        {/* Accuracy: shown always if hits/shots given; otherwise as manual field */}
+        <div>
+          <label className={LABEL_CLASS}>Accuracy %</label>
+          <input type="number" min={0} max={100} step={0.1}
+            value={computedAccuracy !== accuracy ? computedAccuracy : accuracy}
+            onChange={(e) => setAccuracy(e.target.value)}
+            placeholder={computedAccuracy && computedAccuracy !== accuracy ? computedAccuracy : "auto"}
+            className={`${INPUT_CLASS} ${computedAccuracy && computedAccuracy !== accuracy ? "opacity-60" : ""}`}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className={LABEL_CLASS}>Notes</label>
+        <textarea rows={2} value={notes} onChange={(e) => setNotes(e.target.value)}
+          placeholder="e.g. Smooth draw, front sight focus, split times consistent..."
+          className={`${INPUT_CLASS} resize-none`} />
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <button type="button" onClick={onCancel}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm text-vault-text-muted border border-vault-border hover:text-vault-text transition-colors">
+          <X className="w-3.5 h-3.5" /> Cancel
+        </button>
+        <button type="submit" disabled={submitting || !drillName}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 transition-colors">
+          {submitting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
+          {initialValues?.id ? "Save Changes" : "Add Drill"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default function RangeSessionDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params.id as string;
+
+  const [session, setSession] = useState<RangeSession | null>(null);
+  const [templates, setTemplates] = useState<DrillTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showDrillForm, setShowDrillForm] = useState(false);
+  const [editingDrill, setEditingDrill] = useState<SessionDrill | null>(null);
+  const [drillSubmitting, setDrillSubmitting] = useState(false);
+  const [deletingDrillId, setDeletingDrillId] = useState<string | null>(null);
+  const [deleteSessionConfirm, setDeleteSessionConfirm] = useState(false);
+
+  const fetchSession = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/range-sessions/${id}`);
+      if (!res.ok) throw new Error("Session not found");
+      setSession(await res.json());
+    } catch {
+      setError("Failed to load session.");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchSession();
+    fetch("/api/drill-templates")
+      .then((r) => r.json())
+      .then(setTemplates)
+      .catch(() => {});
+  }, [fetchSession]);
+
+  async function handleAddDrill(values: Record<string, unknown>) {
+    setDrillSubmitting(true);
+    try {
+      const res = await fetch(`/api/range-sessions/${id}/drills`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error("Failed to add drill");
+      await fetchSession();
+      setShowDrillForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add drill");
+    } finally {
+      setDrillSubmitting(false);
+    }
+  }
+
+  async function handleEditDrill(drillId: string, values: Record<string, unknown>) {
+    setDrillSubmitting(true);
+    try {
+      const res = await fetch(`/api/range-sessions/${id}/drills/${drillId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error("Failed to update drill");
+      await fetchSession();
+      setEditingDrill(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update drill");
+    } finally {
+      setDrillSubmitting(false);
+    }
+  }
+
+  async function handleDeleteDrill(drillId: string) {
+    setDeletingDrillId(drillId);
+    try {
+      await fetch(`/api/range-sessions/${id}/drills/${drillId}`, { method: "DELETE" });
+      await fetchSession();
+    } finally {
+      setDeletingDrillId(null);
+    }
+  }
+
+  async function handleDeleteSession() {
+    try {
+      await fetch(`/api/range-sessions/${id}`, { method: "DELETE" });
+      router.push("/range/history");
+    } catch {
+      setError("Failed to delete session.");
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-full flex items-center justify-center">
+        <Loader2 className="w-6 h-6 text-[#00C2FF] animate-spin" />
+      </div>
+    );
+  }
+
+  if (error && !session) {
+    return (
+      <div className="min-h-full">
+        <PageHeader title="SESSION DETAIL" subtitle="" />
+        <div className="max-w-3xl mx-auto px-6 py-8">
+          <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3">
+            <AlertCircle className="w-4 h-4 text-[#E53935]" />
+            <p className="text-sm text-[#E53935]">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) return null;
+
+  const hasEnvData = session.environment || session.temperatureF != null || session.windSpeedMph != null || session.lightCondition;
+  const hasGroupData = session.targetDistanceYd != null || session.groupSizeIn != null;
+
+  return (
+    <div className="min-h-full">
+      <PageHeader
+        title={session.firearm.name.toUpperCase()}
+        subtitle={formatDate(session.date)}
+      />
+
+      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {/* Error banner */}
+        {error && (
+          <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3">
+            <AlertCircle className="w-4 h-4 text-[#E53935] shrink-0" />
+            <p className="text-sm text-[#E53935] flex-1">{error}</p>
+            <button onClick={() => setError(null)}><X className="w-4 h-4 text-[#E53935]" /></button>
+          </div>
+        )}
+
+        {/* Back + actions */}
+        <div className="flex items-center justify-between">
+          <Link href="/range/history"
+            className="flex items-center gap-1.5 text-sm text-vault-text-muted hover:text-vault-text transition-colors">
+            <ArrowLeft className="w-4 h-4" />
+            Back to History
+          </Link>
+          <div className="flex items-center gap-2">
+            {!deleteSessionConfirm ? (
+              <button onClick={() => setDeleteSessionConfirm(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-[#E53935]/70 border border-[#E53935]/20 hover:bg-[#E53935]/10 hover:text-[#E53935] transition-colors">
+                <Trash2 className="w-3.5 h-3.5" />
+                Delete Session
+              </button>
+            ) : (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-[#E53935]">Are you sure?</span>
+                <button onClick={handleDeleteSession}
+                  className="px-3 py-1.5 rounded-md text-sm bg-[#E53935] text-white hover:bg-[#E53935]/80 transition-colors">
+                  Yes, Delete
+                </button>
+                <button onClick={() => setDeleteSessionConfirm(false)}
+                  className="px-3 py-1.5 rounded-md text-sm border border-vault-border text-vault-text-muted hover:text-vault-text transition-colors">
+                  Cancel
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Session summary strip */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { label: "Rounds Fired", value: formatNumber(session.roundsFired), unit: "rds", color: "text-[#00C2FF]" },
+            { label: "Caliber", value: session.firearm.caliber, color: "text-vault-text" },
+            { label: "Build", value: session.build?.name ?? "—", color: "text-vault-text" },
+            { label: "Range", value: session.rangeName ?? "—", color: "text-vault-text" },
+          ].map(({ label, value, color }) => (
+            <div key={label} className="bg-vault-surface border border-vault-border rounded-lg p-3">
+              <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-1">{label}</p>
+              <p className={`text-sm font-medium truncate ${color}`}>{value}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Two-column layout */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Left column */}
+          <div className="space-y-4">
+            {/* Environment card */}
+            {hasEnvData && (
+              <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <Thermometer className="w-4 h-4 text-[#00C2FF]" />
+                  <h3 className="text-xs font-mono uppercase tracking-widest text-vault-text-muted">Environment</h3>
+                </div>
+                <div className="flex flex-wrap gap-2 mb-3">
+                  {session.environment && (
+                    <span className="text-xs px-2 py-1 rounded border border-vault-border bg-vault-bg text-vault-text-muted font-mono">
+                      {session.environment}
+                    </span>
+                  )}
+                  {session.temperatureF != null && (
+                    <span className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-vault-border bg-vault-bg text-vault-text-muted">
+                      <Thermometer className="w-3 h-3" />{session.temperatureF}°F
+                    </span>
+                  )}
+                  {session.windSpeedMph != null && (
+                    <span className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-vault-border bg-vault-bg text-vault-text-muted">
+                      <Wind className="w-3 h-3" />{session.windSpeedMph} mph{session.windDirection ? ` ${session.windDirection}` : ""}
+                    </span>
+                  )}
+                  {session.humidity != null && (
+                    <span className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-vault-border bg-vault-bg text-vault-text-muted">
+                      <Droplets className="w-3 h-3" />{session.humidity}%
+                    </span>
+                  )}
+                  {session.lightCondition && (
+                    <span className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-vault-border bg-vault-bg text-vault-text-muted">
+                      <Sun className="w-3 h-3" />{session.lightCondition.replace("_", " ")}
+                    </span>
+                  )}
+                </div>
+                {session.weatherNotes && (
+                  <p className="text-xs text-vault-text-muted border-t border-vault-border pt-2">{session.weatherNotes}</p>
+                )}
+              </div>
+            )}
+
+            {/* Shot group card */}
+            {hasGroupData && (
+              <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <Crosshair className="w-4 h-4 text-[#00C2FF]" />
+                  <h3 className="text-xs font-mono uppercase tracking-widest text-vault-text-muted">Shot Groups</h3>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  {session.targetDistanceYd != null && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Distance</p>
+                      <p className="text-sm font-mono text-vault-text">{session.targetDistanceYd} yd</p>
+                    </div>
+                  )}
+                  {session.numberOfGroups != null && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Groups</p>
+                      <p className="text-sm font-mono text-vault-text">{session.numberOfGroups}</p>
+                    </div>
+                  )}
+                  {session.groupSizeIn != null && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Best Group</p>
+                      <p className="text-sm font-mono text-[#00C853] font-bold">{session.groupSizeIn}&quot;</p>
+                    </div>
+                  )}
+                  {session.groupSizeMoa != null && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Best Group (MOA)</p>
+                      <p className="text-sm font-mono text-[#00C853] font-bold">{session.groupSizeMoa.toFixed(2)} MOA</p>
+                    </div>
+                  )}
+                </div>
+                {session.groupNotes && (
+                  <p className="text-xs text-vault-text-muted border-t border-vault-border pt-2 mt-3">{session.groupNotes}</p>
+                )}
+              </div>
+            )}
+
+            {/* Ammo used card */}
+            {session.ammoLinks.length > 0 && (
+              <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <PackageCheck className="w-4 h-4 text-[#00C2FF]" />
+                  <h3 className="text-xs font-mono uppercase tracking-widest text-vault-text-muted">Ammo Used</h3>
+                </div>
+                <div className="space-y-2">
+                  {session.ammoLinks.map((link) => (
+                    <div key={link.id} className="flex items-center justify-between py-1.5 border-b border-vault-border last:border-0">
+                      <div>
+                        <p className="text-sm text-vault-text">
+                          {link.transaction.stock.brand}
+                          {link.transaction.stock.grainWeight ? ` ${link.transaction.stock.grainWeight}gr` : ""}
+                          {link.transaction.stock.bulletType ? ` ${link.transaction.stock.bulletType}` : ""}
+                        </p>
+                        <p className="text-xs text-vault-text-faint">{link.transaction.stock.caliber}</p>
+                      </div>
+                      <span className="text-sm font-mono text-[#F5A623]">{formatNumber(link.transaction.quantity)} rds</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Notes card */}
+            {session.notes && (
+              <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                <p className="text-xs font-mono uppercase tracking-widest text-vault-text-faint mb-2">Session Notes</p>
+                <p className="text-sm text-vault-text-muted whitespace-pre-wrap">{session.notes}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Right column — Drills */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <ListChecks className="w-4 h-4 text-[#00C2FF]" />
+                <h3 className="text-xs font-mono uppercase tracking-widest text-vault-text-muted">
+                  Drills ({session.sessionDrills.length})
+                </h3>
+              </div>
+              {!showDrillForm && !editingDrill && (
+                <button onClick={() => setShowDrillForm(true)}
+                  className="flex items-center gap-1.5 text-xs text-[#00C2FF] border border-[#00C2FF]/30 px-2.5 py-1 rounded-md hover:bg-[#00C2FF]/10 transition-colors">
+                  <Plus className="w-3.5 h-3.5" /> Add Drill
+                </button>
+              )}
+            </div>
+
+            {/* Add drill form */}
+            {showDrillForm && !editingDrill && (
+              <DrillForm
+                templates={templates}
+                onSubmit={handleAddDrill}
+                onCancel={() => setShowDrillForm(false)}
+                submitting={drillSubmitting}
+              />
+            )}
+
+            {/* Drill list */}
+            {session.sessionDrills.length === 0 && !showDrillForm ? (
+              <div className="bg-vault-surface border border-vault-border rounded-lg p-6 text-center">
+                <ListChecks className="w-8 h-8 text-vault-text-faint mx-auto mb-2" />
+                <p className="text-sm text-vault-text-muted mb-3">No drills logged for this session.</p>
+                <button onClick={() => setShowDrillForm(true)}
+                  className="flex items-center gap-1.5 text-xs text-[#00C2FF] border border-[#00C2FF]/30 px-3 py-1.5 rounded-md hover:bg-[#00C2FF]/10 transition-colors mx-auto">
+                  <Plus className="w-3.5 h-3.5" /> Add Your First Drill
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {session.sessionDrills.map((drill) =>
+                  editingDrill?.id === drill.id ? (
+                    <DrillForm
+                      key={drill.id}
+                      templates={templates}
+                      initialValues={editingDrill}
+                      onSubmit={(values) => handleEditDrill(drill.id, values)}
+                      onCancel={() => setEditingDrill(null)}
+                      submitting={drillSubmitting}
+                    />
+                  ) : (
+                    <DrillCard
+                      key={drill.id}
+                      drill={drill}
+                      onEdit={() => { setEditingDrill(drill); setShowDrillForm(false); }}
+                      onDelete={() => {
+                        if (deletingDrillId !== drill.id) handleDeleteDrill(drill.id);
+                      }}
+                    />
+                  )
+                )}
+              </div>
+            )}
+
+            {/* Template library hint */}
+            {templates.length > 0 && (
+              <p className="text-xs text-vault-text-faint text-center">
+                {templates.filter((t) => t.isBuiltIn).length} built-in drill templates available ·{" "}
+                <Link href="/range/drills" className="text-[#00C2FF] hover:underline">
+                  Manage your library
+                </Link>
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/range/drills/page.tsx
+++ b/src/app/range/drills/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PageHeader } from "@/components/shared/PageHeader";
+import {
+  BookOpen,
+  Plus,
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  Loader2,
+  AlertCircle,
+  Timer,
+  Award,
+  Target,
+  Crosshair,
+  Lock,
+} from "lucide-react";
+
+const INPUT_CLASS =
+  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
+const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+
+interface DrillTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  scoringType: string;
+  parTime: number | null;
+  maxScore: number | null;
+  isBuiltIn: boolean;
+}
+
+const CATEGORIES = ["ACCURACY", "SPEED", "TACTICAL", "FUNDAMENTALS", "CUSTOM"];
+const SCORING_TYPES = ["TIME", "SCORE", "TIME_AND_SCORE", "PASS_FAIL", "NOTES_ONLY"];
+const SCORING_TYPE_LABELS: Record<string, string> = {
+  TIME: "Time",
+  SCORE: "Score",
+  TIME_AND_SCORE: "Time + Score",
+  PASS_FAIL: "Pass / Fail",
+  NOTES_ONLY: "Notes Only",
+};
+const CATEGORY_COLORS: Record<string, string> = {
+  ACCURACY: "text-[#00C853] border-[#00C853]/30 bg-[#00C853]/10",
+  SPEED: "text-[#F5A623] border-[#F5A623]/30 bg-[#F5A623]/10",
+  TACTICAL: "text-[#E53935] border-[#E53935]/30 bg-[#E53935]/10",
+  FUNDAMENTALS: "text-[#00C2FF] border-[#00C2FF]/30 bg-[#00C2FF]/10",
+  CUSTOM: "text-vault-text-muted border-vault-border bg-vault-surface",
+};
+const SCORING_ICONS: Record<string, React.ReactNode> = {
+  TIME: <Timer className="w-3 h-3" />,
+  SCORE: <Award className="w-3 h-3" />,
+  TIME_AND_SCORE: <Target className="w-3 h-3" />,
+  PASS_FAIL: <Crosshair className="w-3 h-3" />,
+  NOTES_ONLY: <BookOpen className="w-3 h-3" />,
+};
+
+function TemplateForm({
+  initialValues,
+  onSubmit,
+  onCancel,
+  submitting,
+}: {
+  initialValues?: Partial<DrillTemplate>;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+  onCancel: () => void;
+  submitting: boolean;
+}) {
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [description, setDescription] = useState(initialValues?.description ?? "");
+  const [category, setCategory] = useState(initialValues?.category ?? "CUSTOM");
+  const [scoringType, setScoringType] = useState(initialValues?.scoringType ?? "NOTES_ONLY");
+  const [parTime, setParTime] = useState(initialValues?.parTime?.toString() ?? "");
+  const [maxScore, setMaxScore] = useState(initialValues?.maxScore?.toString() ?? "");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await onSubmit({
+      name,
+      description: description || null,
+      category,
+      scoringType,
+      parTime: parTime ? parseFloat(parTime) : null,
+      maxScore: maxScore ? parseInt(maxScore) : null,
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-vault-surface border border-[#00C2FF]/30 rounded-lg p-4 space-y-4">
+      <div className="flex items-center gap-2 mb-1">
+        <BookOpen className="w-4 h-4 text-[#00C2FF]" />
+        <span className="text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+          {initialValues?.id ? "Edit Template" : "New Drill Template"}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="sm:col-span-2">
+          <label className={LABEL_CLASS}>Drill Name <span className="text-[#E53935]">*</span></label>
+          <input required type="text" value={name} onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Wizard Drill, Standards Test..." className={INPUT_CLASS} />
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>Category</label>
+          <select value={category} onChange={(e) => setCategory(e.target.value)} className={INPUT_CLASS}>
+            {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>Scoring Type</label>
+          <select value={scoringType} onChange={(e) => setScoringType(e.target.value)} className={INPUT_CLASS}>
+            {SCORING_TYPES.map((s) => (
+              <option key={s} value={s}>{SCORING_TYPE_LABELS[s]}</option>
+            ))}
+          </select>
+        </div>
+
+        {(scoringType === "TIME" || scoringType === "TIME_AND_SCORE") && (
+          <div>
+            <label className={LABEL_CLASS}>Par Time (sec)</label>
+            <input type="number" min={0} step={0.01} value={parTime} onChange={(e) => setParTime(e.target.value)}
+              placeholder="e.g. 2.0" className={INPUT_CLASS} />
+          </div>
+        )}
+
+        {(scoringType === "SCORE" || scoringType === "TIME_AND_SCORE") && (
+          <div>
+            <label className={LABEL_CLASS}>Max Score</label>
+            <input type="number" min={1} value={maxScore} onChange={(e) => setMaxScore(e.target.value)}
+              placeholder="e.g. 50" className={INPUT_CLASS} />
+          </div>
+        )}
+
+        <div className="sm:col-span-2">
+          <label className={LABEL_CLASS}>Description</label>
+          <textarea rows={2} value={description} onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief description of the drill procedure..."
+            className={`${INPUT_CLASS} resize-none`} />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <button type="button" onClick={onCancel}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm text-vault-text-muted border border-vault-border hover:text-vault-text transition-colors">
+          <X className="w-3.5 h-3.5" /> Cancel
+        </button>
+        <button type="submit" disabled={submitting || !name}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 transition-colors">
+          {submitting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
+          {initialValues?.id ? "Save Changes" : "Create Template"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default function DrillLibraryPage() {
+  const [templates, setTemplates] = useState<DrillTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string>("ALL");
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<DrillTemplate | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [formSubmitting, setFormSubmitting] = useState(false);
+
+  async function fetchTemplates() {
+    try {
+      const res = await fetch("/api/drill-templates");
+      setTemplates(await res.json());
+    } catch {
+      setError("Failed to load drill templates.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { fetchTemplates(); }, []);
+
+  async function handleCreate(values: Record<string, unknown>) {
+    setFormSubmitting(true);
+    try {
+      const res = await fetch("/api/drill-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error("Failed to create template");
+      await fetchTemplates();
+      setShowCreateForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create");
+    } finally {
+      setFormSubmitting(false);
+    }
+  }
+
+  async function handleEdit(id: string, values: Record<string, unknown>) {
+    setFormSubmitting(true);
+    try {
+      const res = await fetch(`/api/drill-templates/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error("Failed to update template");
+      await fetchTemplates();
+      setEditingTemplate(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update");
+    } finally {
+      setFormSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeletingId(id);
+    try {
+      await fetch(`/api/drill-templates/${id}`, { method: "DELETE" });
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+    } catch {
+      setError("Failed to delete template.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const filtered = categoryFilter === "ALL"
+    ? templates
+    : templates.filter((t) => t.category === categoryFilter);
+
+  const builtIn = filtered.filter((t) => t.isBuiltIn);
+  const custom = filtered.filter((t) => !t.isBuiltIn);
+
+  return (
+    <div className="min-h-full">
+      <PageHeader title="DRILL LIBRARY" subtitle="Manage reusable drill templates for your training sessions" />
+
+      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {error && (
+          <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3">
+            <AlertCircle className="w-4 h-4 text-[#E53935] shrink-0" />
+            <p className="text-sm text-[#E53935] flex-1">{error}</p>
+            <button onClick={() => setError(null)}><X className="w-4 h-4 text-[#E53935]" /></button>
+          </div>
+        )}
+
+        {/* Header actions */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          {/* Category filter chips */}
+          <div className="flex flex-wrap gap-2">
+            {["ALL", ...CATEGORIES].map((cat) => (
+              <button key={cat} onClick={() => setCategoryFilter(cat)}
+                className={`text-xs px-3 py-1.5 rounded-full border transition-colors font-mono ${
+                  categoryFilter === cat
+                    ? "bg-[#00C2FF]/10 border-[#00C2FF]/40 text-[#00C2FF]"
+                    : "border-vault-border text-vault-text-muted hover:border-vault-text-muted/50"
+                }`}>
+                {cat}
+              </button>
+            ))}
+          </div>
+          {!showCreateForm && !editingTemplate && (
+            <button onClick={() => setShowCreateForm(true)}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 transition-colors">
+              <Plus className="w-4 h-4" /> New Template
+            </button>
+          )}
+        </div>
+
+        {/* Create form */}
+        {showCreateForm && (
+          <TemplateForm
+            onSubmit={handleCreate}
+            onCancel={() => setShowCreateForm(false)}
+            submitting={formSubmitting}
+          />
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="w-6 h-6 text-[#00C2FF] animate-spin" />
+          </div>
+        ) : (
+          <>
+            {/* Custom templates */}
+            {custom.length > 0 && (
+              <div>
+                <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-3">Your Templates</p>
+                <div className="space-y-3">
+                  {custom.map((t) =>
+                    editingTemplate?.id === t.id ? (
+                      <TemplateForm
+                        key={t.id}
+                        initialValues={editingTemplate}
+                        onSubmit={(values) => handleEdit(t.id, values)}
+                        onCancel={() => setEditingTemplate(null)}
+                        submitting={formSubmitting}
+                      />
+                    ) : (
+                      <TemplateCard key={t.id} template={t}
+                        onEdit={() => { setEditingTemplate(t); setShowCreateForm(false); }}
+                        onDelete={() => handleDelete(t.id)}
+                        deleting={deletingId === t.id}
+                      />
+                    )
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Built-in templates */}
+            {builtIn.length > 0 && (
+              <div>
+                <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-3">
+                  Built-in Drills <span className="text-vault-text-faint normal-case tracking-normal">(read-only)</span>
+                </p>
+                <div className="space-y-3">
+                  {builtIn.map((t) => (
+                    <TemplateCard key={t.id} template={t} readOnly />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {filtered.length === 0 && (
+              <div className="text-center py-16">
+                <BookOpen className="w-10 h-10 text-vault-text-faint mx-auto mb-3" />
+                <p className="text-vault-text-muted">No templates in this category.</p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TemplateCard({ template, onEdit, onDelete, deleting, readOnly }: {
+  template: DrillTemplate;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  deleting?: boolean;
+  readOnly?: boolean;
+}) {
+  return (
+    <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <span className="font-medium text-sm text-vault-text">{template.name}</span>
+            <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono ${CATEGORY_COLORS[template.category] ?? CATEGORY_COLORS.CUSTOM}`}>
+              {template.category}
+            </span>
+            {readOnly && (
+              <span className="flex items-center gap-1 text-[10px] text-vault-text-faint border border-vault-border px-1.5 py-0.5 rounded">
+                <Lock className="w-2.5 h-2.5" /> built-in
+              </span>
+            )}
+          </div>
+          {template.description && (
+            <p className="text-xs text-vault-text-muted mb-2">{template.description}</p>
+          )}
+          <div className="flex flex-wrap gap-3">
+            <span className="flex items-center gap-1 text-xs text-vault-text-faint">
+              {SCORING_ICONS[template.scoringType]}
+              {SCORING_TYPE_LABELS[template.scoringType]}
+            </span>
+            {template.parTime != null && (
+              <span className="flex items-center gap-1 text-xs text-vault-text-faint">
+                <Timer className="w-3 h-3" /> par {template.parTime}s
+              </span>
+            )}
+            {template.maxScore != null && (
+              <span className="flex items-center gap-1 text-xs text-vault-text-faint">
+                <Award className="w-3 h-3" /> max {template.maxScore}
+              </span>
+            )}
+          </div>
+        </div>
+        {!readOnly && (
+          <div className="flex items-center gap-1 shrink-0">
+            <button onClick={onEdit}
+              className="p-1.5 rounded hover:bg-vault-border/40 text-vault-text-faint hover:text-vault-text transition-colors">
+              <Pencil className="w-3.5 h-3.5" />
+            </button>
+            <button onClick={onDelete} disabled={deleting}
+              className="p-1.5 rounded hover:bg-[#E53935]/10 text-vault-text-faint hover:text-[#E53935] transition-colors disabled:opacity-50">
+              {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/range/history/page.tsx
+++ b/src/app/range/history/page.tsx
@@ -1,10 +1,23 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatNumber } from "@/lib/utils";
-import { Target, MapPin, Calendar, Loader2, Trash2, ChevronDown, Clock } from "lucide-react";
+import { Target, MapPin, Calendar, Loader2, ChevronDown, Clock, BarChart2, ListIcon } from "lucide-react";
+import * as Tabs from "@radix-ui/react-tabs";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
 
 interface RangeSession {
   id: string;
@@ -15,8 +28,13 @@ interface RangeSession {
   rangeName: string | null;
   rangeLocation: string | null;
   notes: string | null;
-  firearm: { id: string; name: string };
+  groupSizeIn: number | null;
+  groupSizeMoa: number | null;
+  targetDistanceYd: number | null;
+  firearm: { id: string; name: string; caliber: string };
   build: { id: string; name: string } | null;
+  _count: { sessionDrills: number };
+  sessionDrills?: { accuracy: number | null; drillName: string; templateId: string | null; timeSeconds: number | null; score: number | null }[];
 }
 
 function formatSessionDate(dateStr: string): string {
@@ -24,37 +42,95 @@ function formatSessionDate(dateStr: string): string {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
+function getMonthKey(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function getMonthLabel(key: string): string {
+  const [year, month] = key.split("-");
+  return new Date(parseInt(year), parseInt(month) - 1, 1).toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+const CHART_STYLE = {
+  contentStyle: {
+    background: "hsl(var(--vault-surface, 220 14% 12%))",
+    border: "1px solid hsl(var(--vault-border, 220 13% 22%))",
+    borderRadius: 6,
+    fontSize: 11,
+  },
+  tickStyle: { fill: "#6b7280", fontSize: 10 },
+};
+
 export default function RangeHistoryPage() {
   const [sessions, setSessions] = useState<RangeSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [firearmFilter, setFirearmFilter] = useState<string>("ALL");
-  const [deleting, setDeleting] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("history");
 
-  const uniqueFirearms = Array.from(
-    new Map(sessions.map((s) => [s.firearm.id, s.firearm])).values()
+  const uniqueFirearms = useMemo(
+    () => Array.from(new Map(sessions.map((s) => [s.firearm.id, s.firearm])).values()),
+    [sessions]
   );
 
-  const filtered = firearmFilter === "ALL"
-    ? sessions
-    : sessions.filter((s) => s.firearm.id === firearmFilter);
+  const filtered = useMemo(
+    () => firearmFilter === "ALL" ? sessions : sessions.filter((s) => s.firearm.id === firearmFilter),
+    [sessions, firearmFilter]
+  );
 
-  const totalRounds = filtered.reduce((sum, s) => sum + s.roundsFired, 0);
+  const totalRounds = useMemo(() => filtered.reduce((sum, s) => sum + s.roundsFired, 0), [filtered]);
 
   useEffect(() => {
-    fetch("/api/range-sessions")
+    fetch("/api/range-sessions?include=analytics")
       .then((r) => r.json())
       .then((data) => { if (Array.isArray(data)) setSessions(data); setLoading(false); })
       .catch(() => setLoading(false));
   }, []);
 
-  async function handleDelete(id: string) {
-    setDeleting(id);
-    try {
-      await fetch(`/api/range-sessions/${id}`, { method: "DELETE" });
-      setSessions((prev) => prev.filter((s) => s.id !== id));
-    } catch { /* silently fail */ }
-    finally { setDeleting(null); }
-  }
+  // ── Analytics aggregations ───────────────────────────────────────
+  const roundsByMonth = useMemo(() => {
+    const map = new Map<string, { rounds: number; sessions: number }>();
+    // Last 12 months
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(1);
+      d.setMonth(d.getMonth() - i);
+      map.set(getMonthKey(d.toISOString()), { rounds: 0, sessions: 0 });
+    }
+    for (const s of filtered) {
+      const key = getMonthKey(s.date);
+      if (map.has(key)) {
+        map.get(key)!.rounds += s.roundsFired;
+        map.get(key)!.sessions += 1;
+      }
+    }
+    return Array.from(map.entries()).map(([key, val]) => ({
+      month: getMonthLabel(key),
+      rounds: val.rounds,
+      sessions: val.sessions,
+    }));
+  }, [filtered]);
+
+  const groupTrend = useMemo(() => {
+    return filtered
+      .filter((s) => s.groupSizeIn != null && s.targetDistanceYd != null)
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .map((s) => ({
+        date: formatSessionDate(s.date),
+        groupSizeIn: s.groupSizeIn!,
+        distanceYd: s.targetDistanceYd!,
+        firearm: s.firearm.name,
+      }));
+  }, [filtered]);
+
+  const personalBestGroup = useMemo(() => {
+    if (groupTrend.length === 0) return null;
+    return Math.min(...groupTrend.map((g) => g.groupSizeIn));
+  }, [groupTrend]);
+
+  const avgRoundsPerSession = filtered.length > 0
+    ? Math.round(totalRounds / filtered.length)
+    : 0;
 
   return (
     <div className="min-h-full">
@@ -71,8 +147,8 @@ export default function RangeHistoryPage() {
       />
 
       <div className="p-6">
-        {/* Summary */}
-        <div className="flex items-center gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-5 py-3">
+        {/* Summary strip */}
+        <div className="flex items-center gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-5 py-3 flex-wrap">
           <div>
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Total Sessions</p>
             <p className="text-lg font-bold font-mono text-vault-text">{sessions.length}</p>
@@ -82,6 +158,15 @@ export default function RangeHistoryPage() {
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Rounds Fired</p>
             <p className="text-lg font-bold font-mono text-[#00C2FF]">{formatNumber(totalRounds)}</p>
           </div>
+          {avgRoundsPerSession > 0 && (
+            <>
+              <div className="w-px h-8 bg-vault-border" />
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Avg / Session</p>
+                <p className="text-lg font-bold font-mono text-vault-text">{formatNumber(avgRoundsPerSession)}</p>
+              </div>
+            </>
+          )}
           {uniqueFirearms.length > 1 && (
             <>
               <div className="w-px h-8 bg-vault-border" />
@@ -117,81 +202,178 @@ export default function RangeHistoryPage() {
           </div>
         )}
 
-        {loading ? (
-          <div className="flex items-center justify-center py-24">
-            <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div className="w-16 h-16 rounded-full bg-[#00C2FF]/10 border border-[#00C2FF]/20 flex items-center justify-center mb-4">
-              <Clock className="w-8 h-8 text-[#00C2FF]" />
-            </div>
-            <h3 className="text-lg font-semibold text-vault-text mb-2">No range sessions yet</h3>
-            <p className="text-sm text-vault-text-muted mb-6 max-w-sm">
-              Log your first range session to start tracking your shooting history.
-            </p>
-            <Link href="/range"
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-4 py-2 rounded text-sm font-medium transition-colors">
-              <Target className="w-4 h-4" />
-              Log First Session
-            </Link>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {filtered.map((session) => (
-              <div key={session.id}
-                className="bg-vault-surface border border-vault-border rounded-lg p-4 hover:border-vault-text-muted/30 transition-colors">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-3 mb-2 flex-wrap">
-                      <span className="text-sm font-semibold text-vault-text">{session.firearm.name}</span>
-                      {session.build && (
-                        <span className="text-[10px] font-mono text-vault-text-faint border border-vault-border px-1.5 py-0.5 rounded">
-                          {session.build.name}
-                        </span>
-                      )}
-                      <span className="text-[10px] font-mono font-bold text-[#00C2FF] bg-[#00C2FF]/10 border border-[#00C2FF]/20 px-2 py-0.5 rounded">
-                        {formatNumber(session.roundsFired)} rds
-                      </span>
-                    </div>
+        {/* History / Analytics tabs */}
+        <Tabs.Root value={activeTab} onValueChange={setActiveTab}>
+          <Tabs.List className="flex gap-1 mb-5 bg-vault-surface border border-vault-border rounded-lg p-1 w-fit">
+            <Tabs.Trigger value="history"
+              className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium transition-colors data-[state=active]:bg-[#00C2FF]/10 data-[state=active]:text-[#00C2FF] data-[state=inactive]:text-vault-text-muted hover:text-vault-text">
+              <ListIcon className="w-3.5 h-3.5" /> History
+            </Tabs.Trigger>
+            <Tabs.Trigger value="analytics"
+              className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium transition-colors data-[state=active]:bg-[#00C2FF]/10 data-[state=active]:text-[#00C2FF] data-[state=inactive]:text-vault-text-muted hover:text-vault-text">
+              <BarChart2 className="w-3.5 h-3.5" /> Analytics
+            </Tabs.Trigger>
+          </Tabs.List>
 
-                    <div className="flex items-center gap-4 text-xs text-vault-text-faint flex-wrap">
-                      <div className="flex items-center gap-1">
-                        <Calendar className="w-3 h-3" />
-                        <span>{formatSessionDate(session.date)}</span>
-                      </div>
-                      {session.rangeName && (
-                        <div className="flex items-center gap-1">
-                          <MapPin className="w-3 h-3" />
-                          <span>{session.rangeName}{session.rangeLocation ? ` · ${session.rangeLocation}` : ""}</span>
+          {/* HISTORY TAB */}
+          <Tabs.Content value="history">
+            {loading ? (
+              <div className="flex items-center justify-center py-24">
+                <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="w-16 h-16 rounded-full bg-[#00C2FF]/10 border border-[#00C2FF]/20 flex items-center justify-center mb-4">
+                  <Clock className="w-8 h-8 text-[#00C2FF]" />
+                </div>
+                <h3 className="text-lg font-semibold text-vault-text mb-2">No range sessions yet</h3>
+                <p className="text-sm text-vault-text-muted mb-6 max-w-sm">
+                  Log your first range session to start tracking your shooting history.
+                </p>
+                <Link href="/range"
+                  className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-4 py-2 rounded text-sm font-medium transition-colors">
+                  <Target className="w-4 h-4" />
+                  Log First Session
+                </Link>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-3">
+                  {filtered.map((session) => (
+                    <Link key={session.id} href={`/range/${session.id}`}
+                      className="block bg-vault-surface border border-vault-border rounded-lg p-4 hover:border-[#00C2FF]/30 hover:bg-[#00C2FF]/5 transition-colors">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-3 mb-2 flex-wrap">
+                            <span className="text-sm font-semibold text-vault-text">{session.firearm.name}</span>
+                            {session.build && (
+                              <span className="text-[10px] font-mono text-vault-text-faint border border-vault-border px-1.5 py-0.5 rounded">
+                                {session.build.name}
+                              </span>
+                            )}
+                            <span className="text-[10px] font-mono font-bold text-[#00C2FF] bg-[#00C2FF]/10 border border-[#00C2FF]/20 px-2 py-0.5 rounded">
+                              {formatNumber(session.roundsFired)} rds
+                            </span>
+                            {session._count.sessionDrills > 0 && (
+                              <span className="text-[10px] font-mono text-[#F5A623] border border-[#F5A623]/20 px-1.5 py-0.5 rounded">
+                                {session._count.sessionDrills} drill{session._count.sessionDrills !== 1 ? "s" : ""}
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="flex items-center gap-4 text-xs text-vault-text-faint flex-wrap">
+                            <div className="flex items-center gap-1">
+                              <Calendar className="w-3 h-3" />
+                              <span>{formatSessionDate(session.date)}</span>
+                            </div>
+                            {session.rangeName && (
+                              <div className="flex items-center gap-1">
+                                <MapPin className="w-3 h-3" />
+                                <span>{session.rangeName}{session.rangeLocation ? ` · ${session.rangeLocation}` : ""}</span>
+                              </div>
+                            )}
+                            {session.groupSizeIn != null && (
+                              <span className="text-[10px] font-mono text-[#00C853]">
+                                {session.groupSizeIn}&quot; group
+                              </span>
+                            )}
+                          </div>
+
+                          {session.notes && (
+                            <p className="text-xs text-vault-text-muted mt-2 line-clamp-2">{session.notes}</p>
+                          )}
                         </div>
-                      )}
-                    </div>
+                        <ChevronDown className="w-4 h-4 text-vault-text-faint shrink-0 -rotate-90" />
+                      </div>
+                    </Link>
+                  ))}
+                </div>
 
-                    {session.notes && (
-                      <p className="text-xs text-vault-text-muted mt-2 line-clamp-2">{session.notes}</p>
+                {filtered.length > 5 && (
+                  <div className="flex justify-center mt-6">
+                    <ChevronDown className="w-4 h-4 text-vault-text-faint" />
+                  </div>
+                )}
+              </>
+            )}
+          </Tabs.Content>
+
+          {/* ANALYTICS TAB */}
+          <Tabs.Content value="analytics">
+            {loading ? (
+              <div className="flex items-center justify-center py-24">
+                <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
+              </div>
+            ) : sessions.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <BarChart2 className="w-10 h-10 text-vault-text-faint mx-auto mb-3" />
+                <p className="text-vault-text-muted">Log sessions to see analytics.</p>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {/* Rounds over time */}
+                <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                  <p className="text-xs font-mono uppercase tracking-widest text-vault-text-muted mb-4">
+                    Rounds Fired — Last 12 Months
+                  </p>
+                  <ResponsiveContainer width="100%" height={220}>
+                    <LineChart data={roundsByMonth}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                      <XAxis dataKey="month" tick={CHART_STYLE.tickStyle} />
+                      <YAxis tick={CHART_STYLE.tickStyle} />
+                      <Tooltip contentStyle={CHART_STYLE.contentStyle} />
+                      <Line type="monotone" dataKey="rounds" stroke="#00C2FF" strokeWidth={2} dot={false} name="Rounds" />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+
+                {/* Sessions per month */}
+                <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                  <p className="text-xs font-mono uppercase tracking-widest text-vault-text-muted mb-4">
+                    Sessions Per Month
+                  </p>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={roundsByMonth}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                      <XAxis dataKey="month" tick={CHART_STYLE.tickStyle} />
+                      <YAxis allowDecimals={false} tick={CHART_STYLE.tickStyle} />
+                      <Tooltip contentStyle={CHART_STYLE.contentStyle} />
+                      <Bar dataKey="sessions" fill="#00C2FF" fillOpacity={0.7} name="Sessions" radius={[2, 2, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+
+                {/* Group size trend */}
+                {groupTrend.length >= 2 && (
+                  <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+                    <p className="text-xs font-mono uppercase tracking-widest text-vault-text-muted mb-4">
+                      Best Group Size Trend (inches)
+                    </p>
+                    <ResponsiveContainer width="100%" height={200}>
+                      <LineChart data={groupTrend}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                        <XAxis dataKey="date" tick={CHART_STYLE.tickStyle} />
+                        <YAxis tick={CHART_STYLE.tickStyle} domain={["auto", "auto"]} />
+                        <Tooltip contentStyle={CHART_STYLE.contentStyle}
+                          formatter={(v: unknown) => [`${v}"`, "Group"]} />
+                        {personalBestGroup != null && (
+                          <ReferenceLine y={personalBestGroup} stroke="#00C853" strokeDasharray="4 2"
+                            label={{ value: "PB", fill: "#00C853", fontSize: 10 }} />
+                        )}
+                        <Line type="monotone" dataKey="groupSizeIn" stroke="#F5A623" strokeWidth={2} dot={{ r: 3 }} name="Group (in)" />
+                      </LineChart>
+                    </ResponsiveContainer>
+                    {personalBestGroup != null && (
+                      <p className="text-xs text-vault-text-faint mt-1">
+                        Personal best: <span className="text-[#00C853] font-mono">{personalBestGroup}&quot;</span>
+                      </p>
                     )}
                   </div>
-
-                  <button onClick={() => handleDelete(session.id)} disabled={deleting === session.id}
-                    className="shrink-0 w-7 h-7 flex items-center justify-center text-vault-text-faint hover:text-[#E53935] hover:bg-[#E53935]/10 rounded transition-colors disabled:opacity-50"
-                    title="Delete session">
-                    {deleting === session.id
-                      ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                      : <Trash2 className="w-3.5 h-3.5" />}
-                  </button>
-                </div>
+                )}
               </div>
-            ))}
-          </div>
-        )}
-
-        {/* Dropdown summary icon at bottom for spacing */}
-        {filtered.length > 5 && (
-          <div className="flex justify-center mt-6">
-            <ChevronDown className="w-4 h-4 text-vault-text-faint" />
-          </div>
-        )}
+            )}
+          </Tabs.Content>
+        </Tabs.Root>
       </div>
     </div>
   );

--- a/src/app/range/page.tsx
+++ b/src/app/range/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatNumber } from "@/lib/utils";
 import { SLOT_TYPE_LABELS as SLOT_TYPE_LABELS_IMPORT } from "@/lib/types";
@@ -12,6 +13,10 @@ import {
   CheckCircle2,
   Shield,
   MapPin,
+  ChevronRight,
+  Thermometer,
+  Wind,
+  Cloud,
 } from "lucide-react";
 
 const INPUT_CLASS =
@@ -58,6 +63,14 @@ const SLOT_TYPE_LABELS: Record<string, string> = SLOT_TYPE_LABELS_IMPORT as Reco
 // Slots that typically accumulate rounds (wear parts)
 const ROUND_COUNT_SLOTS = new Set(["BARREL", "SUPPRESSOR", "MUZZLE", "TRIGGER", "SLIDE", "FRAME"]);
 
+const LIGHT_CONDITIONS = ["BRIGHT", "OVERCAST", "LOW_LIGHT", "NIGHT"];
+const LIGHT_CONDITION_LABELS: Record<string, string> = {
+  BRIGHT: "Bright / Sunny",
+  OVERCAST: "Overcast",
+  LOW_LIGHT: "Low Light / Dusk",
+  NIGHT: "Night",
+};
+
 export default function RangeSessionPage() {
   const [firearms, setFirearms] = useState<Firearm[]>([]);
   const [builds, setBuilds] = useState<Build[]>([]);
@@ -72,6 +85,23 @@ export default function RangeSessionPage() {
   const [rangeLocation, setRangeLocation] = useState<string>("");
   const [selectedAccessories, setSelectedAccessories] = useState<Set<string>>(new Set());
 
+  // Environment / Weather
+  const [showEnvFieldset, setShowEnvFieldset] = useState(false);
+  const [environment, setEnvironment] = useState<"INDOOR" | "OUTDOOR" | "">("");
+  const [temperatureF, setTemperatureF] = useState<string>("");
+  const [windSpeedMph, setWindSpeedMph] = useState<string>("");
+  const [windDirection, setWindDirection] = useState<string>("");
+  const [humidity, setHumidity] = useState<string>("");
+  const [lightCondition, setLightCondition] = useState<string>("");
+  const [weatherNotes, setWeatherNotes] = useState<string>("");
+
+  // Shot Groups
+  const [showGroupFieldset, setShowGroupFieldset] = useState(false);
+  const [targetDistanceYd, setTargetDistanceYd] = useState<string>("");
+  const [groupSizeIn, setGroupSizeIn] = useState<string>("");
+  const [numberOfGroups, setNumberOfGroups] = useState<string>("");
+  const [groupNotes, setGroupNotes] = useState<string>("");
+
   const [loadingFirearms, setLoadingFirearms] = useState(true);
   const [loadingBuilds, setLoadingBuilds] = useState(false);
   const [loadingAmmo, setLoadingAmmo] = useState(true);
@@ -79,10 +109,17 @@ export default function RangeSessionPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   const [successDetails, setSuccessDetails] = useState<{ accessories: string[]; ammoLeft: number | null }>({
     accessories: [],
     ammoLeft: null,
   });
+
+  // MOA auto-computed
+  const groupSizeMoa =
+    targetDistanceYd && groupSizeIn && parseFloat(targetDistanceYd) > 0
+      ? ((parseFloat(groupSizeIn) * 95.5) / parseFloat(targetDistanceYd)).toFixed(2)
+      : null;
 
   // Load firearms
   useEffect(() => {
@@ -114,12 +151,9 @@ export default function RangeSessionPage() {
       const selectedB = active ?? (data.length > 0 ? data[0] : null);
       if (selectedB) {
         setSelectedBuild(selectedB.id);
-        // Pre-select ALL accessories in the build (not just wear parts)
         const autoSelect = new Set<string>();
         for (const slot of selectedB.slots) {
-          if (slot.accessory) {
-            autoSelect.add(slot.accessory.id);
-          }
+          if (slot.accessory) autoSelect.add(slot.accessory.id);
         }
         setSelectedAccessories(autoSelect);
       } else {
@@ -143,12 +177,9 @@ export default function RangeSessionPage() {
   useEffect(() => {
     const build = builds.find((b) => b.id === selectedBuild);
     if (!build) return;
-    // Pre-select ALL accessories in the build
     const autoSelect = new Set<string>();
     for (const slot of build.slots) {
-      if (slot.accessory) {
-        autoSelect.add(slot.accessory.id);
-      }
+      if (slot.accessory) autoSelect.add(slot.accessory.id);
     }
     setSelectedAccessories(autoSelect);
   }, [selectedBuild, builds]);
@@ -186,6 +217,7 @@ export default function RangeSessionPage() {
     try {
       const results: string[] = [];
       let ammoLeft: number | null = null;
+      let ammoTransactionId: string | null = null;
 
       // Log rounds to each selected accessory
       for (const accessoryId of selectedAccessories) {
@@ -206,7 +238,7 @@ export default function RangeSessionPage() {
         results.push(name);
       }
 
-      // Deduct ammo if stock selected
+      // Deduct ammo if stock selected — capture transaction ID for ammo link
       if (selectedAmmoStock) {
         const res = await fetch(`/api/ammo/${selectedAmmoStock}/transactions`, {
           method: "POST",
@@ -220,10 +252,11 @@ export default function RangeSessionPage() {
         const json = await res.json();
         if (!res.ok) throw new Error(json.error ?? "Failed to deduct ammo");
         ammoLeft = json.stock.quantity;
+        ammoTransactionId = json.transaction?.id ?? null;
       }
 
       // Save range session record
-      await fetch("/api/range-sessions", {
+      const sessionRes = await fetch("/api/range-sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -233,8 +266,27 @@ export default function RangeSessionPage() {
           rangeName: rangeName || null,
           rangeLocation: rangeLocation || null,
           notes: sessionNote || null,
+          // environment
+          environment: environment || null,
+          temperatureF: temperatureF ? parseFloat(temperatureF) : null,
+          windSpeedMph: windSpeedMph ? parseFloat(windSpeedMph) : null,
+          windDirection: windDirection || null,
+          humidity: humidity ? parseFloat(humidity) : null,
+          lightCondition: lightCondition || null,
+          weatherNotes: weatherNotes || null,
+          // shot groups
+          targetDistanceYd: targetDistanceYd ? parseFloat(targetDistanceYd) : null,
+          groupSizeIn: groupSizeIn ? parseFloat(groupSizeIn) : null,
+          groupSizeMoa: groupSizeMoa ? parseFloat(groupSizeMoa) : null,
+          numberOfGroups: numberOfGroups ? parseInt(numberOfGroups) : null,
+          groupNotes: groupNotes || null,
+          // ammo link
+          ammoTransactionIds: ammoTransactionId ? [ammoTransactionId] : [],
         }),
       });
+      const sessionJson = await sessionRes.json();
+      if (!sessionRes.ok) throw new Error(sessionJson.error ?? "Failed to save session");
+      setCreatedSessionId(sessionJson.id ?? null);
 
       setSuccessDetails({ accessories: results, ammoLeft });
       setSuccess(true);
@@ -254,6 +306,18 @@ export default function RangeSessionPage() {
     setRangeName("");
     setRangeLocation("");
     setSelectedAccessories(new Set());
+    setEnvironment("");
+    setTemperatureF("");
+    setWindSpeedMph("");
+    setWindDirection("");
+    setHumidity("");
+    setLightCondition("");
+    setWeatherNotes("");
+    setTargetDistanceYd("");
+    setGroupSizeIn("");
+    setNumberOfGroups("");
+    setGroupNotes("");
+    setCreatedSessionId(null);
     setSuccess(false);
     setError(null);
     setBuilds([]);
@@ -300,10 +364,18 @@ export default function RangeSessionPage() {
               )}
             </div>
           </div>
-          <button onClick={resetForm}
-            className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-5 py-2 rounded-md text-sm font-medium transition-colors">
-            Log Another Session
-          </button>
+          <div className="flex flex-col sm:flex-row items-center gap-3">
+            {createdSessionId && (
+              <Link href={`/range/${createdSessionId}`}
+                className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-5 py-2 rounded-md text-sm font-medium transition-colors">
+                View Session & Add Drills <ChevronRight className="w-4 h-4" />
+              </Link>
+            )}
+            <button onClick={resetForm}
+              className="flex items-center gap-2 bg-vault-surface border border-vault-border text-vault-text-muted hover:text-vault-text hover:border-vault-text-muted/50 px-5 py-2 rounded-md text-sm font-medium transition-colors">
+              Log Another Session
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -508,6 +580,139 @@ export default function RangeSessionPage() {
               </div>
             </div>
           )}
+
+          {/* Environment & Weather (collapsible) */}
+          <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+            <button type="button"
+              onClick={() => setShowEnvFieldset(!showEnvFieldset)}
+              className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-vault-border/20 transition-colors">
+              <div className="flex items-center gap-2">
+                <Thermometer className="w-4 h-4 text-[#00C2FF]" />
+                <span className="text-xs font-mono uppercase tracking-widest text-[#00C2FF]">Environment & Weather</span>
+                <span className="text-xs text-vault-text-faint">(optional)</span>
+              </div>
+              <ChevronDown className={`w-4 h-4 text-vault-text-faint transition-transform ${showEnvFieldset ? "rotate-180" : ""}`} />
+            </button>
+            {showEnvFieldset && (
+              <div className="px-5 pb-5 space-y-4 border-t border-vault-border">
+                {/* Indoor / Outdoor toggle */}
+                <div className="pt-4">
+                  <label className={LABEL_CLASS}>Environment</label>
+                  <div className="flex gap-2">
+                    {(["OUTDOOR", "INDOOR"] as const).map((env) => (
+                      <button key={env} type="button"
+                        onClick={() => setEnvironment(environment === env ? "" : env)}
+                        className={`flex-1 py-2 rounded-md text-sm font-medium border transition-colors ${
+                          environment === env
+                            ? "bg-[#00C2FF]/10 border-[#00C2FF]/40 text-[#00C2FF]"
+                            : "bg-vault-bg border-vault-border text-vault-text-muted hover:border-vault-text-muted/50"
+                        }`}>
+                        {env === "OUTDOOR" ? "Outdoor" : "Indoor"}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                  <div>
+                    <label className={LABEL_CLASS}>
+                      <Thermometer className="w-3 h-3 inline mr-1" />
+                      Temp (°F)
+                    </label>
+                    <input type="number" value={temperatureF} onChange={(e) => setTemperatureF(e.target.value)}
+                      placeholder="72" className={INPUT_CLASS} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>
+                      <Wind className="w-3 h-3 inline mr-1" />
+                      Wind (mph)
+                    </label>
+                    <input type="number" min={0} value={windSpeedMph} onChange={(e) => setWindSpeedMph(e.target.value)}
+                      placeholder="5" className={INPUT_CLASS} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>Wind Dir.</label>
+                    <input type="text" value={windDirection} onChange={(e) => setWindDirection(e.target.value)}
+                      placeholder="NW / Headwind" className={INPUT_CLASS} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>
+                      <Cloud className="w-3 h-3 inline mr-1" />
+                      Humidity (%)
+                    </label>
+                    <input type="number" min={0} max={100} value={humidity} onChange={(e) => setHumidity(e.target.value)}
+                      placeholder="45" className={INPUT_CLASS} />
+                  </div>
+                  <div className="col-span-2">
+                    <label className={LABEL_CLASS}>Light Condition</label>
+                    <div className="relative">
+                      <select value={lightCondition} onChange={(e) => setLightCondition(e.target.value)} className={INPUT_CLASS}>
+                        <option value="">Select...</option>
+                        {LIGHT_CONDITIONS.map((lc) => (
+                          <option key={lc} value={lc}>{LIGHT_CONDITION_LABELS[lc]}</option>
+                        ))}
+                      </select>
+                      <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label className={LABEL_CLASS}>Weather Notes</label>
+                  <textarea rows={2} value={weatherNotes} onChange={(e) => setWeatherNotes(e.target.value)}
+                    placeholder="e.g. Windy at 200yd but calm at 100yd..."
+                    className={`${INPUT_CLASS} resize-none`} />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Shot Groups (collapsible) */}
+          <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+            <button type="button"
+              onClick={() => setShowGroupFieldset(!showGroupFieldset)}
+              className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-vault-border/20 transition-colors">
+              <div className="flex items-center gap-2">
+                <Target className="w-4 h-4 text-[#00C2FF]" />
+                <span className="text-xs font-mono uppercase tracking-widest text-[#00C2FF]">Shot Group Data</span>
+                <span className="text-xs text-vault-text-faint">(optional)</span>
+              </div>
+              <ChevronDown className={`w-4 h-4 text-vault-text-faint transition-transform ${showGroupFieldset ? "rotate-180" : ""}`} />
+            </button>
+            {showGroupFieldset && (
+              <div className="px-5 pb-5 space-y-4 border-t border-vault-border pt-4">
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                  <div>
+                    <label className={LABEL_CLASS}>Distance (yd)</label>
+                    <input type="number" min={0} value={targetDistanceYd} onChange={(e) => setTargetDistanceYd(e.target.value)}
+                      placeholder="100" className={INPUT_CLASS} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>Best Group (in)</label>
+                    <input type="number" min={0} step={0.01} value={groupSizeIn} onChange={(e) => setGroupSizeIn(e.target.value)}
+                      placeholder="0.75" className={INPUT_CLASS} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>Best Group (MOA)</label>
+                    <input type="text" readOnly value={groupSizeMoa ?? ""}
+                      placeholder="auto-computed"
+                      className={`${INPUT_CLASS} opacity-60 cursor-not-allowed`} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}># of Groups</label>
+                    <input type="number" min={1} value={numberOfGroups} onChange={(e) => setNumberOfGroups(e.target.value)}
+                      placeholder="5" className={INPUT_CLASS} />
+                  </div>
+                </div>
+                <div>
+                  <label className={LABEL_CLASS}>Group Notes</label>
+                  <textarea rows={2} value={groupNotes} onChange={(e) => setGroupNotes(e.target.value)}
+                    placeholder="e.g. First group was cold bore, last group tightest..."
+                    className={`${INPUT_CLASS} resize-none`} />
+                </div>
+              </div>
+            )}
+          </div>
 
           {/* Session Note */}
           <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -55,7 +55,7 @@ const TYPE_BADGE_COLORS: Record<string, string> = {
   LEVER_ACTION: "border-[#FF7043]/40 text-[#FF7043]",
 };
 
-const DEFAULT_ORDER = ["stats", "low-ammo", "recent", "ammo-summary"];
+const DEFAULT_ORDER = ["stats", "range-sessions", "low-ammo", "recent", "ammo-summary"];
 const STORAGE_KEY = "vault-dashboard-layout";
 
 interface AmmoStockItem {
@@ -81,6 +81,19 @@ interface RecentFirearm {
   createdAt: Date;
 }
 
+interface RangeStats {
+  count: number;
+  totalRounds: number;
+  sessionsLast30Days: number;
+  lastSession: {
+    id: string;
+    date: string | Date;
+    rangeName: string | null;
+    roundsFired: number;
+    firearmName: string;
+  } | null;
+}
+
 interface DashboardData {
   firearmCount: number;
   accessoryCount: number;
@@ -89,6 +102,7 @@ interface DashboardData {
   lowStockItems: AmmoStockItem[];
   recentFirearms: RecentFirearm[];
   ammoStocks: AmmoStockItem[];
+  rangeStats: RangeStats;
 }
 
 // ── Sortable wrapper ──────────────────────────────────────────
@@ -349,6 +363,80 @@ function RecentWidget({ firearms }: { firearms: RecentFirearm[] }) {
   );
 }
 
+function RangeSessionsWidget({ stats }: { stats: RangeStats }) {
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-3">
+        <Target className="w-4 h-4 text-[#00C2FF]" />
+        <h2 className="text-sm font-semibold tracking-widest uppercase text-[#00C2FF]">
+          Range Activity
+        </h2>
+      </div>
+      <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+        {stats.count === 0 ? (
+          <div className="p-8 text-center">
+            <div className="w-10 h-10 rounded-full bg-[#00C2FF]/10 border border-[#00C2FF]/20 flex items-center justify-center mx-auto mb-3">
+              <Target className="w-5 h-5 text-[#00C2FF]" />
+            </div>
+            <p className="text-sm text-vault-text-muted mb-3">No range sessions logged yet</p>
+            <Link
+              href="/range"
+              className="text-xs bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-3 py-1.5 rounded transition-colors"
+            >
+              Log First Session
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-3 divide-x divide-vault-border border-b border-vault-border">
+              <div className="px-4 py-3 text-center">
+                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Sessions</p>
+                <p className="text-lg font-bold font-mono text-vault-text">{formatNumber(stats.count)}</p>
+              </div>
+              <div className="px-4 py-3 text-center">
+                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Rounds</p>
+                <p className="text-lg font-bold font-mono text-[#00C2FF]">{formatNumber(stats.totalRounds)}</p>
+              </div>
+              <div className="px-4 py-3 text-center">
+                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Last 30 Days</p>
+                <p className="text-lg font-bold font-mono text-vault-text">{stats.sessionsLast30Days}</p>
+              </div>
+            </div>
+            {stats.lastSession && (
+              <Link href={`/range/${stats.lastSession.id}`}
+                className="flex items-center gap-3 px-4 py-3 hover:bg-vault-surface-2 transition-colors group">
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-vault-text-faint mb-0.5">Last session</p>
+                  <p className="text-sm text-vault-text truncate group-hover:text-[#00C2FF] transition-colors">
+                    {stats.lastSession.firearmName}
+                    {stats.lastSession.rangeName ? ` · ${stats.lastSession.rangeName}` : ""}
+                  </p>
+                  <p className="text-xs text-vault-text-faint">
+                    {formatDate(stats.lastSession.date)} · {formatNumber(stats.lastSession.roundsFired)} rds
+                  </p>
+                </div>
+                <ChevronRight className="w-4 h-4 text-vault-text-faint group-hover:text-[#00C2FF] transition-colors shrink-0" />
+              </Link>
+            )}
+          </>
+        )}
+      </div>
+      {stats.count > 0 && (
+        <div className="mt-2 flex items-center justify-end gap-4">
+          <Link href="/range"
+            className="text-xs text-[#00C2FF] hover:text-[#00C2FF]/80 flex items-center gap-1">
+            Log Session <ChevronRight className="w-3 h-3" />
+          </Link>
+          <Link href="/range/history"
+            className="text-xs text-[#00C2FF] hover:text-[#00C2FF]/80 flex items-center gap-1">
+            View History <ChevronRight className="w-3 h-3" />
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function AmmoSummaryWidget({ ammoStocks }: { ammoStocks: AmmoStockItem[] }) {
   // Group by caliber
   const byCaliber = ammoStocks.reduce<Record<string, number>>((acc, stock) => {
@@ -470,6 +558,8 @@ export function DashboardClient({ data }: { data: DashboardData }) {
     switch (id) {
       case "stats":
         return <StatsWidget data={data} />;
+      case "range-sessions":
+        return <RangeSessionsWidget stats={data.rangeStats} />;
       case "low-ammo":
         return <LowAmmoWidget items={data.lowStockItems} />;
       case "recent":


### PR DESCRIPTION
- Schema: add DrillTemplate, SessionDrill, SessionAmmoLink models; extend RangeSession with environment/weather and shot group fields
- Seed: add 8 built-in drill templates (Bill Drill, El Presidente, etc.)
- API: GET+PUT /api/range-sessions/[id], POST+PUT+DELETE drill routes, GET+POST+PUT+DELETE drill template routes, ammoTransactionIds linking, range session stats in /api/stats
- UI: collapsible environment + shot group fieldsets on log form with MOA auto-computation; session detail page with drill management; history page analytics tab (Recharts line/bar charts + group trend); Drill Library page at /range/drills; Range Activity dashboard widget

https://claude.ai/code/session_01HKyHvj77LbDCx2SViUtqxc