### PR TITLE
Improve mobile responsiveness and polish for core dashboard UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,22 @@ html {
   scrollbar-width: thin;
 }
 
+html, body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  -webkit-tap-highlight-color: transparent;
+}
+
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}
+
 body {
   background: var(--vault-bg);
   color: var(--vault-text);

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -169,7 +169,7 @@ function SortableWidget({
 // ── Widgets ───────────────────────────────────────────────────
 function StatsWidget({ data }: { data: DashboardData }) {
   return (
-    <div className="grid grid-cols-2 xl:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 sm:gap-4">
       <Link href="/vault" className="block group">
         <StatCard
           label="Total Firearms"

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -8,21 +8,22 @@ interface MobileHeaderProps {
 
 export function MobileHeader({ onMenuOpen }: MobileHeaderProps) {
   return (
-    <header className="md:hidden flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
+    <header className="md:hidden sticky top-0 z-30 flex items-center gap-3 h-14 px-3 border-b border-vault-border/80 bg-vault-surface/95 backdrop-blur-sm shrink-0">
       <button
         onClick={onMenuOpen}
-        className="p-1.5 text-vault-text-faint hover:text-vault-text-muted transition-colors"
+        className="p-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors"
         aria-label="Open navigation"
       >
         <Menu className="w-5 h-5" />
       </button>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 min-w-0">
         <div className="w-6 h-6 rounded bg-[#00C2FF]/10 border border-[#00C2FF]/30 flex items-center justify-center">
           <Shield className="w-3.5 h-3.5 text-[#00C2FF]" />
         </div>
-        <p className="text-xs font-bold text-vault-text tracking-widest uppercase">
-          BlackVault
-        </p>
+        <div className="min-w-0">
+          <p className="text-xs font-bold text-vault-text tracking-widest uppercase truncate">BlackVault</p>
+          <p className="text-[10px] text-vault-text-faint uppercase tracking-wider truncate">Armory Platform</p>
+        </div>
       </div>
     </header>
   );

--- a/src/components/shared/PageHeader.tsx
+++ b/src/components/shared/PageHeader.tsx
@@ -10,15 +10,15 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, subtitle, actions, className }: PageHeaderProps) {
   return (
-    <div className={cn("flex items-center justify-between py-6 px-6 border-b border-vault-border", className)}>
+    <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between py-4 sm:py-6 px-4 sm:px-6 border-b border-vault-border", className)}>
       <div>
-        <h1 className="text-xl font-bold tracking-tight text-vault-text">{title}</h1>
+        <h1 className="text-lg sm:text-xl font-bold tracking-tight text-vault-text">{title}</h1>
         {subtitle && (
-          <p className="text-sm text-vault-text-muted mt-0.5">{subtitle}</p>
+          <p className="text-xs sm:text-sm text-vault-text-muted mt-0.5">{subtitle}</p>
         )}
       </div>
       {actions && (
-        <div className="flex items-center gap-2">{actions}</div>
+        <div className="flex w-full sm:w-auto items-center gap-2">{actions}</div>
       )}
     </div>
   );

--- a/src/components/shared/StatCard.tsx
+++ b/src/components/shared/StatCard.tsx
@@ -23,26 +23,26 @@ export function StatCard({ label, value, subValue, icon: Icon, accent = "default
   return (
     <div
       className={cn(
-        "bg-vault-surface border border-vault-border border-t-2 rounded-lg p-4 animate-slide-up",
+        "bg-vault-surface border border-vault-border border-t-2 rounded-lg p-3 sm:p-4 animate-slide-up",
         styles.border,
         className
       )}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-xs uppercase tracking-widest text-vault-text-faint font-medium mb-2">
+          <p className="text-[10px] sm:text-xs uppercase tracking-widest text-vault-text-faint font-medium mb-1.5 sm:mb-2">
             {label}
           </p>
-          <p className={cn("text-2xl font-bold font-mono tabular-nums", styles.value)}>
+          <p className={cn("text-xl sm:text-2xl font-bold font-mono tabular-nums", styles.value)}>
             {value}
           </p>
           {subValue && (
-            <p className="text-xs text-vault-text-muted mt-1">{subValue}</p>
+            <p className="text-[11px] sm:text-xs text-vault-text-muted mt-1">{subValue}</p>
           )}
         </div>
         {Icon && (
           <div className={cn("p-2 rounded-md shrink-0", styles.icon)}>
-            <Icon className="w-5 h-5" />
+            <Icon className="w-4 h-4 sm:w-5 sm:h-5" />
           </div>
         )}
       </div>


### PR DESCRIPTION
### Motivation
- Make the app feel better on small screens by improving header behavior, touch targets, and card/layout density so the dashboard is more usable on phones and small tablets.
- Prevent horizontal overflow and respect safe-area insets for devices with notches and to reduce accidental taps from mobile chrome UI.

### Description
- Make the mobile top bar sticky with a light frosted backdrop, larger tappable menu button, and a compact/truncating brand block for small widths (`src/components/layout/MobileHeader.tsx`).
- Update page header layout to stack title, subtitle, and actions on small screens and reduce/title/subtitle type sizes for better hierarchy (`src/components/shared/PageHeader.tsx`).
- Tune `StatCard` spacing and typography (smaller padding, responsive value/icon sizes, tightened label rhythm) for improved density on mobile (`src/components/shared/StatCard.tsx`).
- Switch the dashboard stat widget grid to `grid-cols-1` on very small screens and `sm:grid-cols-2` on small devices (keeping `xl:grid-cols-4`) and add global CSS safeguards for `overflow-x`, tap highlight, and safe-area insets (`src/components/dashboard/DashboardClient.tsx`, `src/app/globals.css`).

### Testing
- Ran unit tests with `npm test`, and all test suites passed (`3 files, 49 tests` reported passing).
- Ran linters with `npm run lint`, which reported existing repo-wide lint errors unrelated to these UI polish changes (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e7f6b80c83268ed813a38a08e94b)