### PR TITLE
Add receipt upload on firearm and accessory creation forms

### DIFF
--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { SLOT_TYPES, SLOT_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
 import { ArrowLeft, Plus, Loader2, AlertCircle } from "lucide-react";
 import ImagePicker from "@/components/shared/ImagePicker";
+import ReceiptUploader from "@/components/shared/ReceiptUploader";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
@@ -19,6 +20,8 @@ export default function NewAccessoryPage() {
   const [caliberDropdownOpen, setCaliberDropdownOpen] = useState(false);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [imageSource, setImageSource] = useState<string | null>(null);
+  const [receiptFile, setReceiptFile] = useState<File | null>(null);
+  const [receiptError, setReceiptError] = useState<string | null>(null);
 
   const filteredCalibers = COMMON_CALIBERS.filter((c) =>
     c.toLowerCase().includes(caliberInput.toLowerCase())
@@ -58,6 +61,30 @@ export default function NewAccessoryPage() {
         setError(json.error ?? "Failed to create accessory");
         setLoading(false);
         return;
+      }
+
+      if (receiptFile) {
+        const receiptName = `${payload.name.trim() || "Accessory"} Receipt`;
+        const receiptFormData = new FormData();
+        receiptFormData.append("file", receiptFile);
+        receiptFormData.append("name", receiptName);
+        receiptFormData.append("type", "RECEIPT");
+        receiptFormData.append("accessoryId", json.id);
+
+        const receiptRes = await fetch("/api/documents/upload", {
+          method: "POST",
+          body: receiptFormData,
+        });
+
+        if (!receiptRes.ok) {
+          const receiptJson = await receiptRes.json();
+          setError(
+            receiptJson.error ??
+              "Accessory created, but receipt upload failed. You can upload it later from Documents."
+          );
+          setLoading(false);
+          return;
+        }
       }
 
       setLoading(false);
@@ -171,6 +198,17 @@ export default function NewAccessoryPage() {
               entityType="accessory"
               currentUrl={imageUrl}
               onChange={(url, source) => { setImageUrl(url); setImageSource(source); }}
+            />
+          </fieldset>
+
+          {/* Receipt */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Receipt</legend>
+            <ReceiptUploader
+              file={receiptFile}
+              onFileChange={setReceiptFile}
+              onValidationError={setReceiptError}
+              error={receiptError}
             />
           </fieldset>
 

--- a/src/app/vault/new/page.tsx
+++ b/src/app/vault/new/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { FIREARM_TYPES, FIREARM_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
 import { ArrowLeft, Plus, Loader2, AlertCircle } from "lucide-react";
 import ImagePicker from "@/components/shared/ImagePicker";
+import ReceiptUploader from "@/components/shared/ReceiptUploader";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
@@ -20,6 +21,8 @@ export default function NewFirearmPage() {
   const caliberRef = useRef<HTMLDivElement>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [imageSource, setImageSource] = useState<string | null>(null);
+  const [receiptFile, setReceiptFile] = useState<File | null>(null);
+  const [receiptError, setReceiptError] = useState<string | null>(null);
 
   const filteredCalibers = COMMON_CALIBERS.filter((c) =>
     c.toLowerCase().includes(caliberInput.toLowerCase())
@@ -61,6 +64,30 @@ export default function NewFirearmPage() {
         setError(json.error ?? "Failed to create firearm");
         setLoading(false);
         return;
+      }
+
+      if (receiptFile) {
+        const receiptName = `${payload.name.trim() || "Firearm"} Receipt`;
+        const receiptFormData = new FormData();
+        receiptFormData.append("file", receiptFile);
+        receiptFormData.append("name", receiptName);
+        receiptFormData.append("type", "RECEIPT");
+        receiptFormData.append("firearmId", json.id);
+
+        const receiptRes = await fetch("/api/documents/upload", {
+          method: "POST",
+          body: receiptFormData,
+        });
+
+        if (!receiptRes.ok) {
+          const receiptJson = await receiptRes.json();
+          setError(
+            receiptJson.error ??
+              "Firearm created, but receipt upload failed. You can upload it later from Documents."
+          );
+          setLoading(false);
+          return;
+        }
       }
 
       router.push(`/vault/${json.id}`);
@@ -196,6 +223,17 @@ export default function NewFirearmPage() {
               entityType="firearm"
               currentUrl={imageUrl}
               onChange={(url, source) => { setImageUrl(url); setImageSource(source); }}
+            />
+          </fieldset>
+
+          {/* Receipt */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Receipt</legend>
+            <ReceiptUploader
+              file={receiptFile}
+              onFileChange={setReceiptFile}
+              onValidationError={setReceiptError}
+              error={receiptError}
             />
           </fieldset>
 

--- a/src/components/shared/ReceiptUploader.tsx
+++ b/src/components/shared/ReceiptUploader.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { AlertCircle, FileIcon, FileText, Upload, X } from "lucide-react";
+
+interface ReceiptUploaderProps {
+  file: File | null;
+  onFileChange: (file: File | null) => void;
+  onValidationError: (message: string | null) => void;
+  error: string | null;
+}
+
+const ALLOWED_TYPES = ["application/pdf", "image/jpeg", "image/jpg", "image/png", "image/webp"];
+const MAX_SIZE = 20 * 1024 * 1024;
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function ReceiptUploader({
+  file,
+  onFileChange,
+  onValidationError,
+  error,
+}: ReceiptUploaderProps) {
+  function handleFileSelect(selected: File) {
+    if (!ALLOWED_TYPES.includes(selected.type)) {
+      onFileChange(null);
+      onValidationError("Invalid receipt file type. Allowed: PDF, JPG, PNG, WebP.");
+      return;
+    }
+
+    if (selected.size > MAX_SIZE) {
+      onFileChange(null);
+      onValidationError("Receipt file too large. Maximum size is 20MB.");
+      return;
+    }
+
+    onValidationError(null);
+    onFileChange(selected);
+  }
+
+  return (
+    <div className="space-y-3">
+      {!file ? (
+        <label className="block border-2 border-dashed rounded-lg p-6 text-center cursor-pointer border-vault-border hover:border-[#00C2FF]/40 hover:bg-vault-border/20 transition-colors">
+          <input
+            type="file"
+            accept=".pdf,.jpg,.jpeg,.png,.webp"
+            className="sr-only"
+            onChange={(e) => {
+              const selected = e.target.files?.[0] ?? null;
+              if (selected) {
+                handleFileSelect(selected);
+              }
+            }}
+          />
+          <Upload className="w-7 h-7 text-vault-text-faint mx-auto mb-2" />
+          <p className="text-sm text-vault-text-muted">Drop receipt here or click to browse</p>
+          <p className="text-xs text-vault-text-faint mt-1">PDF, JPG, PNG, WebP — max 20MB</p>
+        </label>
+      ) : (
+        <div className="flex items-center gap-3 p-3 rounded-lg border border-vault-border bg-vault-bg">
+          {file.type === "application/pdf" ? (
+            <FileText className="w-8 h-8 text-[#F5A623] shrink-0" />
+          ) : (
+            <FileIcon className="w-8 h-8 text-[#00C2FF] shrink-0" />
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-vault-text truncate">{file.name}</p>
+            <p className="text-xs text-vault-text-faint">{formatBytes(file.size)}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              onValidationError(null);
+              onFileChange(null);
+            }}
+            className="text-vault-text-faint hover:text-red-400 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-2 text-red-400 text-xs">
+          <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Enable users to attach a purchase receipt when creating a firearm or accessory so receipts are stored and linked at creation time.

### Description
- Add a reusable client component `src/components/shared/ReceiptUploader.tsx` that accepts a single PDF/Image file, enforces allowed MIME types and a 20MB limit, and surfaces validation errors. 
- Integrate `ReceiptUploader` into the Add Firearm form (`src/app/vault/new/page.tsx`) and Add Accessory form (`src/app/accessories/new/page.tsx`) with local state to track the selected file and validation messages. 
- After the base entity is successfully created, upload the selected receipt to the existing endpoint `POST /api/documents/upload` and attach it using `firearmId` or `accessoryId`, and show a clear error if the receipt upload fails so users can retry later from Documents. 

### Testing
- Ran the unit tests subset with `npm run test -- src/lib/__tests__/utils.test.ts` and the tests passed. 
- Ran project lint with `npm run lint` and it reported failures, but they are pre-existing repository-wide lint errors unrelated to these changes (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e65c54b4832696a49712b75518ad)