### PR TITLE
Fix theme provider initialization to avoid effect-driven state update

### DIFF
--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -22,23 +22,25 @@ function applyTheme(t: Theme) {
   }
 }
 
+function resolveInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "dark";
+  }
+
+  const stored = localStorage.getItem("vault-theme");
+  return stored === "light" ? "light" : "dark";
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setTheme] = useState<Theme>(resolveInitialTheme);
 
   useEffect(() => {
-    const stored = localStorage.getItem("vault-theme") as Theme | null;
-    const resolved: Theme = stored === "light" ? "light" : "dark";
-    setTheme(resolved);
-    applyTheme(resolved);
-  }, []);
+    localStorage.setItem("vault-theme", theme);
+    applyTheme(theme);
+  }, [theme]);
 
   function toggleTheme() {
-    setTheme((prev) => {
-      const next: Theme = prev === "dark" ? "light" : "dark";
-      localStorage.setItem("vault-theme", next);
-      applyTheme(next);
-      return next;
-    });
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
   }
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent synchronous `setState` inside mount effects in `ThemeProvider` which caused unnecessary extra renders and ESLint `react-hooks/set-state-in-effect` errors by ensuring the persisted theme is available at initialization.

### Description
- Replace mount-time `setTheme` with a lazy initializer `resolveInitialTheme()` that reads `localStorage`, centralize DOM and storage updates in a `useEffect` keyed on `[theme]`, and simplify `toggleTheme()` to only update React state (file: `src/components/layout/ThemeProvider.tsx`).

### Testing
- Ran `npm test` (all tests passed), ran `npx eslint src/components/layout/ThemeProvider.tsx` (no reported errors), and booted the dev server with `npm run dev` for visual verification (started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e926836883269214ac586240960e)