### PR TITLE
Refactor dashboard aggregation into a shared cached server utility

### DIFF
--- a/src/app/api/accessories/[id]/battery/route.ts
+++ b/src/app/api/accessories/[id]/battery/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // POST /api/accessories/[id]/battery - Log a battery change
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -13,6 +14,8 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     where: { id },
     data: { batteryChangedAt: new Date() },
   });
+
+  revalidateDashboardCaches(["accessories"]);
 
   return NextResponse.json(updated);
 }

--- a/src/app/api/accessories/[id]/rounds/route.ts
+++ b/src/app/api/accessories/[id]/rounds/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // POST /api/accessories/[id]/rounds - Log round count for an accessory
 // Body: { rounds: number, note?: string }
@@ -55,6 +56,8 @@ export async function POST(
       }),
     ]);
 
+    revalidateDashboardCaches(["accessories"]);
+
     return NextResponse.json(
       {
         accessory: updatedAccessory,
@@ -64,6 +67,7 @@ export async function POST(
     );
   } catch (error) {
     console.error("POST /api/accessories/[id]/rounds error:", error);
+
     return NextResponse.json(
       { error: "Failed to log round count" },
       { status: 500 }

--- a/src/app/api/accessories/[id]/route.ts
+++ b/src/app/api/accessories/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/accessories/[id] - Get a single accessory with roundCountLogs and current buildSlots
 export async function GET(
@@ -62,6 +63,7 @@ export async function GET(
     });
   } catch (error) {
     console.error("GET /api/accessories/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to fetch accessory" },
       { status: 500 }
@@ -147,9 +149,12 @@ export async function PUT(
       },
     });
 
+    revalidateDashboardCaches(["accessories"]);
+
     return NextResponse.json(updated);
   } catch (error) {
     console.error("PUT /api/accessories/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to update accessory" },
       { status: 500 }
@@ -175,9 +180,12 @@ export async function DELETE(
 
     await prisma.accessory.delete({ where: { id } });
 
+    revalidateDashboardCaches(["accessories"]);
+
     return NextResponse.json({ success: true, id });
   } catch (error) {
     console.error("DELETE /api/accessories/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to delete accessory" },
       { status: 500 }

--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/accessories - List all accessories with current build name
 export async function GET(request: NextRequest) {
@@ -51,6 +52,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(result);
   } catch (error) {
     console.error("GET /api/accessories error:", error);
+
     return NextResponse.json(
       { error: "Failed to fetch accessories" },
       { status: 500 }
@@ -102,9 +104,12 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    revalidateDashboardCaches(["accessories"]);
+
     return NextResponse.json(accessory, { status: 201 });
   } catch (error) {
     console.error("POST /api/accessories error:", error);
+
     return NextResponse.json(
       { error: "Failed to create accessory" },
       { status: 500 }

--- a/src/app/api/ammo/[id]/route.ts
+++ b/src/app/api/ammo/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/ammo/[id] - Get a single AmmoStock entry
 export async function GET(
@@ -28,6 +29,7 @@ export async function GET(
     return NextResponse.json(stock);
   } catch (error) {
     console.error("GET /api/ammo/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to fetch ammo stock" },
       { status: 500 }
@@ -89,9 +91,12 @@ export async function PUT(
       },
     });
 
+    revalidateDashboardCaches(["ammo"]);
+
     return NextResponse.json(updated);
   } catch (error) {
     console.error("PUT /api/ammo/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to update ammo stock" },
       { status: 500 }
@@ -117,9 +122,12 @@ export async function DELETE(
 
     await prisma.ammoStock.delete({ where: { id } });
 
+    revalidateDashboardCaches(["ammo"]);
+
     return NextResponse.json({ success: true, id });
   } catch (error) {
     console.error("DELETE /api/ammo/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to delete ammo stock" },
       { status: 500 }

--- a/src/app/api/ammo/[id]/transactions/route.ts
+++ b/src/app/api/ammo/[id]/transactions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // Types that subtract from quantity
 const SUBTRACT_TYPES = new Set(["RANGE_USE", "TRANSFER_OUT", "EXPENDED"]);
@@ -100,6 +101,8 @@ export async function POST(
       }),
     ]);
 
+    revalidateDashboardCaches(["ammo", "range"]);
+
     return NextResponse.json(
       {
         stock: updatedStock,
@@ -109,6 +112,7 @@ export async function POST(
     );
   } catch (error) {
     console.error("POST /api/ammo/[id]/transactions error:", error);
+
     return NextResponse.json(
       { error: "Failed to create ammo transaction" },
       { status: 500 }

--- a/src/app/api/ammo/route.ts
+++ b/src/app/api/ammo/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/ammo - List all AmmoStock grouped by caliber
 export async function GET() {
@@ -49,6 +50,7 @@ export async function GET() {
     return NextResponse.json(result);
   } catch (error) {
     console.error("GET /api/ammo error:", error);
+
     return NextResponse.json(
       { error: "Failed to fetch ammo stock" },
       { status: 500 }
@@ -101,9 +103,12 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    revalidateDashboardCaches(["ammo"]);
+
     return NextResponse.json(stock, { status: 201 });
   } catch (error) {
     console.error("POST /api/ammo error:", error);
+
     return NextResponse.json(
       { error: "Failed to create ammo stock" },
       { status: 500 }

--- a/src/app/api/firearms/[id]/route.ts
+++ b/src/app/api/firearms/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/firearms/[id] - Get a single firearm with active build, slots, and accessories
 export async function GET(
@@ -45,6 +46,7 @@ export async function GET(
     });
   } catch (error) {
     console.error("GET /api/firearms/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to fetch firearm" },
       { status: 500 }
@@ -117,6 +119,8 @@ export async function PUT(
       },
     });
 
+    revalidateDashboardCaches(["firearms"]);
+
     return NextResponse.json({
       ...updated,
       buildCount: updated._count.builds,
@@ -136,6 +140,7 @@ export async function PUT(
         { status: 409 }
       );
     }
+
     return NextResponse.json(
       { error: "Failed to update firearm" },
       { status: 500 }
@@ -158,9 +163,12 @@ export async function DELETE(
 
     await prisma.firearm.delete({ where: { id } });
 
+    revalidateDashboardCaches(["firearms"]);
+
     return NextResponse.json({ success: true, id });
   } catch (error) {
     console.error("DELETE /api/firearms/[id] error:", error);
+
     return NextResponse.json(
       { error: "Failed to delete firearm" },
       { status: 500 }

--- a/src/app/api/firearms/route.ts
+++ b/src/app/api/firearms/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/firearms - List all firearms with build count
 export async function GET() {
@@ -97,6 +98,8 @@ export async function POST(request: NextRequest) {
         },
       },
     });
+
+    revalidateDashboardCaches(["firearms"]);
 
     return NextResponse.json(
       { ...firearm, buildCount: firearm._count.builds, _count: undefined },

--- a/src/app/api/range-sessions/[id]/route.ts
+++ b/src/app/api/range-sessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/range-sessions/[id]
 export async function GET(
@@ -131,6 +132,8 @@ export async function PUT(
       return updated;
     });
 
+    revalidateDashboardCaches(["range", "ammo"]);
+
     return NextResponse.json(session);
   } catch (error) {
     console.error("PUT /api/range-sessions/[id] error:", error);
@@ -146,6 +149,9 @@ export async function DELETE(
   try {
     const { id } = await params;
     await prisma.rangeSession.delete({ where: { id } });
+
+    revalidateDashboardCaches(["range", "ammo"]);
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("DELETE /api/range-sessions/[id] error:", error);

--- a/src/app/api/range-sessions/route.ts
+++ b/src/app/api/range-sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
 // GET /api/range-sessions - List range sessions, optional ?firearmId= filter, ?include=analytics
 export async function GET(request: NextRequest) {
@@ -131,6 +132,8 @@ export async function POST(request: NextRequest) {
 
       return created;
     });
+
+    revalidateDashboardCaches(["range", "ammo"]);
 
     return NextResponse.json(session, { status: 201 });
   } catch (error) {

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,210 +1,32 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { getDashboardAggregates } from "@/lib/server/dashboard";
 
 // GET /api/stats - Dashboard stats
 // Returns: total firearms, total accessories, total ammo by caliber,
 //          total investment value, recent items
 export async function GET() {
   try {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
-    const [
-      firearmCount,
-      accessoryCount,
-      ammoStocks,
-      firearms,
-      accessories,
-      recentFirearms,
-      recentAccessories,
-      recentAmmo,
-      rangeSessionAggregate,
-      rangeSessionsLast30,
-      lastRangeSession,
-    ] = await Promise.all([
-      // Total firearms
-      prisma.firearm.count(),
-
-      // Total accessories
-      prisma.accessory.count(),
-
-      // All ammo stocks (to compute totals by caliber and investment)
-      prisma.ammoStock.findMany({
-        select: {
-          id: true,
-          caliber: true,
-          brand: true,
-          quantity: true,
-          purchasePrice: true,
-          lowStockAlert: true,
-          grainWeight: true,
-          bulletType: true,
-        },
-      }),
-
-      // All firearms for investment calculations
-      prisma.firearm.findMany({
-        select: {
-          id: true,
-          purchasePrice: true,
-          currentValue: true,
-        },
-      }),
-
-      // All accessories for investment calculations
-      prisma.accessory.findMany({
-        select: {
-          id: true,
-          purchasePrice: true,
-        },
-      }),
-
-      // Recently added firearms
-      prisma.firearm.findMany({
-        take: 5,
-        orderBy: { createdAt: "desc" },
-        select: {
-          id: true,
-          name: true,
-          manufacturer: true,
-          model: true,
-          type: true,
-          caliber: true,
-          imageUrl: true,
-          createdAt: true,
-        },
-      }),
-
-      // Recently added accessories
-      prisma.accessory.findMany({
-        take: 5,
-        orderBy: { createdAt: "desc" },
-        select: {
-          id: true,
-          name: true,
-          manufacturer: true,
-          type: true,
-          imageUrl: true,
-          createdAt: true,
-        },
-      }),
-
-      // Recently updated ammo stocks
-      prisma.ammoStock.findMany({
-        take: 5,
-        orderBy: { updatedAt: "desc" },
-        select: {
-          id: true,
-          caliber: true,
-          brand: true,
-          quantity: true,
-          updatedAt: true,
-        },
-      }),
-
-      // Range session totals
-      prisma.rangeSession.aggregate({
-        _sum: { roundsFired: true },
-        _count: { id: true },
-      }),
-
-      // Sessions in last 30 days
-      prisma.rangeSession.count({
-        where: { date: { gte: thirtyDaysAgo } },
-      }),
-
-      // Most recent session
-      prisma.rangeSession.findFirst({
-        orderBy: { date: "desc" },
-        select: {
-          id: true,
-          date: true,
-          rangeName: true,
-          roundsFired: true,
-          firearm: { select: { name: true } },
-        },
-      }),
-    ]);
-
-    // Aggregate ammo by caliber
-    const ammoByCaliber: Record<
-      string,
-      { caliber: string; totalRounds: number; stockCount: number; lowStock: boolean }
-    > = {};
-
-    let totalAmmoRounds = 0;
-
-    for (const stock of ammoStocks) {
-      totalAmmoRounds += stock.quantity;
-
-      if (!ammoByCaliber[stock.caliber]) {
-        ammoByCaliber[stock.caliber] = {
-          caliber: stock.caliber,
-          totalRounds: 0,
-          stockCount: 0,
-          lowStock: false,
-        };
-      }
-      ammoByCaliber[stock.caliber].totalRounds += stock.quantity;
-      ammoByCaliber[stock.caliber].stockCount += 1;
-
-      // Flag as low stock if quantity falls at or below the alert threshold
-      if (
-        stock.lowStockAlert !== null &&
-        stock.lowStockAlert !== undefined &&
-        stock.quantity <= stock.lowStockAlert
-      ) {
-        ammoByCaliber[stock.caliber].lowStock = true;
-      }
-    }
-
-    // Investment calculations
-    const totalFirearmInvestment = firearms.reduce(
-      (sum, f) => sum + (f.purchasePrice ?? 0),
-      0
-    );
-    const totalFirearmCurrentValue = firearms.reduce(
-      (sum, f) => sum + (f.currentValue ?? f.purchasePrice ?? 0),
-      0
-    );
-    const totalAccessoryInvestment = accessories.reduce(
-      (sum, a) => sum + (a.purchasePrice ?? 0),
-      0
-    );
-    const totalInvestment =
-      totalFirearmInvestment + totalAccessoryInvestment;
-    const totalCurrentValue =
-      totalFirearmCurrentValue + totalAccessoryInvestment;
-    const unrealizedGainLoss = totalCurrentValue - totalInvestment;
-
-    // Low stock alerts
-    const lowStockItems = ammoStocks.filter(
-      (s) =>
-        s.lowStockAlert !== null &&
-        s.lowStockAlert !== undefined &&
-        s.quantity <= s.lowStockAlert
-    );
+    const data = await getDashboardAggregates();
 
     return NextResponse.json({
       totals: {
-        firearms: firearmCount,
-        accessories: accessoryCount,
-        ammoRounds: totalAmmoRounds,
-        ammoStocks: ammoStocks.length,
+        firearms: data.firearmCount,
+        accessories: data.accessoryCount,
+        ammoRounds: data.totalAmmoRounds,
+        ammoStocks: data.ammoStocks.length,
       },
       investment: {
-        totalCost: totalInvestment,
-        totalCurrentValue,
-        unrealizedGainLoss,
-        firearmCost: totalFirearmInvestment,
-        firearmCurrentValue: totalFirearmCurrentValue,
-        accessoryCost: totalAccessoryInvestment,
+        totalCost: data.totalInvestment,
+        totalCurrentValue: data.totalCurrentValue,
+        unrealizedGainLoss: data.unrealizedGainLoss,
+        firearmCost: data.totalFirearmInvestment,
+        firearmCurrentValue: data.totalFirearmCurrentValue,
+        accessoryCost: data.totalAccessoryInvestment,
       },
       ammo: {
-        byCaliber: Object.values(ammoByCaliber).sort((a, b) =>
-          a.caliber.localeCompare(b.caliber)
-        ),
-        lowStockCount: lowStockItems.length,
-        lowStockItems: lowStockItems.map((s) => ({
+        byCaliber: data.ammoByCaliber,
+        lowStockCount: data.lowStockItems.length,
+        lowStockItems: data.lowStockItems.map((s) => ({
           id: s.id,
           caliber: s.caliber,
           brand: s.brand,
@@ -213,30 +35,14 @@ export async function GET() {
         })),
       },
       recent: {
-        firearms: recentFirearms,
-        accessories: recentAccessories,
-        ammo: recentAmmo,
+        firearms: data.recentFirearms,
+        accessories: data.recentAccessories,
+        ammo: data.recentAmmo,
       },
-      rangeSessions: {
-        count: rangeSessionAggregate._count.id,
-        totalRounds: rangeSessionAggregate._sum.roundsFired ?? 0,
-        sessionsLast30Days: rangeSessionsLast30,
-        lastSession: lastRangeSession
-          ? {
-              id: lastRangeSession.id,
-              date: lastRangeSession.date,
-              rangeName: lastRangeSession.rangeName,
-              roundsFired: lastRangeSession.roundsFired,
-              firearmName: lastRangeSession.firearm.name,
-            }
-          : null,
-      },
+      rangeSessions: data.rangeStats,
     });
   } catch (error) {
     console.error("GET /api/stats error:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch stats" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,188 +1,20 @@
-import { prisma } from "@/lib/prisma";
+import { getDashboardAggregates } from "@/lib/server/dashboard";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { DashboardClient } from "@/components/dashboard/DashboardClient";
 
 async function getDashboardData() {
-  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
-  const [
-    firearmCount,
-    accessoryCount,
-    ammoStocks,
-    firearms,
-    accessories,
-    recentFirearms,
-    rangeSessionAggregate,
-    rangeSessionsLast30,
-    lastRangeSession,
-    maintenanceSchedulesRaw,
-    batteriesTracked,
-    roundsPerFirearmRaw,
-  ] = await Promise.all([
-    prisma.firearm.count(),
-    prisma.accessory.count(),
-    prisma.ammoStock.findMany({
-      select: {
-        id: true,
-        caliber: true,
-        brand: true,
-        quantity: true,
-        purchasePrice: true,
-        lowStockAlert: true,
-        grainWeight: true,
-        bulletType: true,
-      },
-    }),
-    prisma.firearm.findMany({
-      select: { id: true, purchasePrice: true, currentValue: true },
-    }),
-    prisma.accessory.findMany({
-      select: { id: true, purchasePrice: true },
-    }),
-    prisma.firearm.findMany({
-      take: 5,
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        name: true,
-        manufacturer: true,
-        model: true,
-        type: true,
-        caliber: true,
-        imageUrl: true,
-        acquisitionDate: true,
-        createdAt: true,
-      },
-    }),
-    prisma.rangeSession.aggregate({
-      _sum: { roundsFired: true },
-      _count: { id: true },
-    }),
-    prisma.rangeSession.count({
-      where: { date: { gte: thirtyDaysAgo } },
-    }),
-    prisma.rangeSession.findFirst({
-      orderBy: { date: "desc" },
-      select: {
-        id: true,
-        date: true,
-        rangeName: true,
-        roundsFired: true,
-        firearm: { select: { name: true } },
-      },
-    }),
-    prisma.maintenanceSchedule.findMany({
-      include: { firearm: { select: { id: true, name: true } } },
-      orderBy: { createdAt: "asc" },
-    }),
-    prisma.accessory.findMany({
-      where: { hasBattery: true, batteryIntervalDays: { not: null } },
-      select: { id: true, name: true, batteryChangedAt: true, batteryIntervalDays: true },
-    }),
-    prisma.rangeSession.groupBy({
-      by: ["firearmId"],
-      _sum: { roundsFired: true },
-    }),
-  ]);
-
-  const totalAmmoRounds = ammoStocks.reduce((sum, s) => sum + s.quantity, 0);
-  const totalFirearmInvestment = firearms.reduce((sum, f) => sum + (f.purchasePrice ?? 0), 0);
-  const totalAccessoryInvestment = accessories.reduce((sum, a) => sum + (a.purchasePrice ?? 0), 0);
-  const totalInvestment = totalFirearmInvestment + totalAccessoryInvestment;
-
-  const lowStockItems = ammoStocks.filter(
-    (s) => s.lowStockAlert != null && s.quantity <= s.lowStockAlert
-  );
-
-  // Build a map of firearmId -> total rounds
-  const roundsByFirearm = new Map<string, number>();
-  for (const row of roundsPerFirearmRaw) {
-    roundsByFirearm.set(row.firearmId, row._sum.roundsFired ?? 0);
-  }
-
-  // Compute due info for each maintenance schedule
-  const now = Date.now();
-  const maintenanceDue = [
-    ...maintenanceSchedulesRaw.map((s) => {
-      let daysUntilDue: number | null = null;
-      let roundsUntilDue: number | null = null;
-      let overdue = false;
-      if (s.intervalType === "ROUNDS") {
-        const currentRounds = roundsByFirearm.get(s.firearmId) ?? 0;
-        const base = s.lastRoundCount ?? 0;
-        const remaining = base + s.intervalValue - currentRounds;
-        roundsUntilDue = remaining;
-        overdue = remaining <= 0;
-      } else {
-        const base = s.lastCompletedAt ? new Date(s.lastCompletedAt) : new Date(s.createdAt);
-        const nextDueMs = base.getTime() + s.intervalValue * 86400000;
-        daysUntilDue = Math.ceil((nextDueMs - now) / 86400000);
-        overdue = daysUntilDue <= 0;
-      }
-      return {
-        id: s.id,
-        type: "schedule" as const,
-        name: s.taskName,
-        entityName: s.firearm.name,
-        entityId: s.firearmId,
-        entityHref: `/vault/${s.firearmId}`,
-        intervalType: s.intervalType as "ROUNDS" | "DAYS",
-        daysUntilDue,
-        roundsUntilDue,
-        overdue,
-      };
-    }),
-    ...batteriesTracked.map((a) => {
-      const base = a.batteryChangedAt ? new Date(a.batteryChangedAt) : null;
-      const daysUntilDue = base && a.batteryIntervalDays
-        ? Math.ceil((base.getTime() + a.batteryIntervalDays * 86400000 - now) / 86400000)
-        : null;
-      return {
-        id: `battery-${a.id}`,
-        type: "battery" as const,
-        name: "Battery Change",
-        entityName: a.name,
-        entityId: a.id,
-        entityHref: `/accessories/${a.id}`,
-        intervalType: "DAYS" as const,
-        daysUntilDue,
-        roundsUntilDue: null,
-        overdue: daysUntilDue != null ? daysUntilDue <= 0 : false,
-      };
-    }),
-  ]
-    .filter((item) => item.overdue || (item.daysUntilDue != null && item.daysUntilDue <= 60) || (item.roundsUntilDue != null && item.roundsUntilDue <= 500))
-    .sort((a, b) => {
-      if (a.overdue && !b.overdue) return -1;
-      if (!a.overdue && b.overdue) return 1;
-      const aVal = a.daysUntilDue ?? (a.roundsUntilDue ?? 0);
-      const bVal = b.daysUntilDue ?? (b.roundsUntilDue ?? 0);
-      return aVal - bVal;
-    });
+  const data = await getDashboardAggregates();
 
   return {
-    firearmCount,
-    accessoryCount,
-    totalAmmoRounds,
-    totalInvestment,
-    lowStockItems,
-    recentFirearms,
-    ammoStocks,
-    maintenanceDue,
-    rangeStats: {
-      count: rangeSessionAggregate._count.id,
-      totalRounds: rangeSessionAggregate._sum.roundsFired ?? 0,
-      sessionsLast30Days: rangeSessionsLast30,
-      lastSession: lastRangeSession
-        ? {
-            id: lastRangeSession.id,
-            date: lastRangeSession.date,
-            rangeName: lastRangeSession.rangeName,
-            roundsFired: lastRangeSession.roundsFired,
-            firearmName: lastRangeSession.firearm.name,
-          }
-        : null,
-    },
+    firearmCount: data.firearmCount,
+    accessoryCount: data.accessoryCount,
+    totalAmmoRounds: data.totalAmmoRounds,
+    totalInvestment: data.totalInvestment,
+    lowStockItems: data.lowStockItems,
+    recentFirearms: data.recentFirearms,
+    ammoStocks: data.ammoStocks,
+    maintenanceDue: data.maintenanceDue,
+    rangeStats: data.rangeStats,
   };
 }
 

--- a/src/lib/server/dashboard.ts
+++ b/src/lib/server/dashboard.ts
@@ -1,0 +1,283 @@
+import { revalidateTag, unstable_cache } from "next/cache";
+import { prisma } from "@/lib/prisma";
+
+export const DASHBOARD_CACHE_TAGS = {
+  all: "dashboard:all",
+  firearms: "dashboard:firearms",
+  accessories: "dashboard:accessories",
+  ammo: "dashboard:ammo",
+  range: "dashboard:range",
+} as const;
+
+export const DASHBOARD_MUTATION_TAGS = [
+  DASHBOARD_CACHE_TAGS.all,
+  DASHBOARD_CACHE_TAGS.firearms,
+  DASHBOARD_CACHE_TAGS.accessories,
+  DASHBOARD_CACHE_TAGS.ammo,
+  DASHBOARD_CACHE_TAGS.range,
+] as const;
+
+async function getDashboardAggregatesUncached() {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const [
+    firearmCount,
+    accessoryCount,
+    ammoStocks,
+    firearms,
+    accessories,
+    recentFirearms,
+    recentAccessories,
+    recentAmmo,
+    rangeSessionAggregate,
+    rangeSessionsLast30,
+    lastRangeSession,
+    maintenanceSchedulesRaw,
+    batteriesTracked,
+    roundsPerFirearmRaw,
+  ] = await Promise.all([
+    prisma.firearm.count(),
+    prisma.accessory.count(),
+    prisma.ammoStock.findMany({
+      select: {
+        id: true,
+        caliber: true,
+        brand: true,
+        quantity: true,
+        purchasePrice: true,
+        lowStockAlert: true,
+        grainWeight: true,
+        bulletType: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.firearm.findMany({
+      select: { id: true, purchasePrice: true, currentValue: true },
+    }),
+    prisma.accessory.findMany({
+      select: { id: true, purchasePrice: true },
+    }),
+    prisma.firearm.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        manufacturer: true,
+        model: true,
+        type: true,
+        caliber: true,
+        imageUrl: true,
+        acquisitionDate: true,
+        createdAt: true,
+      },
+    }),
+    prisma.accessory.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        manufacturer: true,
+        type: true,
+        imageUrl: true,
+        createdAt: true,
+      },
+    }),
+    prisma.ammoStock.findMany({
+      take: 5,
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        caliber: true,
+        brand: true,
+        quantity: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.rangeSession.aggregate({
+      _sum: { roundsFired: true },
+      _count: { id: true },
+    }),
+    prisma.rangeSession.count({
+      where: { date: { gte: thirtyDaysAgo } },
+    }),
+    prisma.rangeSession.findFirst({
+      orderBy: { date: "desc" },
+      select: {
+        id: true,
+        date: true,
+        rangeName: true,
+        roundsFired: true,
+        firearm: { select: { name: true } },
+      },
+    }),
+    prisma.maintenanceSchedule.findMany({
+      include: { firearm: { select: { id: true, name: true } } },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.accessory.findMany({
+      where: { hasBattery: true, batteryIntervalDays: { not: null } },
+      select: { id: true, name: true, batteryChangedAt: true, batteryIntervalDays: true },
+    }),
+    prisma.rangeSession.groupBy({
+      by: ["firearmId"],
+      _sum: { roundsFired: true },
+    }),
+  ]);
+
+  const ammoByCaliber: Record<
+    string,
+    { caliber: string; totalRounds: number; stockCount: number; lowStock: boolean }
+  > = {};
+
+  let totalAmmoRounds = 0;
+  for (const stock of ammoStocks) {
+    totalAmmoRounds += stock.quantity;
+    if (!ammoByCaliber[stock.caliber]) {
+      ammoByCaliber[stock.caliber] = {
+        caliber: stock.caliber,
+        totalRounds: 0,
+        stockCount: 0,
+        lowStock: false,
+      };
+    }
+    ammoByCaliber[stock.caliber].totalRounds += stock.quantity;
+    ammoByCaliber[stock.caliber].stockCount += 1;
+    if (stock.lowStockAlert != null && stock.quantity <= stock.lowStockAlert) {
+      ammoByCaliber[stock.caliber].lowStock = true;
+    }
+  }
+
+  const totalFirearmInvestment = firearms.reduce((sum, f) => sum + (f.purchasePrice ?? 0), 0);
+  const totalFirearmCurrentValue = firearms.reduce(
+    (sum, f) => sum + (f.currentValue ?? f.purchasePrice ?? 0),
+    0
+  );
+  const totalAccessoryInvestment = accessories.reduce((sum, a) => sum + (a.purchasePrice ?? 0), 0);
+  const totalInvestment = totalFirearmInvestment + totalAccessoryInvestment;
+  const totalCurrentValue = totalFirearmCurrentValue + totalAccessoryInvestment;
+  const unrealizedGainLoss = totalCurrentValue - totalInvestment;
+
+  const lowStockItems = ammoStocks.filter(
+    (s) => s.lowStockAlert != null && s.quantity <= s.lowStockAlert
+  );
+
+  const roundsByFirearm = new Map<string, number>();
+  for (const row of roundsPerFirearmRaw) {
+    roundsByFirearm.set(row.firearmId, row._sum.roundsFired ?? 0);
+  }
+
+  const now = Date.now();
+  const maintenanceDue = [
+    ...maintenanceSchedulesRaw.map((s) => {
+      let daysUntilDue: number | null = null;
+      let roundsUntilDue: number | null = null;
+      let overdue = false;
+      if (s.intervalType === "ROUNDS") {
+        const currentRounds = roundsByFirearm.get(s.firearmId) ?? 0;
+        const base = s.lastRoundCount ?? 0;
+        const remaining = base + s.intervalValue - currentRounds;
+        roundsUntilDue = remaining;
+        overdue = remaining <= 0;
+      } else {
+        const base = s.lastCompletedAt ? new Date(s.lastCompletedAt) : new Date(s.createdAt);
+        const nextDueMs = base.getTime() + s.intervalValue * 86400000;
+        daysUntilDue = Math.ceil((nextDueMs - now) / 86400000);
+        overdue = daysUntilDue <= 0;
+      }
+      return {
+        id: s.id,
+        type: "schedule" as const,
+        name: s.taskName,
+        entityName: s.firearm.name,
+        entityId: s.firearmId,
+        entityHref: `/vault/${s.firearmId}`,
+        intervalType: s.intervalType as "ROUNDS" | "DAYS",
+        daysUntilDue,
+        roundsUntilDue,
+        overdue,
+      };
+    }),
+    ...batteriesTracked.map((a) => {
+      const base = a.batteryChangedAt ? new Date(a.batteryChangedAt) : null;
+      const daysUntilDue =
+        base && a.batteryIntervalDays
+          ? Math.ceil((base.getTime() + a.batteryIntervalDays * 86400000 - now) / 86400000)
+          : null;
+      return {
+        id: `battery-${a.id}`,
+        type: "battery" as const,
+        name: "Battery Change",
+        entityName: a.name,
+        entityId: a.id,
+        entityHref: `/accessories/${a.id}`,
+        intervalType: "DAYS" as const,
+        daysUntilDue,
+        roundsUntilDue: null,
+        overdue: daysUntilDue != null ? daysUntilDue <= 0 : false,
+      };
+    }),
+  ]
+    .filter(
+      (item) =>
+        item.overdue ||
+        (item.daysUntilDue != null && item.daysUntilDue <= 60) ||
+        (item.roundsUntilDue != null && item.roundsUntilDue <= 500)
+    )
+    .sort((a, b) => {
+      if (a.overdue && !b.overdue) return -1;
+      if (!a.overdue && b.overdue) return 1;
+      const aVal = a.daysUntilDue ?? (a.roundsUntilDue ?? 0);
+      const bVal = b.daysUntilDue ?? (b.roundsUntilDue ?? 0);
+      return aVal - bVal;
+    });
+
+  return {
+    firearmCount,
+    accessoryCount,
+    ammoStocks,
+    ammoByCaliber: Object.values(ammoByCaliber).sort((a, b) => a.caliber.localeCompare(b.caliber)),
+    recentFirearms,
+    recentAccessories,
+    recentAmmo,
+    lowStockItems,
+    totalAmmoRounds,
+    totalInvestment,
+    totalCurrentValue,
+    unrealizedGainLoss,
+    totalFirearmInvestment,
+    totalFirearmCurrentValue,
+    totalAccessoryInvestment,
+    maintenanceDue,
+    rangeStats: {
+      count: rangeSessionAggregate._count.id,
+      totalRounds: rangeSessionAggregate._sum.roundsFired ?? 0,
+      sessionsLast30Days: rangeSessionsLast30,
+      lastSession: lastRangeSession
+        ? {
+            id: lastRangeSession.id,
+            date: lastRangeSession.date,
+            rangeName: lastRangeSession.rangeName,
+            roundsFired: lastRangeSession.roundsFired,
+            firearmName: lastRangeSession.firearm.name,
+          }
+        : null,
+    },
+  };
+}
+
+export const getDashboardAggregates = unstable_cache(getDashboardAggregatesUncached, ["dashboard-aggregates-v1"], {
+  revalidate: 30,
+  tags: [...DASHBOARD_MUTATION_TAGS],
+});
+
+export function revalidateDashboardCaches(domains: Array<keyof typeof DASHBOARD_CACHE_TAGS> = ["all"]) {
+  const uniqueTags = new Set<string>([DASHBOARD_CACHE_TAGS.all]);
+  for (const domain of domains) {
+    uniqueTags.add(DASHBOARD_CACHE_TAGS[domain]);
+  }
+  for (const tag of uniqueTags) {
+    revalidateTag(tag);
+  }
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicated dashboard aggregation logic used by the UI page and `/api/stats` into a single server-side function for maintainability and consistency.
- Add short-lived server-side caching and targeted invalidation so dashboard reads are fast while remaining up-to-date after mutations.

### Description
- Added a new shared server utility `src/lib/server/dashboard.ts` that implements the full aggregation (totals, investments, ammo grouping, low-stock, maintenance due items, recent entities, and range stats) and exposes `getDashboardAggregates` cached via `unstable_cache` (TTL `revalidate: 30`) with domain cache tags (`dashboard:firearms`, `dashboard:accessories`, `dashboard:ammo`, `dashboard:range`, and a global `dashboard:all`).
- Added `revalidateDashboardCaches(domains)` helper to revalidate specific dashboard cache tags from mutation endpoints.
- Refactored `src/app/page.tsx` and `src/app/api/stats/route.ts` to call `getDashboardAggregates()` and preserve the existing response shapes expected by the UI and `/api/stats` respectively.
- Wired cache invalidation calls into mutation routes that touch firearms/accessories/ammo/range (create/update/delete and relevant transaction endpoints) so only relevant dashboard tags are revalidated on writes.

### Testing
- Ran `npx eslint` against the modified server & API files (`src/lib/server/dashboard.ts`, `src/app/page.tsx`, `src/app/api/**/route.ts`) to validate syntax and surface issues; the targeted lint run completed and did not introduce new lint errors in the modified files.
- Ran the project lint script (`npm run lint`) which still fails due to pre-existing unrelated lint issues in UI components (e.g. `src/components/layout/Sidebar.tsx`, `ThemeProvider.tsx`), so full-lint remains failing but unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ea3087c0832698048d5843aafb70)