### PR TITLE
Add secure encrypted backups, automatic server backup checks, and full armory export with UI and docs

### DIFF
--- a/docs/full-armory-export-format.md
+++ b/docs/full-armory-export-format.md
@@ -1,0 +1,144 @@
+# Full Armory Export: Recommended Printable Format
+
+## Goal
+Create a **single printable packet** that can be handed to insurance, law enforcement, or legal representatives after theft, fire, or total loss.
+
+## Best overall format
+Use a **hybrid export**:
+
+1. **Primary:** A paginated **PDF report** (print-ready, human-readable).
+2. **Secondary attachment:** **CSV files** for raw line-item data (easy for adjusters to ingest into claims systems).
+
+For most users, the PDF is the "official" document, while CSV is backup/detail data.
+
+---
+
+## Why PDF + CSV is best
+- **PDF is court/claims friendly:** fixed layout, page numbers, easy signatures, easy to print.
+- **CSV is machine-friendly:** insurance adjusters and auditors can sort/filter totals quickly.
+- **Redundancy:** if one format is hard to read or import, the other still works.
+
+---
+
+## Suggested PDF structure ("Full Armory Export")
+
+### 1) Cover Page
+- Report title: **Full Armory Export**
+- Owner name / account
+- Generated date and time (with timezone)
+- Optional claim/reference number
+- Total item count and estimated total value
+- Data disclaimer ("Values are owner-provided unless appraised")
+
+### 2) Summary Page
+- Category totals (e.g., rifles, pistols, optics, accessories, ammo)
+- Count by status/location (e.g., home safe, offsite storage)
+- Overall replacement value and purchase-cost total
+- Quick chart/table (optional)
+
+### 3) Master Inventory Table (core section)
+For each item include:
+- Unique internal ID
+- Item type/category
+- Manufacturer
+- Model
+- Caliber/gauge (when relevant)
+- **Serial number** (full or masked depending on privacy setting)
+- Condition
+- Purchase date
+- Purchase price
+- Estimated replacement value
+- Storage location
+- Notes/tags
+- Receipt/document count linked to the item
+
+### 4) Item Detail Pages (one per item or grouped)
+- Primary and secondary photos (timestamp if available)
+- Full identifying details
+- Accessories included with the item
+- Provenance (where purchased)
+- Warranty/appraisal references
+- Linked receipt reference IDs (matching appendix/index)
+
+### 5) Supporting Documents Index
+- Receipt filenames or references
+- Appraisal documents
+- Warranty certificates
+- Permit/license references (if user chooses)
+- For each document: linked item ID, upload date, page count, file hash/checksum (optional)
+
+### 6) **Receipt Appendix (required)**
+- Include **all uploaded receipts** as printable pages in the export packet.
+- Preserve original order by item, then by upload date.
+- Print a header on each receipt page with item ID + receipt filename.
+- If the original receipt is an image/PDF, render it as-is in the appendix.
+
+### 7) Signature & Attestation Block
+- "I attest this inventory is accurate to the best of my knowledge"
+- Name, signature line, date
+
+### 8) Footer on every page
+- Page X of Y
+- Export generation timestamp
+- Optional tamper hash (short checksum)
+
+---
+
+## Privacy and safety controls (important)
+Offer export privacy levels:
+
+1. **Insurance/Law Enforcement mode (full detail):** full serial numbers and exact locations.
+2. **General backup mode (redacted):** serial masked (e.g., `***1234`), generalized location.
+
+Also include:
+- Optional "exclude photos" toggle.
+- Optional "exclude legal docs" toggle.
+- Optional "include receipt images/pages" toggle (default **ON**).
+- Password-protected PDF option.
+
+---
+
+## CSV companion files
+Ship one ZIP containing:
+- `full-armory-export.pdf`
+- `inventory-items.csv`
+- `attachments-index.csv`
+- `valuation-summary.csv`
+- `receipts/` folder with the **original uploaded receipt files** (or `receipts.zip`)
+
+This makes both printing and digital ingestion straightforward while preserving originals.
+
+---
+
+## Formatting guidelines for print readiness
+- US Letter by default (with A4 option)
+- High contrast black text
+- No dependence on background colors
+- Keep row heights large enough for manual annotation
+- Repeat table headers on each new page
+
+---
+
+## Recommendation
+If you only build one output first, build the **PDF packet** with:
+1. cover,
+2. summary,
+3. master table,
+4. receipt appendix (all uploaded receipts),
+5. appendix of photos and document index.
+
+Then add CSV/original-file bundle as a second phase for power users and insurance workflows.
+
+---
+
+## Implemented in app (current behavior)
+- Settings now includes an actionable **Full Armory Export** panel with preset selection:
+  - `CLAIMS`: full-detail export for insurance/law enforcement.
+  - `BACKUP`: masked serials for safer personal backup sharing.
+- The export action calls `GET /api/exports/full-armory?preset=CLAIMS|BACKUP`.
+- Generated download set:
+  - `full-armory-export-<timestamp>.json`
+  - `inventory-items-<timestamp>.csv`
+  - `attachments-index-<timestamp>.csv`
+  - `valuation-summary-<timestamp>.csv`
+- The payload includes missing-evidence counters (`missingReceipt`, `missingPhoto`, `missingValue`, `missingSerial`) to identify weak claim records early.

--- a/docs/secure-backup-system.md
+++ b/docs/secure-backup-system.md
@@ -1,0 +1,68 @@
+# Secure Backup System (Self-Hosted)
+
+## What it does
+BlackVault provides two backup paths in **Settings**:
+
+1. **Manual Encrypted Backup** (best for immediate offline backup)
+2. **Automatic Backup Checks** (best for continuous protection after data changes)
+
+A setup wizard in Settings walks users through security + backup setup:
+- Set app password
+- Enable encryption at rest
+- Create first encrypted backup
+- Enable automatic backup checks
+
+## Manual backup flow (non-technical)
+1. Open Settings → Secure System Backup.
+2. Enter a passphrase and confirm it.
+3. Click **Create Encrypted Backup**.
+4. Save the generated `.bvault` file.
+
+The file is encrypted client-side in the browser using:
+- **AES-256-GCM**
+- **PBKDF2-SHA256** (high iteration count)
+
+## Automatic backups after changes
+Automatic checks can be enabled from Settings with a check interval.
+
+How it works:
+- UI periodically calls `POST /api/backup/auto`.
+- Server computes a change token based on latest `updatedAt` values.
+- If token changed since last auto-backup, server writes a new encrypted backup file.
+- If no changes occurred, it skips creating another file.
+
+Server requirement:
+- Set `AUTO_BACKUP_PASSPHRASE` environment variable.
+
+Output location:
+- `./backups/auto-backup-<timestamp>.bvault`
+
+## Included data
+The backup payload includes:
+- settings
+- firearms
+- accessories
+- builds/build slots
+- maintenance records
+- range/training records
+- ammo + transactions
+- document metadata
+
+Optional toggle:
+- Include uploaded document files (recommended ON for disaster recovery)
+
+## Security notes
+- Backup passphrases are not persisted to the database.
+- Manual backup files are encrypted before being saved locally.
+- Automatic backup files are encrypted server-side before being written to `./backups`.
+- Keep backup passphrases separate from backup files.
+- Set a strong `SESSION_SECRET` in production.
+
+## Endpoints
+- `POST /api/backup/export`
+  - body: `{ "includeDocumentFiles": true | false }`
+  - returns raw backup JSON used by the UI before client-side encryption.
+
+- `POST /api/backup/auto`
+  - body: `{ "includeDocumentFiles": true | false, "force": boolean }`
+  - writes an encrypted backup only when data changed (or when forced).

--- a/src/app/api/backup/auto/route.ts
+++ b/src/app/api/backup/auto/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+import { collectBackupData, latestBackupChangeToken } from "@/lib/backup";
+
+type AutoBackupState = {
+  lastToken: number;
+  lastBackupAt: string;
+  lastFile: string;
+};
+
+function encryptForServerBackup(payload: unknown, passphrase: string) {
+  const salt = crypto.randomBytes(16);
+  const iv = crypto.randomBytes(12);
+  const iterations = 250_000;
+  const key = crypto.pbkdf2Sync(passphrase, salt, iterations, 32, "sha256");
+
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const plaintext = Buffer.from(JSON.stringify(payload), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    type: "blackvault-encrypted-backup",
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    kdf: {
+      algorithm: "PBKDF2",
+      hash: "SHA-256",
+      iterations,
+      salt: salt.toString("base64"),
+    },
+    cipher: {
+      algorithm: "AES-256-GCM",
+      iv: iv.toString("base64"),
+      tag: tag.toString("base64"),
+      ciphertext: ciphertext.toString("base64"),
+    },
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const autoPassphrase = process.env.AUTO_BACKUP_PASSPHRASE;
+    if (!autoPassphrase) {
+      return NextResponse.json(
+        { error: "AUTO_BACKUP_PASSPHRASE is not set on the server" },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const includeDocumentFiles = body?.includeDocumentFiles !== false;
+    const force = body?.force === true;
+
+    const data = await collectBackupData(includeDocumentFiles);
+    const token = latestBackupChangeToken(data);
+
+    const backupDir = path.join(process.cwd(), "backups");
+    const statePath = path.join(backupDir, ".auto-backup-state.json");
+
+    await fs.mkdir(backupDir, { recursive: true });
+
+    let priorState: AutoBackupState | null = null;
+    try {
+      const raw = await fs.readFile(statePath, "utf8");
+      priorState = JSON.parse(raw) as AutoBackupState;
+    } catch {
+      priorState = null;
+    }
+
+    if (!force && priorState && priorState.lastToken === token) {
+      return NextResponse.json({
+        ok: true,
+        created: false,
+        reason: "No data changes since last automatic backup",
+        lastBackupAt: priorState.lastBackupAt,
+        lastFile: priorState.lastFile,
+      });
+    }
+
+    const payload = {
+      meta: {
+        app: "ProjectBlackVault",
+        formatVersion: 1,
+        generatedAt: new Date().toISOString(),
+        includeDocumentFiles,
+        automated: true,
+      },
+      data,
+    };
+
+    const encrypted = encryptForServerBackup(payload, autoPassphrase);
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `auto-backup-${stamp}.bvault`;
+    const filePath = path.join(backupDir, fileName);
+
+    await fs.writeFile(filePath, JSON.stringify(encrypted, null, 2), "utf8");
+
+    const nextState: AutoBackupState = {
+      lastToken: token,
+      lastBackupAt: new Date().toISOString(),
+      lastFile: fileName,
+    };
+
+    await fs.writeFile(statePath, JSON.stringify(nextState, null, 2), "utf8");
+
+    return NextResponse.json({
+      ok: true,
+      created: true,
+      fileName,
+      backupDir: "backups",
+      token,
+    });
+  } catch (error) {
+    console.error("POST /api/backup/auto error:", error);
+    return NextResponse.json({ error: "Failed to run automatic backup" }, { status: 500 });
+  }
+}

--- a/src/app/api/backup/export/route.ts
+++ b/src/app/api/backup/export/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { collectBackupData } from "@/lib/backup";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const includeDocumentFiles = body?.includeDocumentFiles !== false;
+
+    const data = await collectBackupData(includeDocumentFiles);
+
+    const backup = {
+      meta: {
+        app: "ProjectBlackVault",
+        formatVersion: 1,
+        generatedAt: new Date().toISOString(),
+        includeDocumentFiles,
+      },
+      data,
+    };
+
+    return NextResponse.json(backup);
+  } catch (error) {
+    console.error("POST /api/backup/export error:", error);
+    return NextResponse.json({ error: "Failed to generate backup" }, { status: 500 });
+  }
+}

--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -1,0 +1,216 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+type ExportPreset = "CLAIMS" | "BACKUP";
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const text = String(value);
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function rowsToCsv(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0]);
+  const lines = [headers.join(",")];
+  for (const row of rows) {
+    lines.push(headers.map((header) => csvEscape(row[header])).join(","));
+  }
+  return lines.join("\n");
+}
+
+function formatDate(value: Date | null | undefined): string {
+  if (!value) return "";
+  return value.toISOString().slice(0, 10);
+}
+
+function maskSerial(serialNumber: string | null | undefined): string {
+  if (!serialNumber) return "";
+  if (serialNumber.length <= 4) return "****";
+  return `${"*".repeat(Math.max(serialNumber.length - 4, 3))}${serialNumber.slice(-4)}`;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const presetRaw = request.nextUrl.searchParams.get("preset");
+    const preset: ExportPreset = presetRaw === "BACKUP" ? "BACKUP" : "CLAIMS";
+
+    const [firearms, accessories, documents] = await Promise.all([
+      prisma.firearm.findMany({ orderBy: [{ manufacturer: "asc" }, { model: "asc" }, { name: "asc" }] }),
+      prisma.accessory.findMany({ orderBy: [{ manufacturer: "asc" }, { name: "asc" }] }),
+      prisma.document.findMany({
+        orderBy: [{ createdAt: "asc" }],
+        include: {
+          firearm: { select: { id: true, name: true } },
+          accessory: { select: { id: true, name: true } },
+        },
+      }),
+    ]);
+
+    const receiptDocuments = documents.filter((doc) => doc.type === "RECEIPT");
+
+    const itemRows = [
+      ...firearms.map((firearm) => {
+        const itemDocs = documents.filter((doc) => doc.firearmId === firearm.id);
+        const receiptCount = itemDocs.filter((doc) => doc.type === "RECEIPT").length;
+        const hasPhoto = !!firearm.imageUrl;
+
+        return {
+          itemId: firearm.id,
+          entityType: "FIREARM",
+          category: firearm.type || "",
+          manufacturer: firearm.manufacturer || "",
+          model: firearm.model || firearm.name,
+          caliber: firearm.caliber || "",
+          serialNumber: preset === "BACKUP" ? maskSerial(firearm.serialNumber) : (firearm.serialNumber ?? ""),
+          hasSerial: !!firearm.serialNumber,
+          purchaseDate: formatDate(firearm.acquisitionDate),
+          purchasePrice: firearm.purchasePrice ?? null,
+          replacementValue: firearm.currentValue ?? null,
+          receiptCount,
+          documentCount: itemDocs.length,
+          hasPhoto,
+          missingSerial: !firearm.serialNumber,
+          missingReceipt: receiptCount === 0,
+          missingPhoto: !hasPhoto,
+          missingValue: firearm.currentValue == null && firearm.purchasePrice == null,
+          notes: firearm.notes ?? "",
+        };
+      }),
+      ...accessories.map((accessory) => {
+        const itemDocs = documents.filter((doc) => doc.accessoryId === accessory.id);
+        const receiptCount = itemDocs.filter((doc) => doc.type === "RECEIPT").length;
+        const hasPhoto = !!accessory.imageUrl;
+
+        return {
+          itemId: accessory.id,
+          entityType: "ACCESSORY",
+          category: accessory.type || "",
+          manufacturer: accessory.manufacturer || "",
+          model: accessory.model || accessory.name,
+          caliber: accessory.caliber || "",
+          serialNumber: "",
+          hasSerial: false,
+          purchaseDate: formatDate(accessory.acquisitionDate),
+          purchasePrice: accessory.purchasePrice ?? null,
+          replacementValue: null,
+          receiptCount,
+          documentCount: itemDocs.length,
+          hasPhoto,
+          missingSerial: true,
+          missingReceipt: receiptCount === 0,
+          missingPhoto: !hasPhoto,
+          missingValue: accessory.purchasePrice == null,
+          notes: accessory.notes ?? "",
+        };
+      }),
+    ];
+
+    const attachmentsRows = documents.map((doc) => ({
+      documentId: doc.id,
+      type: doc.type,
+      name: doc.name,
+      linkedItemId: doc.firearmId || doc.accessoryId || "",
+      linkedItemType: doc.firearmId ? "FIREARM" : doc.accessoryId ? "ACCESSORY" : "UNATTACHED",
+      linkedItemName: doc.firearm?.name || doc.accessory?.name || "",
+      mimeType: doc.mimeType ?? "",
+      fileSize: doc.fileSize ?? "",
+      fileUrl: doc.fileUrl,
+      uploadedAt: doc.createdAt.toISOString(),
+    }));
+
+    const totalPurchaseValue = itemRows.reduce((sum, item) => sum + (typeof item.purchasePrice === "number" ? item.purchasePrice : 0), 0);
+    const totalReplacementValue = itemRows.reduce((sum, item) => sum + (typeof item.replacementValue === "number" ? item.replacementValue : 0), 0);
+
+    const summaryRows = [
+      {
+        metric: "Generated At",
+        value: new Date().toISOString(),
+      },
+      {
+        metric: "Preset",
+        value: preset,
+      },
+      {
+        metric: "Total Items",
+        value: itemRows.length,
+      },
+      {
+        metric: "Total Firearms",
+        value: firearms.length,
+      },
+      {
+        metric: "Total Accessories",
+        value: accessories.length,
+      },
+      {
+        metric: "Total Documents",
+        value: documents.length,
+      },
+      {
+        metric: "Total Receipts",
+        value: receiptDocuments.length,
+      },
+      {
+        metric: "Total Purchase Value",
+        value: totalPurchaseValue.toFixed(2),
+      },
+      {
+        metric: "Total Replacement Value",
+        value: totalReplacementValue.toFixed(2),
+      },
+      {
+        metric: "Items Missing Receipts",
+        value: itemRows.filter((i) => i.missingReceipt).length,
+      },
+      {
+        metric: "Items Missing Photos",
+        value: itemRows.filter((i) => i.missingPhoto).length,
+      },
+      {
+        metric: "Items Missing Value",
+        value: itemRows.filter((i) => i.missingValue).length,
+      },
+      {
+        metric: "Items Missing Serial",
+        value: itemRows.filter((i) => i.missingSerial).length,
+      },
+    ];
+
+    return NextResponse.json({
+      meta: {
+        generatedAt: new Date().toISOString(),
+        preset,
+        includesAllUploadedReceipts: true,
+      },
+      summary: {
+        totalItems: itemRows.length,
+        totalFirearms: firearms.length,
+        totalAccessories: accessories.length,
+        totalDocuments: documents.length,
+        totalReceipts: receiptDocuments.length,
+        totalPurchaseValue,
+        totalReplacementValue,
+        missingEvidence: {
+          missingReceipts: itemRows.filter((i) => i.missingReceipt).length,
+          missingPhotos: itemRows.filter((i) => i.missingPhoto).length,
+          missingValues: itemRows.filter((i) => i.missingValue).length,
+          missingSerials: itemRows.filter((i) => i.missingSerial).length,
+        },
+      },
+      items: itemRows,
+      attachments: attachmentsRows,
+      csv: {
+        inventoryItems: rowsToCsv(itemRows),
+        attachmentsIndex: rowsToCsv(attachmentsRows),
+        valuationSummary: rowsToCsv(summaryRows),
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/exports/full-armory error:", error);
+    return NextResponse.json({ error: "Failed to generate full armory export" }, { status: 500 });
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Save,
   Loader2,
@@ -22,6 +22,11 @@ import {
   ChevronDown,
   ChevronUp,
   Shield,
+  FileText,
+  DownloadCloud,
+  Archive,
+  Rocket,
+  RefreshCw,
 } from "lucide-react";
 
 const INPUT_CLASS =
@@ -63,6 +68,24 @@ export default function SettingsPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
 
+  const [exportPreset, setExportPreset] = useState<"CLAIMS" | "BACKUP">("CLAIMS");
+  const [exportBusy, setExportBusy] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportSuccess, setExportSuccess] = useState<string | null>(null);
+
+  const [backupBusy, setBackupBusy] = useState(false);
+  const [backupError, setBackupError] = useState<string | null>(null);
+  const [backupSuccess, setBackupSuccess] = useState<string | null>(null);
+  const [backupPassphrase, setBackupPassphrase] = useState("");
+  const [backupConfirm, setBackupConfirm] = useState("");
+  const [includeDocumentFilesInBackup, setIncludeDocumentFilesInBackup] = useState(true);
+  const [wizardStep, setWizardStep] = useState(0);
+  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
+  const [autoBackupIntervalMin, setAutoBackupIntervalMin] = useState(15);
+  const [autoBackupStatus, setAutoBackupStatus] = useState<string | null>(null);
+  const [autoBackupError, setAutoBackupError] = useState<string | null>(null);
+  const [autoBackupRunning, setAutoBackupRunning] = useState(false);
+
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -101,6 +124,20 @@ export default function SettingsPage() {
         setDataLoading(false);
       });
   }, []);
+
+  useEffect(() => {
+    const enabled = localStorage.getItem("blackvault:auto-backup-enabled");
+    const interval = localStorage.getItem("blackvault:auto-backup-interval");
+    if (enabled === "true") setAutoBackupEnabled(true);
+    if (interval && !Number.isNaN(Number(interval))) {
+      setAutoBackupIntervalMin(Math.max(5, Number(interval)));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("blackvault:auto-backup-enabled", String(autoBackupEnabled));
+    localStorage.setItem("blackvault:auto-backup-interval", String(autoBackupIntervalMin));
+  }, [autoBackupEnabled, autoBackupIntervalMin]);
 
   function handleCopyUrl(url: string) {
     navigator.clipboard.writeText(url).then(() => {
@@ -258,6 +295,173 @@ export default function SettingsPage() {
     URL.revokeObjectURL(url);
   }
 
+  async function handleDownloadFullArmoryExport() {
+    setExportBusy(true);
+    setExportError(null);
+    setExportSuccess(null);
+
+    try {
+      const res = await fetch(`/api/exports/full-armory?preset=${exportPreset}`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed to generate export");
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+      const files: Array<{ name: string; content: string }> = [
+        { name: `full-armory-export-${timestamp}.json`, content: JSON.stringify(json, null, 2) },
+        { name: `inventory-items-${timestamp}.csv`, content: json.csv?.inventoryItems ?? "" },
+        { name: `attachments-index-${timestamp}.csv`, content: json.csv?.attachmentsIndex ?? "" },
+        { name: `valuation-summary-${timestamp}.csv`, content: json.csv?.valuationSummary ?? "" },
+      ];
+
+      for (const file of files) {
+        const blob = new Blob([file.content], { type: file.name.endsWith(".json") ? "application/json" : "text/csv" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = file.name;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      setExportSuccess("Full Armory Export generated. JSON + CSV files downloaded.");
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : "Failed to generate export");
+    } finally {
+      setExportBusy(false);
+    }
+  }
+
+
+  async function encryptBackupPayload(payload: unknown, passphrase: string) {
+    const encoder = new TextEncoder();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iterations = 250000;
+
+    const baseKey = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(passphrase),
+      { name: "PBKDF2" },
+      false,
+      ["deriveKey"]
+    );
+
+    const key = await crypto.subtle.deriveKey(
+      { name: "PBKDF2", salt, iterations, hash: "SHA-256" },
+      baseKey,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const plaintext = encoder.encode(JSON.stringify(payload));
+    const encryptedBuffer = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+    const encrypted = new Uint8Array(encryptedBuffer);
+
+    const b64 = (bytes: Uint8Array) => btoa(String.fromCharCode(...bytes));
+
+    return {
+      type: "blackvault-encrypted-backup",
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      kdf: { algorithm: "PBKDF2", hash: "SHA-256", iterations, salt: b64(salt) },
+      cipher: { algorithm: "AES-GCM", iv: b64(iv), ciphertext: b64(encrypted) },
+    };
+  }
+
+  async function handleCreateSecureBackup() {
+    setBackupError(null);
+    setBackupSuccess(null);
+
+    if (!backupPassphrase || backupPassphrase.length < 12) {
+      setBackupError("Use a backup passphrase with at least 12 characters.");
+      return;
+    }
+
+    if (backupPassphrase !== backupConfirm) {
+      setBackupError("Passphrase confirmation does not match.");
+      return;
+    }
+
+    setBackupBusy(true);
+
+    try {
+      const res = await fetch("/api/backup/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ includeDocumentFiles: includeDocumentFilesInBackup }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed to generate backup");
+
+      const encryptedPayload = await encryptBackupPayload(json, backupPassphrase);
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const blob = new Blob([JSON.stringify(encryptedPayload, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `blackvault-backup-${timestamp}.bvault`;
+      a.click();
+      URL.revokeObjectURL(url);
+
+      setBackupPassphrase("");
+      setBackupConfirm("");
+      setBackupSuccess("Encrypted backup created. Save the file and your passphrase in separate safe locations.");
+    } catch (error) {
+      setBackupError(error instanceof Error ? error.message : "Failed to create backup");
+    } finally {
+      setBackupBusy(false);
+    }
+  }
+
+  const runAutoBackupCheck = useCallback(async (force = false) => {
+    setAutoBackupError(null);
+    setAutoBackupRunning(true);
+    try {
+      const res = await fetch("/api/backup/auto", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          includeDocumentFiles: includeDocumentFilesInBackup,
+          force,
+        }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Automatic backup failed");
+
+      if (json.created) {
+        setAutoBackupStatus(`Automatic backup created: ${json.fileName}`);
+      } else {
+        setAutoBackupStatus(json.reason ?? "No changes detected since last backup.");
+      }
+    } catch (error) {
+      setAutoBackupError(error instanceof Error ? error.message : "Automatic backup failed");
+    } finally {
+      setAutoBackupRunning(false);
+    }
+  }, [includeDocumentFilesInBackup]);
+
+  useEffect(() => {
+    if (!autoBackupEnabled) return;
+
+    if (typeof document !== "undefined" && document.visibilityState === "visible") {
+      runAutoBackupCheck(false);
+    }
+
+    const ms = Math.max(5, autoBackupIntervalMin) * 60 * 1000;
+    const timer = setInterval(() => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      runAutoBackupCheck(false);
+    }, ms);
+
+    return () => clearInterval(timer);
+  }, [autoBackupEnabled, autoBackupIntervalMin, runAutoBackupCheck]);
+
+
+
   if (dataLoading) {
     return (
       <div className="flex items-center justify-center min-h-full">
@@ -277,6 +481,31 @@ export default function SettingsPage() {
 
   const imageSearchConfigured =
     settings?._googleCseApiKeyIsSet && !!settings?.googleCseSearchEngineId;
+
+  const wizardSteps = [
+    {
+      title: "Secure Access",
+      description: "Set an app password so the vault is protected on startup.",
+      done: !!settings?.appPassword,
+    },
+    {
+      title: "Encryption",
+      description: "Enable encryption at rest and save your encryption key offline.",
+      done: !!settings?.encryptionEnabled,
+    },
+    {
+      title: "Backups",
+      description: "Create your first encrypted .bvault backup with document files included.",
+      done: !!backupSuccess,
+    },
+    {
+      title: "Auto-Backup",
+      description: "Enable automatic backup checks to protect new changes automatically.",
+      done: autoBackupEnabled,
+    },
+  ] as const;
+
+  const completedWizardSteps = wizardSteps.filter((step) => step.done).length;
 
   return (
     <div className="min-h-full">
@@ -674,6 +903,285 @@ export default function SettingsPage() {
               <p className="text-xs text-vault-text-faint leading-relaxed">
                 Ensure the container port is mapped with <code className="font-mono">-p 3000:3000</code> or equivalent in docker-compose.yml.
               </p>
+            </div>
+          </fieldset>
+
+          {/* ── Setup Wizard ───────────────────────────────── */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+              <Rocket className="w-3.5 h-3.5" />
+              Setup Wizard
+            </legend>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              Guided onboarding for non-technical users. Complete each step to harden security and automate backup protection.
+            </p>
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-3">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint font-mono">Progress</p>
+                <p className="text-xs text-vault-text-muted">{completedWizardSteps} / {wizardSteps.length} complete</p>
+              </div>
+              <div className="h-2 rounded bg-vault-border overflow-hidden">
+                <div className="h-full bg-[#00C2FF] transition-all" style={{ width: `${(completedWizardSteps / wizardSteps.length) * 100}%` }} />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {wizardSteps.map((step, idx) => (
+                <button
+                  key={step.title}
+                  type="button"
+                  onClick={() => setWizardStep(idx)}
+                  className={`text-left rounded-md border px-3 py-2 text-xs transition-colors ${wizardStep === idx ? "border-[#00C2FF]/40 bg-[#00C2FF]/10" : "border-vault-border hover:border-vault-text-muted/30"}`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className={`font-medium ${wizardStep === idx ? "text-[#00C2FF]" : "text-vault-text"}`}>{idx + 1}. {step.title}</p>
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono border ${step.done ? "text-[#00C853] border-[#00C853]/40" : "text-vault-text-faint border-vault-border"}`}>
+                      {step.done ? "DONE" : "PENDING"}
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-vault-text-faint mt-1">{step.description}</p>
+                </button>
+              ))}
+            </div>
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-4 space-y-2">
+              <p className="text-xs text-vault-text font-medium">Current Step: {wizardSteps[wizardStep].title}</p>
+              <p className="text-xs text-vault-text-faint">{wizardSteps[wizardStep].description}</p>
+              {wizardStep === 3 && (
+                <button
+                  type="button"
+                  onClick={() => runAutoBackupCheck(true)}
+                  className="mt-2 inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-xs border border-vault-border text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                  Run First Auto-Backup Check
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setWizardStep((s) => Math.max(0, s - 1))}
+                disabled={wizardStep === 0}
+                className="px-3 py-1.5 text-xs rounded-md border border-vault-border text-vault-text-faint disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => setWizardStep((s) => Math.min(wizardSteps.length - 1, s + 1))}
+                disabled={wizardStep === wizardSteps.length - 1}
+                className="px-3 py-1.5 text-xs rounded-md border border-[#00C2FF]/30 text-[#00C2FF] disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </fieldset>
+
+          {/* ── Full Armory Export ─────────────────────────── */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+              <FileText className="w-3.5 h-3.5" />
+              Full Armory Export
+            </legend>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              Build a claim-ready package with missing-evidence flags, uploaded receipts, and CSV companion files.
+            </p>
+
+            {exportError && (
+              <div className="flex items-center gap-2 rounded-md border border-[#E53935]/30 bg-[#E53935]/10 px-3 py-2">
+                <AlertCircle className="h-3.5 w-3.5 text-[#E53935]" />
+                <p className="text-xs text-[#E53935]">{exportError}</p>
+              </div>
+            )}
+
+            {exportSuccess && (
+              <div className="flex items-center gap-2 rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2">
+                <CheckCircle2 className="h-3.5 w-3.5 text-[#00C853]" />
+                <p className="text-xs text-[#00C853]">{exportSuccess}</p>
+              </div>
+            )}
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-4 space-y-3">
+              <p className="text-[10px] text-vault-text-faint font-mono uppercase tracking-widest">Claims Preset</p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => setExportPreset("CLAIMS")}
+                  className={`rounded-md border px-3 py-2 text-left transition-colors ${
+                    exportPreset === "CLAIMS"
+                      ? "border-[#00C2FF]/40 bg-[#00C2FF]/10 text-[#00C2FF]"
+                      : "border-vault-border text-vault-text-muted hover:border-vault-text-muted/30"
+                  }`}
+                >
+                  <p className="text-xs font-medium">Insurance / Law Enforcement</p>
+                  <p className="text-[11px] mt-1">Full details, unmasked serials, all receipts included.</p>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExportPreset("BACKUP")}
+                  className={`rounded-md border px-3 py-2 text-left transition-colors ${
+                    exportPreset === "BACKUP"
+                      ? "border-[#00C2FF]/40 bg-[#00C2FF]/10 text-[#00C2FF]"
+                      : "border-vault-border text-vault-text-muted hover:border-vault-text-muted/30"
+                  }`}
+                >
+                  <p className="text-xs font-medium">General Backup</p>
+                  <p className="text-[11px] mt-1">Masked serials with the same document/receipt coverage.</p>
+                </button>
+              </div>
+            </div>
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-4 space-y-3">
+              <p className="text-[10px] text-vault-text-faint font-mono uppercase tracking-widest">What gets generated</p>
+              <ul className="space-y-1.5 text-xs text-vault-text-muted">
+                <li>• `full-armory-export-*.json` with complete item + attachment data.</li>
+                <li>• `inventory-items-*.csv` for line-item adjuster workflows.</li>
+                <li>• `attachments-index-*.csv` with uploaded receipt/document linkage.</li>
+                <li>• `valuation-summary-*.csv` including missing evidence counters.</li>
+              </ul>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleDownloadFullArmoryExport}
+                disabled={exportBusy}
+                className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              >
+                {exportBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <DownloadCloud className="w-4 h-4" />}
+                {exportBusy ? "Generating Export..." : "Generate Full Armory Export"}
+              </button>
+              <p className="text-xs text-vault-text-faint">Includes all uploaded receipts in the attachment index output.</p>
+            </div>
+
+            <p className="text-xs text-vault-text-faint">
+              Specification reference: <code className="font-mono">docs/full-armory-export-format.md</code>
+            </p>
+          </fieldset>
+
+          {/* ── Secure System Backup ─────────────────────────── */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+              <Archive className="w-3.5 h-3.5" />
+              Secure System Backup
+            </legend>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              One-click encrypted backup for self-hosted deployments. Great for non-technical users: enter a passphrase, click create, and save one backup file.
+            </p>
+
+            {backupError && (
+              <div className="flex items-center gap-2 rounded-md border border-[#E53935]/30 bg-[#E53935]/10 px-3 py-2">
+                <AlertCircle className="h-3.5 w-3.5 text-[#E53935]" />
+                <p className="text-xs text-[#E53935]">{backupError}</p>
+              </div>
+            )}
+
+            {backupSuccess && (
+              <div className="flex items-center gap-2 rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2">
+                <CheckCircle2 className="h-3.5 w-3.5 text-[#00C853]" />
+                <p className="text-xs text-[#00C853]">{backupSuccess}</p>
+              </div>
+            )}
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-4 space-y-3">
+              <label className={LABEL_CLASS}>Backup Passphrase</label>
+              <input
+                type="password"
+                value={backupPassphrase}
+                onChange={(e) => setBackupPassphrase(e.target.value)}
+                placeholder="At least 12 characters"
+                className={INPUT_CLASS}
+              />
+
+              <label className={LABEL_CLASS}>Confirm Passphrase</label>
+              <input
+                type="password"
+                value={backupConfirm}
+                onChange={(e) => setBackupConfirm(e.target.value)}
+                placeholder="Re-enter passphrase"
+                className={INPUT_CLASS}
+              />
+
+              <button
+                type="button"
+                onClick={() => setIncludeDocumentFilesInBackup((v) => !v)}
+                className={`flex items-center gap-3 w-full text-left px-4 py-3 rounded-md border transition-all ${includeDocumentFilesInBackup ? "border-[#00C2FF]/40 bg-[#00C2FF]/5" : "border-vault-border hover:border-vault-text-muted/20"}`}
+              >
+                <div className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${includeDocumentFilesInBackup ? "bg-[#00C2FF]" : "bg-vault-border"}`}>
+                  <div className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${includeDocumentFilesInBackup ? "left-4" : "left-0.5"}`} />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-vault-text">Include uploaded document files</p>
+                  <p className="text-xs text-vault-text-faint mt-0.5">Keeps receipts and other uploaded files inside the encrypted backup.</p>
+                </div>
+              </button>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleCreateSecureBackup}
+                disabled={backupBusy}
+                className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              >
+                {backupBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Archive className="w-4 h-4" />}
+                {backupBusy ? "Creating Secure Backup..." : "Create Encrypted Backup"}
+              </button>
+              <p className="text-xs text-vault-text-faint">Uses AES-256-GCM encryption in your browser with PBKDF2 key stretching.</p>
+            </div>
+
+            <div className="bg-vault-bg border border-vault-border rounded-md p-4 space-y-3">
+              <p className="text-[10px] text-vault-text-faint font-mono uppercase tracking-widest">Automatic Backup (After Changes)</p>
+
+              {autoBackupError && (
+                <p className="text-xs text-[#E53935]">{autoBackupError}</p>
+              )}
+              {autoBackupStatus && (
+                <p className="text-xs text-[#00C853]">{autoBackupStatus}</p>
+              )}
+
+              <button
+                type="button"
+                onClick={() => setAutoBackupEnabled((v) => !v)}
+                className={`flex items-center gap-3 w-full text-left px-4 py-3 rounded-md border transition-all ${autoBackupEnabled ? "border-[#00C2FF]/40 bg-[#00C2FF]/5" : "border-vault-border hover:border-vault-text-muted/20"}`}
+              >
+                <div className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${autoBackupEnabled ? "bg-[#00C2FF]" : "bg-vault-border"}`}>
+                  <div className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${autoBackupEnabled ? "left-4" : "left-0.5"}`} />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-vault-text">Enable automatic backup checks</p>
+                  <p className="text-xs text-vault-text-faint mt-0.5">When enabled, the app checks for data changes and triggers a secure server backup.</p>
+                </div>
+              </button>
+
+              <div>
+                <label className={LABEL_CLASS}>Check Interval (minutes)</label>
+                <input
+                  type="number"
+                  min={5}
+                  value={autoBackupIntervalMin}
+                  onChange={(e) => setAutoBackupIntervalMin(Math.max(5, Number(e.target.value || 5)))}
+                  className={INPUT_CLASS}
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={() => runAutoBackupCheck(true)}
+                disabled={autoBackupRunning}
+                className="flex items-center gap-2 px-4 py-2 rounded-md text-sm border border-vault-border text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 disabled:opacity-50"
+              >
+                {autoBackupRunning ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+                {autoBackupRunning ? "Running..." : "Run Backup Check Now"}
+              </button>
+
+              <p className="text-xs text-vault-text-faint">Server requirement: set <code className="font-mono">AUTO_BACKUP_PASSPHRASE</code> for automatic encrypted backup files in <code className="font-mono">/backups</code>.</p>
             </div>
           </fieldset>
 

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { prisma } from "@/lib/prisma";
+
+async function readDocumentFileAsBase64(fileUrl: string): Promise<string | null> {
+  if (!fileUrl.startsWith("/uploads/")) return null;
+  const absolutePath = path.join(process.cwd(), "public", fileUrl.replace(/^\//, ""));
+  try {
+    const buf = await fs.readFile(absolutePath);
+    return buf.toString("base64");
+  } catch {
+    return null;
+  }
+}
+
+export async function collectBackupData(includeDocumentFiles: boolean) {
+  const [
+    settings,
+    firearms,
+    accessories,
+    builds,
+    buildSlots,
+    maintenanceNotes,
+    maintenanceSchedules,
+    rangeSessions,
+    drillTemplates,
+    sessionDrills,
+    drillLogs,
+    ammo,
+    ammoTransactions,
+    documents,
+  ] = await Promise.all([
+    prisma.appSettings.findUnique({ where: { id: "singleton" } }),
+    prisma.firearm.findMany(),
+    prisma.accessory.findMany(),
+    prisma.build.findMany(),
+    prisma.buildSlot.findMany(),
+    prisma.maintenanceNote.findMany(),
+    prisma.maintenanceSchedule.findMany(),
+    prisma.rangeSession.findMany(),
+    prisma.drillTemplate.findMany(),
+    prisma.sessionDrill.findMany(),
+    prisma.drillLog.findMany(),
+    prisma.ammoStock.findMany(),
+    prisma.ammoTransaction.findMany(),
+    prisma.document.findMany(),
+  ]);
+
+  const documentFiles = includeDocumentFiles
+    ? await Promise.all(
+        documents.map(async (doc) => ({
+          documentId: doc.id,
+          fileUrl: doc.fileUrl,
+          mimeType: doc.mimeType,
+          contentBase64: await readDocumentFileAsBase64(doc.fileUrl),
+        }))
+      )
+    : [];
+
+  return {
+    settings,
+    firearms,
+    accessories,
+    builds,
+    buildSlots,
+    maintenanceNotes,
+    maintenanceSchedules,
+    rangeSessions,
+    drillTemplates,
+    sessionDrills,
+    drillLogs,
+    ammo,
+    ammoTransactions,
+    documents,
+    documentFiles,
+  };
+}
+
+export function latestBackupChangeToken(data: Awaited<ReturnType<typeof collectBackupData>>): number {
+  const allDates: number[] = [];
+
+  const pushDates = <T extends { updatedAt?: Date | null }>(items: T[]) => {
+    for (const item of items) {
+      if (item.updatedAt) allDates.push(item.updatedAt.getTime());
+    }
+  };
+
+  if (data.settings?.updatedAt) allDates.push(data.settings.updatedAt.getTime());
+  pushDates(data.firearms);
+  pushDates(data.accessories);
+  pushDates(data.builds);
+  pushDates(data.buildSlots);
+  pushDates(data.maintenanceNotes);
+  pushDates(data.maintenanceSchedules);
+  pushDates(data.rangeSessions);
+  pushDates(data.drillTemplates);
+  pushDates(data.sessionDrills);
+  pushDates(data.drillLogs);
+  pushDates(data.ammo);
+  pushDates(data.ammoTransactions);
+  pushDates(data.documents);
+
+  return allDates.length ? Math.max(...allDates) : 0;
+}


### PR DESCRIPTION
### Motivation

- Provide a simple, self-hosted encrypted backup workflow and an automated server-side backup check to help users preserve data and uploaded receipts. 
- Offer a claim-ready "Full Armory Export" (JSON + CSV companion files) for insurance/law-enforcement or masked backups for general use. 
- Expose these features in the Settings UI with a guided setup wizard so non-technical users can create secure backups and generate exports easily.

### Description

- Added documentation files `docs/full-armory-export-format.md` and `docs/secure-backup-system.md` describing export format and backup flows. 
- Implemented backup data collection in `src/lib/backup.ts` with `collectBackupData` (includes optional base64-encoded document files) and `latestBackupChangeToken` for change detection. 
- Added API endpoints `POST /api/backup/export` (`src/app/api/backup/export/route.ts`) to return raw backup JSON and `POST /api/backup/auto` (`src/app/api/backup/auto/route.ts`) to write encrypted `.bvault` files to `./backups` when changes are detected using server-side PBKDF2 + AES-256-GCM. 
- Implemented full armory export endpoint `GET /api/exports/full-armory` (`src/app/api/exports/full-armory/route.ts`) that queries Prisma for firearms/accessories/documents, computes missing-evidence counters, supports `CLAIMS` and `BACKUP` presets (serial masking), and returns JSON plus CSV strings (`inventoryItems`, `attachmentsIndex`, `valuationSummary`). 
- Extended the Settings UI (`src/app/settings/page.tsx`) with: a setup wizard, client-side encrypted backup creation (PBKDF2 + AES-GCM), automatic backup check scheduling and controls (stored in `localStorage`), and a Full Armory Export generator that downloads JSON and CSV companion files; added related UI state and helper functions.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2da934f9083269afd3cc0f6a22b9c)