### PR TITLE
Allow users to set accessory battery last-changed date manually

### DIFF
--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -110,6 +110,7 @@ export default function AccessoryDetailPage() {
   // Battery tracking
   const [showBatterySettings, setShowBatterySettings] = useState(false);
   const [batteryForm, setBatteryForm] = useState({ hasBattery: false, batteryType: "", batteryIntervalDays: "" });
+  const [batteryChangedAtInput, setBatteryChangedAtInput] = useState("");
   const [savingBattery, setSavingBattery] = useState(false);
   const [loggingBatteryChange, setLoggingBatteryChange] = useState(false);
   const [batteryError, setBatteryError] = useState<string | null>(null);
@@ -124,6 +125,7 @@ export default function AccessoryDetailPage() {
           setAccessory(data);
           setLocalImageUrl(data.imageUrl ?? null);
           setBatteryForm({ hasBattery: data.hasBattery ?? false, batteryType: data.batteryType ?? "", batteryIntervalDays: data.batteryIntervalDays?.toString() ?? "" });
+          setBatteryChangedAtInput(data.batteryChangedAt ? new Date(data.batteryChangedAt).toISOString().slice(0, 10) : "");
         }
         setLoading(false);
       })
@@ -201,10 +203,15 @@ export default function AccessoryDetailPage() {
     setBatteryError(null);
     setLoggingBatteryChange(true);
     try {
-      const res = await fetch(`/api/accessories/${id}/battery`, { method: "POST" });
+      const res = await fetch(`/api/accessories/${id}/battery`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ changedAt: batteryChangedAtInput || undefined }),
+      });
       if (res.ok) {
         const updated = await res.json();
         setAccessory((prev) => prev ? { ...prev, batteryChangedAt: updated.batteryChangedAt } : prev);
+        setBatteryChangedAtInput(updated.batteryChangedAt ? new Date(updated.batteryChangedAt).toISOString().slice(0, 10) : "");
       } else {
         const json = await res.json().catch(() => ({}));
         setBatteryError(json.error ?? "Failed to log battery change.");
@@ -703,9 +710,18 @@ export default function AccessoryDetailPage() {
                   </div>
                 );
               })()}
+              <div>
+                <label className="text-[10px] uppercase text-vault-text-faint block mb-1">Last Changed Date</label>
+                <input
+                  type="date"
+                  value={batteryChangedAtInput}
+                  onChange={(e) => setBatteryChangedAtInput(e.target.value)}
+                  className="w-full bg-vault-bg border border-vault-border rounded px-2 py-1.5 text-sm text-vault-text"
+                />
+              </div>
               <button onClick={handleLogBatteryChange} disabled={loggingBatteryChange} className="w-full flex items-center justify-center gap-1.5 text-xs bg-[#00C853]/10 border border-[#00C853]/30 text-[#00C853] hover:bg-[#00C853]/20 px-3 py-2 rounded transition-colors disabled:opacity-50">
                 {loggingBatteryChange ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
-                Log Battery Change
+                Save Last Changed Date
               </button>
             </div>
           ) : null}

--- a/src/app/api/accessories/[id]/battery/route.ts
+++ b/src/app/api/accessories/[id]/battery/route.ts
@@ -2,8 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
 // POST /api/accessories/[id]/battery - Log a battery change
-export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+
+  let changedAt = new Date();
+  try {
+    const body = await req.json();
+    if (body?.changedAt) {
+      const parsed = new Date(body.changedAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json({ error: "Invalid changedAt date" }, { status: 400 });
+      }
+      changedAt = parsed;
+    }
+  } catch {
+    // Empty body is valid and defaults to now.
+  }
 
   const accessory = await prisma.accessory.findUnique({ where: { id } });
   if (!accessory) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -11,7 +25,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
 
   const updated = await prisma.accessory.update({
     where: { id },
-    data: { batteryChangedAt: new Date() },
+    data: { batteryChangedAt: changedAt },
   });
 
   return NextResponse.json(updated);


### PR DESCRIPTION
### Motivation
- Users need the ability to retroactively set the battery "last changed" date when they first enable battery tracking so recorded schedules are accurate.
- The existing flow always recorded the change time as "now", which prevents importing or backfilling historical battery events.

### Description
- API: `POST /api/accessories/[id]/battery` now accepts an optional `changedAt` timestamp in the request body, validates it, and uses it when updating `batteryChangedAt`, defaulting to the current time when absent. (file: `src/app/api/accessories/[id]/battery/route.ts`)
- UI: added `batteryChangedAtInput` state and a date input to the accessory battery panel, initialized from the accessory data on load and updated after save. (file: `src/app/accessories/[id]/page.tsx`)
- UI → API: the battery save action now sends the selected date (`changedAt`) in the POST body and synchronizes the input with the returned server value.
- Backwards compatibility: empty/missing request bodies still behave like the previous implementation by defaulting to `new Date()`.

### Testing
- Ran `npx eslint src/app/accessories/[id]/page.tsx src/app/api/accessories/[id]/battery/route.ts` which passed for the changed files. 
- Ran unit tests with `npm test` which completed successfully (3 test files, 49 tests passed).
- Ran full lint via `npm run lint` which failed due to pre-existing unrelated lint issues in other files and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e843d1c88326baac7833874033fb)