### PR TITLE
Use `next/image` for images in vault, accessories, dashboard and image picker

### DIFF
--- a/src/app/accessories/page.tsx
+++ b/src/app/accessories/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import { Plus, Crosshair, Shield, ExternalLink, Loader2, ChevronDown } from "lucide-react";
@@ -160,10 +161,9 @@ export default function AccessoriesPage() {
                     return (
                       <tr key={accessory.id} className="hover:bg-vault-surface-2 transition-colors group">
                         <td className="px-4 py-3">
-                          <div className="w-9 h-9 rounded bg-vault-bg border border-vault-border overflow-hidden flex items-center justify-center shrink-0">
+                          <div className="relative w-9 h-9 rounded bg-vault-bg border border-vault-border overflow-hidden flex items-center justify-center shrink-0">
                             {accessory.imageUrl ? (
-                              // eslint-disable-next-line @next/next/no-img-element
-                              <img src={accessory.imageUrl} alt={accessory.name} className="w-full h-full object-cover" />
+                              <Image src={accessory.imageUrl} alt={accessory.name} fill sizes="36px" loading="lazy" className="w-full h-full object-cover" />
                             ) : (
                               <Shield className="w-4 h-4 text-vault-text-faint" />
                             )}

--- a/src/app/vault/[id]/page.tsx
+++ b/src/app/vault/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import { SLOT_TYPE_LABELS } from "@/lib/types";
 import {
@@ -356,10 +357,12 @@ export default function FirearmDetailPage() {
         <div className="relative h-56 bg-vault-bg overflow-hidden">
           {localImageUrl ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 src={localImageUrl}
                 alt={firearm.name}
+                fill
+                sizes="100vw"
+                priority
                 className="w-full h-full object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-vault-bg via-vault-bg/60 to-transparent" />

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatCurrency, formatNumber } from "@/lib/utils";
 import {
@@ -110,10 +111,12 @@ function FirearmCard({ firearm, editMode, editBuilds, onDeleteBuild }: FirearmCa
       {/* Image / Placeholder */}
       <div className="h-40 bg-vault-bg relative overflow-hidden border-b border-vault-border">
         {firearm.imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <Image
             src={firearm.imageUrl}
             alt={firearm.name}
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            loading="lazy"
             className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
           />
         ) : (

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import {
   DndContext,
   closestCenter,
@@ -324,12 +325,14 @@ function RecentWidget({ firearms }: { firearms: RecentFirearm[] }) {
                 href={`/vault/${firearm.id}`}
                 className="flex items-center gap-3 px-4 py-3 hover:bg-vault-surface-2 transition-colors group"
               >
-                <div className="w-10 h-10 rounded bg-vault-border border border-vault-border overflow-hidden shrink-0 flex items-center justify-center">
+                <div className="relative w-10 h-10 rounded bg-vault-border border border-vault-border overflow-hidden shrink-0 flex items-center justify-center">
                   {firearm.imageUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
+                    <Image
                       src={firearm.imageUrl}
                       alt={firearm.name}
+                      fill
+                      sizes="40px"
+                      loading="lazy"
                       className="w-full h-full object-cover"
                     />
                   ) : (

--- a/src/components/shared/ImagePicker.tsx
+++ b/src/components/shared/ImagePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import Image from "next/image";
 import { Camera, Link, Loader2, X, AlertCircle, ChevronDown, ChevronUp } from "lucide-react";
 
 interface ImagePickerProps {
@@ -99,11 +100,13 @@ export default function ImagePicker({
       {/* Preview */}
       {preview ? (
         <div className="relative rounded-md overflow-hidden border border-vault-border bg-vault-bg">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <Image
             src={preview}
             alt="Preview"
-            className="w-full max-h-48 object-contain"
+            width={1200}
+            height={800}
+            loading="lazy"
+            className="w-full max-h-48 h-auto object-contain"
             onError={() => {
               setError("Could not load this image URL. Please check the link.");
             }}


### PR DESCRIPTION
### Motivation
- Improve image performance and avoid layout shift by replacing raw `<img>` tags with Next.js' `next/image` component where layout is known.
- Ensure consistent sizing for cards/thumbnails and allow responsive loading with `sizes` or explicit dimensions.
- Apply lazy loading for non-critical images and reserve `priority` for the above-the-fold hero to preserve perceived performance.

### Description
- Replaced raw image elements with `next/image` and added `import Image from "next/image"` in the following files: `src/app/vault/page.tsx`, `src/app/vault/[id]/page.tsx`, `src/app/accessories/page.tsx`, `src/components/dashboard/DashboardClient.tsx`, and `src/components/shared/ImagePicker.tsx`.
- Used `fill` + `sizes` inside fixed-size/relative wrappers for card thumbnails and the hero banner, and preserved fallback placeholders (icons / empty states) when `imageUrl` is missing.
- Set `loading="lazy"` for list/card/preview images and applied `priority` to the firearm detail hero image only; preserved existing `className` styling to keep layout parity.
- Ensured thumbnail wrappers are `relative` when using `fill`, and provided `width`/`height` on preview images to keep intrinsic sizing and avoid layout shift.

### Testing
- Ran lint with `npm run lint -- <files>` which completed but reported pre-existing `react-hooks/set-state-in-effect` errors in `src/app/accessories/page.tsx` and `src/components/dashboard/DashboardClient.tsx`; no new image-related lint errors were introduced (lint overall considered failing due to the pre-existing issues).
- Started the dev server (`next dev`) and verified the app boots; a UI snapshot of `/vault` was captured via Playwright to validate the visual result (artifact: `browser:/tmp/codex_browser_invocations/.../vault-page-image-next-image.png`).
- Confirmed no runtime errors were introduced by the `next/image` changes during the dev run aside from unrelated environment/database warnings from the local setup (e.g. missing `DATABASE_URL` for Prisma).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ea2902f08326930bb4109ba8b7bb)