### PR TITLE
Fix drill performance graph data for built-in templates

### DIFF
--- a/src/app/api/drill-templates/[id]/results/route.ts
+++ b/src/app/api/drill-templates/[id]/results/route.ts
@@ -15,9 +15,19 @@ export async function GET(
       return NextResponse.json({ error: "Template not found" }, { status: 404 });
     }
 
+    const nameMatchFilter = {
+      templateId: null,
+      drillName: template.name,
+    };
+
     const [sessionDrills, drillLogs] = await Promise.all([
       prisma.sessionDrill.findMany({
-        where: { templateId: id },
+        where: {
+          OR: [
+            { templateId: id },
+            ...(template.isBuiltIn ? [nameMatchFilter] : []),
+          ],
+        },
         include: {
           session: {
             select: {
@@ -32,7 +42,12 @@ export async function GET(
         orderBy: { session: { date: "asc" } },
       }),
       prisma.drillLog.findMany({
-        where: { templateId: id },
+        where: {
+          OR: [
+            { templateId: id },
+            ...(template.isBuiltIn ? [nameMatchFilter] : []),
+          ],
+        },
         orderBy: { performedAt: "asc" },
       }),
     ]);


### PR DESCRIPTION
## Summary
- fixed drill performance aggregation to include legacy drill results that were logged without a template id
- added built-in template fallback matching by exact drill name when `templateId` is null
- applied the fallback to both session drills and standalone drill logs so pre-configured drills graph like custom template-linked entries

## Details
`GET /api/drill-templates/[id]/results` now queries with:
- direct template match (`templateId = id`) for all templates
- plus, for built-in templates only, null-template records where `drillName` matches the built-in template name

This preserves normal behavior for custom templates while restoring historical graph data visibility for preconfigured drills.

## Validation
- static code inspection of updated route and query conditions
- no runtime tests executed in this environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30b2461e48326b5b7327117076806)