### PR TITLE
Add TASK_PROPOSALS.md with four actionable codebase-review tasks

### DIFF
--- a/TASK_PROPOSALS.md
+++ b/TASK_PROPOSALS.md
@@ -1,0 +1,78 @@
+# Codebase Review: Actionable Task Proposals
+
+This document lists four concrete, implementation-ready tasks found during review.
+
+## 1) Typo / wording cleanup task
+
+**Title:** Clarify HMAC token format wording in session helper docs  
+**Type:** Typo / developer-facing wording  
+**Location:** `src/lib/session.ts`
+
+### Problem
+The doc comment says `Returns "token.hmachex"`, which is hard to read and inconsistently styled.
+
+### Proposed task
+Update the wording to a clearer, explicit format such as `Returns "<token>.<hmacHex>"`.
+
+### Acceptance criteria
+- `signToken` doc comment uses consistent casing (`hmacHex`) and delimiter notation.
+- No runtime behavior changes.
+
+---
+
+## 2) Bug fix task
+
+**Title:** Prevent destructive partial updates in `PUT /api/range-sessions/[id]`  
+**Type:** Bug  
+**Location:** `src/app/api/range-sessions/[id]/route.ts`
+
+### Problem
+Several optional fields are currently mapped to `null` when omitted from request bodies, which can erase existing data during partial updates.
+
+### Proposed task
+In the `data` object for `tx.rangeSession.update`, treat omitted fields as `undefined` (do not update), and only set `null` when the caller explicitly provides a null-like value intended to clear data.
+
+### Acceptance criteria
+- Omitting `rangeName`, `rangeLocation`, `notes`, `environment`, etc. preserves stored values.
+- Explicit clear operations (e.g., sending `null` or empty string, based on decided API contract) still work and are documented.
+- Existing update paths continue to work for provided values.
+
+---
+
+## 3) Comment/documentation discrepancy task
+
+**Title:** Fix inaccurate segment-count description in password hash test  
+**Type:** Docs/test-comment discrepancy  
+**Location:** `src/lib/__tests__/password.test.ts`
+
+### Problem
+Test text says "includes three colon-separated segments after prefix" while the test removes `scrypt:` and correctly asserts two segments (`salt`, `hash`).
+
+### Proposed task
+Align the test title/comment with the actual assertion and hash format logic.
+
+### Acceptance criteria
+- Test description accurately matches implementation (`scrypt:<salt>:<hash>` overall, two segments after stripping prefix).
+- No logic changes required.
+
+---
+
+## 4) Test improvement task
+
+**Title:** Add regression tests for partial update semantics in range sessions API  
+**Type:** Test improvement  
+**Location:** new tests around `src/app/api/range-sessions/[id]/route.ts`
+
+### Gap
+Current tests do not guard against accidental field clearing during partial updates.
+
+### Proposed task
+Add route-level tests that verify:
+1. Omitted optional fields remain unchanged.
+2. Explicitly provided clearing values behave per contract.
+3. Provided values update correctly without side effects.
+
+### Acceptance criteria
+- At least one failing test before bug fix (if using TDD workflow) that reproduces destructive update behavior.
+- Tests pass after applying the bug fix.
+- Future regressions in partial update behavior are caught by CI.


### PR DESCRIPTION
### Motivation
- Capture and track actionable issues found during a codebase review in a single developer-facing document.
- Prioritize a real bug (destructive partial updates) alongside smaller documentation/test clarifications to reduce regression risk.
- Make it explicit what changes and tests are needed so follow-up PRs can be scoped and implemented reliably.

### Description
- Add a new file `TASK_PROPOSALS.md` that lists four implementation-ready tasks discovered during review. 
- Task 1 proposes a wording/typo cleanup in `src/lib/session.ts` to clarify the HMAC token format (use `"<token>.<hmacHex>"`).
- Task 2 describes a bug fix for `PUT /api/range-sessions/[id]` in `src/app/api/range-sessions/[id]/route.ts` to avoid mapping omitted fields to `null` (use `undefined` to preserve existing values) and documents acceptance criteria.
- Task 3 calls out a mismatched test description in `src/lib/__tests__/password.test.ts` and requests aligning the comment/title with the actual assertion.
- Task 4 proposes adding regression tests around the range-sessions partial-update behavior to prevent accidental field clearing and specifies expected test cases and acceptance criteria.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d176e6508326ae36a436e208ca1d)