### PR TITLE
Add list-query indexes for firearms, accessories, and builds

### DIFF
--- a/prisma/migrations/20260312163203_add_list_query_indexes/migration.sql
+++ b/prisma/migrations/20260312163203_add_list_query_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX "Accessory_createdAt_idx" ON "Accessory"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Accessory_type_createdAt_idx" ON "Accessory"("type", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Build_isActive_updatedAt_idx" ON "Build"("isActive", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Build_firearmId_isActive_updatedAt_idx" ON "Build"("firearmId", "isActive", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Firearm_createdAt_idx" ON "Firearm"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Firearm {
 
   @@index([caliber])
   @@index([type])
+  @@index([createdAt])
 }
 
 // ─── BUILDS ───────────────────────────────────────────────────
@@ -59,6 +60,8 @@ model Build {
 
   @@index([firearmId])
   @@index([isActive])
+  @@index([isActive, updatedAt])
+  @@index([firearmId, isActive, updatedAt])
 }
 
 model BuildSlot {
@@ -123,6 +126,8 @@ model Accessory {
 
   @@index([type])
   @@index([roundCount])
+  @@index([createdAt])
+  @@index([type, createdAt])
 }
 
 model RoundCountLog {


### PR DESCRIPTION
### Motivation
- Reduce full-table sorts and scan costs for high-frequency list endpoints that order or filter by timestamps and small cardinality flags.
- Target the API patterns used by `/api/firearms` (`createdAt desc`), `/api/accessories` (`createdAt desc` with optional `type`), and `/api/builds` (`isActive`, `updatedAt`, optional `firearmId`).

### Description
- Added `@@index([createdAt])` to the `Firearm` model to optimize `ORDER BY createdAt` patterns.
- Added `@@index([createdAt])` and `@@index([type, createdAt])` to the `Accessory` model to optimize sorted lists and filtered+sorted queries.
- Added `@@index([isActive, updatedAt])` and `@@index([firearmId, isActive, updatedAt])` to the `Build` model to optimize `isActive`/`updatedAt` sorting and `firearmId`-scoped lists.
- Generated a migration at `prisma/migrations/20260312163203_add_list_query_indexes/migration.sql` that creates the corresponding SQLite indexes.

### Testing
- Ran `npx prisma migrate dev --name add_list_query_indexes` to generate and apply the migration and the command completed successfully.
- Ran `npx prisma validate` and the schema was reported valid.
- Verified representative SQLite query plans with `EXPLAIN QUERY PLAN` and confirmed index usage for target queries: `Firearm ORDER BY createdAt DESC` used `Firearm_createdAt_idx`, `Accessory ORDER BY createdAt DESC` used `Accessory_createdAt_idx`, `Accessory WHERE type=? ORDER BY createdAt DESC` used `Accessory_type_createdAt_idx`, `Build WHERE firearmId=? ORDER BY isActive DESC, updatedAt DESC` used `Build_firearmId_isActive_updatedAt_idx`, and `Build ORDER BY isActive DESC, updatedAt DESC` used `Build_isActive_updatedAt_idx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ea3251808326bb005d8c7f2f511d)