### PR TITLE
Batch builds fetching for vault edit-mode; targeted refresh on build delete

### DIFF
--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -1,32 +1,69 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
-// GET /api/builds - List all builds, optional ?firearmId= filter
+// GET /api/builds - List all builds, optional ?firearmId= filter and batched ?firearmIds=id1,id2
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const firearmId = searchParams.get("firearmId");
+    const firearmIdsParam = searchParams.get("firearmIds");
+    const firearmIds = firearmIdsParam
+      ?.split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+
+    const where = firearmIds?.length
+      ? { firearmId: { in: firearmIds } }
+      : firearmId
+        ? { firearmId }
+        : undefined;
+
+    const isBatchedFilter = Boolean(firearmIds?.length);
 
     const builds = await prisma.build.findMany({
-      where: firearmId ? { firearmId } : undefined,
-      include: {
-        firearm: {
-          select: {
-            id: true,
-            name: true,
-            manufacturer: true,
-            model: true,
-            type: true,
-            caliber: true,
-            imageUrl: true,
-          },
-        },
-        slots: {
-          include: {
-            accessory: true,
-          },
-        },
-      },
+      where,
+      ...(isBatchedFilter
+        ? {
+            select: {
+              id: true,
+              firearmId: true,
+              name: true,
+              isActive: true,
+              sortOrder: true,
+              slots: {
+                select: {
+                  id: true,
+                  slotType: true,
+                  accessory: {
+                    select: {
+                      id: true,
+                      name: true,
+                    },
+                  },
+                },
+              },
+            },
+          }
+        : {
+            include: {
+              firearm: {
+                select: {
+                  id: true,
+                  name: true,
+                  manufacturer: true,
+                  model: true,
+                  type: true,
+                  caliber: true,
+                  imageUrl: true,
+                },
+              },
+              slots: {
+                include: {
+                  accessory: true,
+                },
+              },
+            },
+          }),
       orderBy: [{ isActive: "desc" }, { updatedAt: "desc" }],
     });
 

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -73,6 +73,10 @@ interface Build {
   slots: { id: string; slotType: string; accessory: { id: string; name: string } | null }[];
 }
 
+interface BatchedBuild extends Build {
+  firearmId: string;
+}
+
 function FirearmTypeIcon({ type }: { type: string }) {
   switch (type) {
     case "PISTOL":
@@ -261,6 +265,38 @@ export default function VaultPage() {
   } | null>(null);
   const [deleting, setDeleting] = useState(false);
 
+  async function fetchBuildsForFirearms(firearmIds: string[]) {
+    if (firearmIds.length === 0) {
+      setBuildsByFirearm({});
+      return;
+    }
+
+    const data = await fetch(`/api/builds?firearmIds=${firearmIds.join(",")}`)
+      .then((r) => r.json())
+      .catch(() => []);
+
+    const map = firearmIds.reduce((acc, id) => {
+      acc[id] = [];
+      return acc;
+    }, {} as Record<string, Build[]>);
+
+    if (Array.isArray(data)) {
+      data.forEach((build) => {
+        const typedBuild = build as BatchedBuild;
+        if (!typedBuild.firearmId || !map[typedBuild.firearmId]) return;
+        map[typedBuild.firearmId].push({
+          id: typedBuild.id,
+          name: typedBuild.name,
+          isActive: typedBuild.isActive,
+          sortOrder: typedBuild.sortOrder,
+          slots: typedBuild.slots,
+        });
+      });
+    }
+
+    setBuildsByFirearm(map);
+  }
+
   useEffect(() => {
     fetch("/api/firearms")
       .then((r) => r.json())
@@ -273,17 +309,7 @@ export default function VaultPage() {
 
   useEffect(() => {
     if (!editMode) return;
-    Promise.all(
-      firearms.map(f =>
-        fetch(`/api/builds?firearmId=${f.id}`)
-          .then(r => r.json())
-          .then(data => ({ firearmId: f.id, builds: Array.isArray(data) ? data : [] }))
-      )
-    ).then(results => {
-      const map: Record<string, Build[]> = {};
-      results.forEach(r => { map[r.firearmId] = r.builds; });
-      setBuildsByFirearm(map);
-    });
+    fetchBuildsForFirearms(firearms.map((f) => f.id));
   }, [editMode, firearms]);
 
   function openDeleteModal(build: Build & { firearmId: string }, accessories: { id: string; name: string }[]) {
@@ -306,16 +332,19 @@ export default function VaultPage() {
         );
       }
 
-      // Refresh firearms list
-      const res = await fetch("/api/firearms");
-      const data = await res.json();
-      if (Array.isArray(data)) setFirearms(data);
+      // Refresh only the affected firearm card data
+      const firearmRes = await fetch(`/api/firearms/${deleteTarget.build.firearmId}`);
+      const firearmData = await firearmRes.json();
+      if (firearmRes.ok && firearmData?.id) {
+        setFirearms((prev) =>
+          prev.map((firearm) =>
+            firearm.id === firearmData.id ? ({ ...firearm, ...firearmData } as Firearm) : firearm
+          )
+        );
+      }
 
-      // Update buildsByFirearm state
-      const newBuilds = await fetch(`/api/builds?firearmId=${deleteTarget.build.firearmId}`)
-        .then(r => r.json())
-        .then(d => Array.isArray(d) ? d : []);
-      setBuildsByFirearm(prev => ({ ...prev, [deleteTarget.build.firearmId]: newBuilds }));
+      // Refresh only affected firearm builds in edit mode map
+      await fetchBuildsForFirearms([deleteTarget.build.firearmId]);
 
       setDeleteTarget(null);
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Reduce multiple per-firearm requests in vault edit-mode by requesting all needed builds in a single batched call to improve performance and simplify client logic.
- Return only fields required by the edit modal/build list for batched queries to minimize payload size.
- When a build is deleted, avoid reloading all firearms and builds by refreshing only the affected firearm and its builds.

### Description
- Added `?firearmIds=id1,id2,...` batched filter to `GET /api/builds` in `src/app/api/builds/route.ts` and make batched responses return a minimized payload (`id`, `firearmId`, `name`, `isActive`, `sortOrder`, `slots[id, slotType, accessory{id,name}]`).
- Replaced the per-firearm `Promise.all(fetch(/api/builds?firearmId=...))` pattern in `src/app/vault/page.tsx` with a single `fetchBuildsForFirearms` call that hits `/api/builds?firearmIds=...` and transforms the flat response into `Record<firearmId, Build[]>` client-side, preserving the `buildsByFirearm` shape used by the UI.
- Introduced a `BatchedBuild` type and the `fetchBuildsForFirearms` helper in `src/app/vault/page.tsx` and swapped the edit-mode effect to use the batched fetch.
- Updated deletion flow to refresh only `/api/firearms/:id` for the affected firearm and call `fetchBuildsForFirearms([id])` to update the builds map, while keeping the edit-mode build row rendering logic unchanged.

### Testing
- Ran linter: `npm run lint -- src/app/api/builds/route.ts src/app/vault/page.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ea2705f08326a97337d3f14ba7f3)