### PR TITLE
Support multi-firearm range sessions in range logging, APIs, and history views

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model Firearm {
 
   builds          Build[]
   rangeSessions   RangeSession[]
+  sessionFirearms SessionFirearm[]
   maintenanceNotes MaintenanceNote[]
   maintenanceSchedules MaintenanceSchedule[]
   documents       Document[]
@@ -54,6 +55,7 @@ model Build {
 
   slots       BuildSlot[]
   rangeSessions RangeSession[]
+  sessionFirearms SessionFirearm[]
 
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
@@ -175,6 +177,7 @@ model RangeSession {
   groupNotes       String?
 
   // ── Relations ─────────────────────────────────────────
+  sessionFirearms SessionFirearm[]
   sessionDrills  SessionDrill[]
   ammoLinks      SessionAmmoLink[]
 
@@ -183,6 +186,21 @@ model RangeSession {
 
   @@index([firearmId])
   @@index([date])
+}
+
+model SessionFirearm {
+  id          String       @id @default(cuid())
+  sessionId   String
+  session     RangeSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  firearmId   String
+  firearm     Firearm      @relation(fields: [firearmId], references: [id], onDelete: Cascade)
+  buildId     String?
+  build       Build?       @relation(fields: [buildId], references: [id], onDelete: SetNull)
+  roundsFired Int
+
+  @@index([sessionId])
+  @@index([firearmId])
+  @@unique([sessionId, firearmId, buildId])
 }
 
 model DrillTemplate {

--- a/src/app/api/range-sessions/[id]/route.ts
+++ b/src/app/api/range-sessions/[id]/route.ts
@@ -2,6 +2,34 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
+type FirearmPayload = {
+  firearmId?: unknown;
+  roundsFired?: unknown;
+  buildId?: unknown;
+};
+
+const sessionInclude = {
+  sessionFirearms: {
+    include: {
+      firearm: { select: { id: true, name: true, caliber: true } },
+      build: { select: { id: true, name: true } },
+    },
+  },
+  sessionDrills: {
+    include: { template: true },
+    orderBy: { sortOrder: "asc" as const },
+  },
+  ammoLinks: {
+    include: {
+      transaction: {
+        include: {
+          stock: { select: { caliber: true, brand: true, grainWeight: true, bulletType: true } },
+        },
+      },
+    },
+  },
+};
+
 // GET /api/range-sessions/[id]
 export async function GET(
   _request: NextRequest,
@@ -11,23 +39,7 @@ export async function GET(
     const { id } = await params;
     const session = await prisma.rangeSession.findUnique({
       where: { id },
-      include: {
-        firearm: { select: { id: true, name: true, caliber: true } },
-        build: { select: { id: true, name: true } },
-        sessionDrills: {
-          include: { template: true },
-          orderBy: { sortOrder: "asc" },
-        },
-        ammoLinks: {
-          include: {
-            transaction: {
-              include: {
-                stock: { select: { caliber: true, brand: true, grainWeight: true, bulletType: true } },
-              },
-            },
-          },
-        },
-      },
+      include: sessionInclude,
     });
 
     if (!session) {
@@ -50,8 +62,7 @@ export async function PUT(
     const { id } = await params;
     const body = await request.json();
     const {
-      buildId,
-      roundsFired,
+      firearms,
       rangeName,
       rangeLocation,
       notes,
@@ -82,12 +93,33 @@ export async function PUT(
       return Number.isFinite(n) ? n : null;
     };
 
+    let parsedFirearms: { firearmId: string; buildId: string | null; roundsFired: number }[] | null = null;
+    if (firearms !== undefined) {
+      if (!Array.isArray(firearms) || firearms.length === 0) {
+        return NextResponse.json({ error: "At least one firearm entry is required" }, { status: 400 });
+      }
+      parsedFirearms = (firearms as FirearmPayload[]).map((entry) => ({
+        firearmId: typeof entry.firearmId === "string" ? entry.firearmId : "",
+        buildId: typeof entry.buildId === "string" && entry.buildId ? entry.buildId : null,
+        roundsFired: parseInt(String(entry.roundsFired), 10),
+      }));
+      if (parsedFirearms.some((entry) => !entry.firearmId || !Number.isFinite(entry.roundsFired) || entry.roundsFired <= 0)) {
+        return NextResponse.json(
+          { error: "Each firearm entry must include firearmId and a roundsFired value greater than 0" },
+          { status: 400 }
+        );
+      }
+    }
+
     const session = await prisma.$transaction(async (tx) => {
       const updated = await tx.rangeSession.update({
         where: { id },
         data: {
-          buildId: buildId !== undefined ? (buildId || null) : undefined,
-          roundsFired: roundsFired !== undefined ? parseInt(String(roundsFired), 10) : undefined,
+          firearmId: parsedFirearms ? parsedFirearms[0].firearmId : undefined,
+          buildId: parsedFirearms ? parsedFirearms[0].buildId : undefined,
+          roundsFired: parsedFirearms
+            ? parsedFirearms.reduce((sum, entry) => sum + entry.roundsFired, 0)
+            : undefined,
           rangeName: typeof rangeName === "string" ? rangeName.slice(0, 200) : null,
           rangeLocation: typeof rangeLocation === "string" ? rangeLocation.slice(0, 200) : null,
           notes: typeof notes === "string" ? notes.slice(0, 5000) : null,
@@ -105,21 +137,19 @@ export async function PUT(
           numberOfGroups: parseInt_(numberOfGroups),
           groupNotes: typeof groupNotes === "string" && groupNotes ? groupNotes.slice(0, 1000) : null,
         },
-        include: {
-          firearm: { select: { id: true, name: true, caliber: true } },
-          build: { select: { id: true, name: true } },
-          sessionDrills: { include: { template: true }, orderBy: { sortOrder: "asc" } },
-          ammoLinks: {
-            include: {
-              transaction: {
-                include: {
-                  stock: { select: { caliber: true, brand: true, grainWeight: true, bulletType: true } },
-                },
-              },
-            },
-          },
-        },
       });
+
+      if (parsedFirearms) {
+        await tx.sessionFirearm.deleteMany({ where: { sessionId: id } });
+        await tx.sessionFirearm.createMany({
+          data: parsedFirearms.map((entry) => ({
+            sessionId: id,
+            firearmId: entry.firearmId,
+            buildId: entry.buildId,
+            roundsFired: entry.roundsFired,
+          })),
+        });
+      }
 
       // Update ammo links if provided
       if (Array.isArray(ammoTransactionIds)) {
@@ -132,9 +162,11 @@ export async function PUT(
       return updated;
     });
 
+    const hydrated = await prisma.rangeSession.findUnique({ where: { id: session.id }, include: sessionInclude });
+
     revalidateDashboardCaches(["range", "ammo"]);
 
-    return NextResponse.json(session);
+    return NextResponse.json(hydrated);
   } catch (error) {
     console.error("PUT /api/range-sessions/[id] error:", error);
     return NextResponse.json({ error: "Failed to update session" }, { status: 500 });

--- a/src/app/api/range-sessions/route.ts
+++ b/src/app/api/range-sessions/route.ts
@@ -2,6 +2,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
 
+type FirearmPayload = {
+  firearmId?: unknown;
+  roundsFired?: unknown;
+  buildId?: unknown;
+};
+
+const firearmInclude = {
+  sessionFirearms: {
+    include: {
+      firearm: { select: { id: true, name: true, caliber: true } },
+      build: { select: { id: true, name: true } },
+    }
+  },
+};
+
 // GET /api/range-sessions - List range sessions, optional ?firearmId= filter, ?include=analytics
 export async function GET(request: NextRequest) {
   try {
@@ -12,10 +27,9 @@ export async function GET(request: NextRequest) {
     const includeAnalytics = searchParams.get("include") === "analytics";
 
     const sessions = await prisma.rangeSession.findMany({
-      where: firearmId ? { firearmId } : undefined,
+      where: firearmId ? { sessionFirearms: { some: { firearmId } } } : undefined,
       include: {
-        firearm: { select: { id: true, name: true, caliber: true } },
-        build: { select: { id: true, name: true } },
+        ...firearmInclude,
         _count: { select: { sessionDrills: true } },
         ...(includeAnalytics
           ? {
@@ -41,9 +55,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const {
-      firearmId,
-      buildId,
-      roundsFired,
+      firearms,
       rangeName,
       rangeLocation,
       notes,
@@ -66,17 +78,24 @@ export async function POST(request: NextRequest) {
       ammoTransactionIds,
     } = body;
 
-    if (!firearmId || roundsFired === undefined || roundsFired === null) {
+    if (!Array.isArray(firearms) || firearms.length === 0) {
+      return NextResponse.json({ error: "At least one firearm entry is required" }, { status: 400 });
+    }
+
+    const parsedFirearms = (firearms as FirearmPayload[]).map((entry) => ({
+      firearmId: typeof entry.firearmId === "string" ? entry.firearmId : "",
+      buildId: typeof entry.buildId === "string" && entry.buildId ? entry.buildId : null,
+      roundsFired: parseInt(String(entry.roundsFired), 10),
+    }));
+
+    if (parsedFirearms.some((entry) => !entry.firearmId || !Number.isFinite(entry.roundsFired) || entry.roundsFired <= 0)) {
       return NextResponse.json(
-        { error: "Missing required fields: firearmId, roundsFired" },
+        { error: "Each firearm entry must include firearmId and a roundsFired value greater than 0" },
         { status: 400 }
       );
     }
 
-    const rounds = parseInt(String(roundsFired), 10);
-    if (!Number.isFinite(rounds) || rounds < 0) {
-      return NextResponse.json({ error: "roundsFired must be a non-negative integer" }, { status: 400 });
-    }
+    const rounds = parsedFirearms.reduce((sum, entry) => sum + entry.roundsFired, 0);
 
     const parseFloat_ = (v: unknown) => {
       if (v === null || v === undefined || v === "") return null;
@@ -92,8 +111,8 @@ export async function POST(request: NextRequest) {
     const session = await prisma.$transaction(async (tx) => {
       const created = await tx.rangeSession.create({
         data: {
-          firearmId,
-          buildId: buildId || null,
+          firearmId: parsedFirearms[0].firearmId,
+          buildId: parsedFirearms[0].buildId,
           roundsFired: rounds,
           rangeName: typeof rangeName === "string" ? rangeName.slice(0, 200) : null,
           rangeLocation: typeof rangeLocation === "string" ? rangeLocation.slice(0, 200) : null,
@@ -113,11 +132,11 @@ export async function POST(request: NextRequest) {
           groupSizeMoa: parseFloat_(groupSizeMoa),
           numberOfGroups: parseInt_(numberOfGroups),
           groupNotes: typeof groupNotes === "string" && groupNotes ? groupNotes.slice(0, 1000) : null,
+          sessionFirearms: {
+            create: parsedFirearms,
+          },
         },
-        include: {
-          firearm: { select: { id: true, name: true, caliber: true } },
-          build: { select: { id: true, name: true } },
-        },
+        include: firearmInclude,
       });
 
       if (Array.isArray(ammoTransactionIds) && ammoTransactionIds.length > 0) {

--- a/src/app/range/[id]/page.tsx
+++ b/src/app/range/[id]/page.tsx
@@ -73,6 +73,14 @@ interface AmmoLink {
   };
 }
 
+interface SessionFirearm {
+  id: string;
+  firearmId: string;
+  roundsFired: number;
+  firearm: { id: string; name: string; caliber: string };
+  build: { id: string; name: string } | null;
+}
+
 interface RangeSession {
   id: string;
   date: string;
@@ -92,8 +100,7 @@ interface RangeSession {
   groupSizeMoa: number | null;
   numberOfGroups: number | null;
   groupNotes: string | null;
-  firearm: { id: string; name: string; caliber: string };
-  build: { id: string; name: string } | null;
+  sessionFirearms: SessionFirearm[];
   sessionDrills: SessionDrill[];
   ammoLinks: AmmoLink[];
 }
@@ -489,7 +496,7 @@ export default function RangeSessionDetailPage() {
   return (
     <div className="min-h-full">
       <PageHeader
-        title={session.firearm.name.toUpperCase()}
+        title={session.sessionFirearms.map((sf) => sf.firearm.name).join(" + ").toUpperCase()}
         subtitle={formatDate(session.date)}
       />
 
@@ -537,8 +544,8 @@ export default function RangeSessionDetailPage() {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {[
             { label: "Rounds Fired", value: formatNumber(session.roundsFired), unit: "rds", color: "text-[#00C2FF]" },
-            { label: "Caliber", value: session.firearm.caliber, color: "text-vault-text" },
-            { label: "Build", value: session.build?.name ?? "—", color: "text-vault-text" },
+            { label: "Calibers", value: Array.from(new Set(session.sessionFirearms.map((sf) => sf.firearm.caliber))).join(", "), color: "text-vault-text" },
+            { label: "Builds", value: session.sessionFirearms.filter((sf) => sf.build).map((sf) => sf.build!.name).join(", ") || "—", color: "text-vault-text" },
             { label: "Range", value: session.rangeName ?? "—", color: "text-vault-text" },
           ].map(({ label, value, color }) => (
             <div key={label} className="bg-vault-surface border border-vault-border rounded-lg p-3">

--- a/src/app/range/history/page.tsx
+++ b/src/app/range/history/page.tsx
@@ -19,10 +19,16 @@ import {
   ReferenceLine,
 } from "recharts";
 
-interface RangeSession {
+interface RangeSessionFirearm {
   id: string;
   firearmId: string;
-  buildId: string | null;
+  roundsFired: number;
+  firearm: { id: string; name: string; caliber: string };
+  build: { id: string; name: string } | null;
+}
+
+interface RangeSession {
+  id: string;
   date: string;
   roundsFired: number;
   rangeName: string | null;
@@ -31,8 +37,7 @@ interface RangeSession {
   groupSizeIn: number | null;
   groupSizeMoa: number | null;
   targetDistanceYd: number | null;
-  firearm: { id: string; name: string; caliber: string };
-  build: { id: string; name: string } | null;
+  sessionFirearms: RangeSessionFirearm[];
   _count: { sessionDrills: number };
   sessionDrills?: { accuracy: number | null; drillName: string; templateId: string | null; timeSeconds: number | null; score: number | null }[];
 }
@@ -144,12 +149,12 @@ export default function RangeHistoryPage() {
   const [calendarLoading, setCalendarLoading] = useState(false);
 
   const uniqueFirearms = useMemo(
-    () => Array.from(new Map(sessions.map((s) => [s.firearm.id, s.firearm])).values()),
+    () => Array.from(new Map(sessions.flatMap((s) => s.sessionFirearms.map((sf) => [sf.firearm.id, sf.firearm]))).values()),
     [sessions]
   );
 
   const filtered = useMemo(
-    () => firearmFilter === "ALL" ? sessions : sessions.filter((s) => s.firearm.id === firearmFilter),
+    () => firearmFilter === "ALL" ? sessions : sessions.filter((s) => s.sessionFirearms.some((sf) => sf.firearm.id === firearmFilter)),
     [sessions, firearmFilter]
   );
 
@@ -224,7 +229,7 @@ export default function RangeHistoryPage() {
         date: formatSessionDate(s.date),
         groupSizeIn: s.groupSizeIn!,
         distanceYd: s.targetDistanceYd!,
-        firearm: s.firearm.name,
+        firearm: s.sessionFirearms.map((sf) => sf.firearm.name).join(", "),
       }));
   }, [filtered]);
 
@@ -382,10 +387,10 @@ export default function RangeHistoryPage() {
                     <div className="flex items-start justify-between gap-4">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-3 mb-2 flex-wrap">
-                          <span className="text-sm font-semibold text-vault-text">{session.firearm.name}</span>
-                          {session.build && (
+                          <span className="text-sm font-semibold text-vault-text">{session.sessionFirearms.map((sf) => sf.firearm.name).join(", ")}</span>
+                          {session.sessionFirearms.some((sf) => sf.build) && (
                             <span className="text-[10px] font-mono text-vault-text-faint border border-vault-border px-1.5 py-0.5 rounded">
-                              {session.build.name}
+                              {session.sessionFirearms.filter((sf) => sf.build).map((sf) => sf.build!.name).join(", ")}
                             </span>
                           )}
                           <span className="text-[10px] font-mono font-bold text-[#00C2FF] bg-[#00C2FF]/10 border border-[#00C2FF]/20 px-2 py-0.5 rounded">

--- a/src/app/range/page.tsx
+++ b/src/app/range/page.tsx
@@ -114,9 +114,10 @@ export default function RangeSessionPage() {
   const [builds, setBuilds] = useState<Build[]>([]);
   const [ammoStocks, setAmmoStocks] = useState<AmmoStock[]>([]);
 
-  const [selectedFirearm, setSelectedFirearm] = useState<string>("");
+  const [selectedFirearms, setSelectedFirearms] = useState<Set<string>>(new Set());
+  const [roundsByFirearm, setRoundsByFirearm] = useState<Record<string, string>>({});
   const [selectedBuild, setSelectedBuild] = useState<string>("");
-  const [roundsFired, setRoundsFired] = useState<string>("");
+  const [primaryFirearmId, setPrimaryFirearmId] = useState<string>("");
   const [ammoUsageEntries, setAmmoUsageEntries] = useState<AmmoUsageEntry[]>([
     { key: crypto.randomUUID(), stockId: "", quantity: "" },
   ]);
@@ -229,13 +230,13 @@ export default function RangeSessionPage() {
   }, []);
 
   useEffect(() => {
-    if (selectedFirearm) {
-      loadBuilds(selectedFirearm);
+    if (primaryFirearmId) {
+      loadBuilds(primaryFirearmId);
     } else {
       setBuilds([]);
       setSelectedBuild("");
     }
-  }, [selectedFirearm, loadBuilds]);
+  }, [primaryFirearmId, loadBuilds]);
 
   // Update accessory defaults when build changes
   useEffect(() => {
@@ -248,14 +249,22 @@ export default function RangeSessionPage() {
     setSelectedAccessories(autoSelect);
   }, [selectedBuild, builds]);
 
-  const selectedFirearmData = firearms.find((f) => f.id === selectedFirearm);
+  const selectedFirearmIds = Array.from(selectedFirearms);
   const selectedBuildData = builds.find((b) => b.id === selectedBuild);
   const buildAccessories = selectedBuildData?.slots.filter((s) => s.accessory) ?? [];
 
-  // Filter ammo by firearm caliber
-  const compatibleAmmo = selectedFirearmData
-    ? ammoStocks.filter((a) => a.caliber === selectedFirearmData.caliber)
+  // Filter ammo by selected firearm caliber(s)
+  const selectedCalibers = new Set(
+    firearms.filter((f) => selectedFirearms.has(f.id)).map((f) => f.caliber).filter(Boolean)
+  );
+  const compatibleAmmo = selectedCalibers.size > 0
+    ? ammoStocks.filter((a) => selectedCalibers.has(a.caliber))
     : ammoStocks;
+
+  const totalEnteredRounds = selectedFirearmIds.reduce(
+    (sum, id) => sum + (parseInt(roundsByFirearm[id] ?? "0", 10) || 0),
+    0
+  );
 
   const totalAmmoToDeduct = ammoUsageEntries.reduce((sum, entry) => {
     if (!entry.stockId || entry.quantity === "") return sum;
@@ -274,17 +283,46 @@ export default function RangeSessionPage() {
     });
   }
 
+  function toggleFirearm(firearmId: string) {
+    setSelectedFirearms((prev) => {
+      const next = new Set(prev);
+      if (next.has(firearmId)) {
+        next.delete(firearmId);
+        setRoundsByFirearm((current) => { const c = { ...current }; delete c[firearmId]; return c; });
+      } else {
+        next.add(firearmId);
+      }
+      const first = next.values().next().value ?? "";
+      setPrimaryFirearmId(first);
+      if (next.size === 0 || !next.has(primaryFirearmId)) setSelectedBuild("");
+      return next;
+    });
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setSubmitting(true);
 
-    const rounds = parseInt(roundsFired);
-    if (!rounds || rounds <= 0) {
-      setError("Please enter a valid number of rounds fired.");
+    if (selectedFirearmIds.length === 0) {
+      setError("Select at least one firearm.");
       setSubmitting(false);
       return;
     }
+
+    const firearmEntries = selectedFirearmIds.map((firearmId) => ({
+      firearmId,
+      buildId: firearmId === primaryFirearmId && selectedBuild ? selectedBuild : null,
+      roundsFired: parseInt(roundsByFirearm[firearmId] ?? "", 10),
+    }));
+
+    if (firearmEntries.some((entry) => !Number.isFinite(entry.roundsFired) || entry.roundsFired <= 0)) {
+      setError("Each selected firearm needs a valid rounds fired value.");
+      setSubmitting(false);
+      return;
+    }
+
+    const rounds = firearmEntries.reduce((sum, entry) => sum + entry.roundsFired, 0);
 
     try {
       const results: string[] = [];
@@ -351,9 +389,7 @@ export default function RangeSessionPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          firearmId: selectedFirearm,
-          buildId: selectedBuild || null,
-          roundsFired: rounds,
+          firearms: firearmEntries,
           rangeName: rangeName || null,
           rangeLocation: rangeLocation || null,
           notes: sessionNote || null,
@@ -424,9 +460,10 @@ export default function RangeSessionPage() {
   }
 
   function resetForm() {
-    setSelectedFirearm("");
+    setSelectedFirearms(new Set());
+    setRoundsByFirearm({});
+    setPrimaryFirearmId("");
     setSelectedBuild("");
-    setRoundsFired("");
     setAmmoUsageEntries([{ key: crypto.randomUUID(), stockId: "", quantity: "" }]);
     setSessionNote("");
     setRangeName("");
@@ -473,7 +510,7 @@ export default function RangeSessionPage() {
             <div className="space-y-2">
               <div className="flex justify-between">
                 <span className="text-sm text-vault-text-muted">Rounds fired</span>
-                <span className="text-sm font-mono font-bold text-[#00C2FF]">{formatNumber(parseInt(roundsFired))}</span>
+                <span className="text-sm font-mono font-bold text-[#00C2FF]">{formatNumber(totalEnteredRounds)}</span>
               </div>
               {successDetails.accessories.length > 0 && (
                 <div>
@@ -534,28 +571,40 @@ export default function RangeSessionPage() {
             </legend>
 
             <div>
-              <label className={LABEL_CLASS}>Firearm <span className="text-[#E53935]">*</span></label>
+              <label className={LABEL_CLASS}>Firearms <span className="text-[#E53935]">*</span></label>
               {loadingFirearms ? (
                 <div className="flex items-center gap-2 h-10">
                   <Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" />
                   <span className="text-sm text-vault-text-muted">Loading...</span>
                 </div>
               ) : (
-                <div className="relative">
-                  <select required value={selectedFirearm}
-                    onChange={(e) => { setSelectedFirearm(e.target.value); setSelectedBuild(""); setAmmoUsageEntries([{ key: crypto.randomUUID(), stockId: "", quantity: "" }]); }}
-                    className={INPUT_CLASS}>
-                    <option value="">Select firearm...</option>
-                    {firearms.map((f) => (
-                      <option key={f.id} value={f.id}>{f.name}{f.caliber ? ` (${f.caliber})` : ""}</option>
-                    ))}
-                  </select>
-                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+                <div className="space-y-2">
+                  {firearms.map((f) => {
+                    const checked = selectedFirearms.has(f.id);
+                    return (
+                      <label key={f.id} className={`flex items-center justify-between gap-3 p-2.5 rounded-md border cursor-pointer ${checked ? "bg-[#00C2FF]/10 border-[#00C2FF]/30" : "bg-vault-bg border-vault-border"}`}>
+                        <div className="flex items-center gap-2">
+                          <input type="checkbox" checked={checked} onChange={() => toggleFirearm(f.id)} />
+                          <span className="text-sm text-vault-text">{f.name}{f.caliber ? ` (${f.caliber})` : ""}</span>
+                        </div>
+                        {checked && (
+                          <input
+                            type="number"
+                            min={1}
+                            value={roundsByFirearm[f.id] ?? ""}
+                            onChange={(e) => setRoundsByFirearm((prev) => ({ ...prev, [f.id]: e.target.value }))}
+                            placeholder="Rounds"
+                            className="w-28 bg-vault-surface border border-vault-border text-vault-text rounded-md px-2 py-1 text-xs"
+                          />
+                        )}
+                      </label>
+                    );
+                  })}
                 </div>
               )}
             </div>
 
-            {selectedFirearm && (
+            {primaryFirearmId && (
               <div>
                 <label className={LABEL_CLASS}>Build</label>
                 {loadingBuilds ? (
@@ -620,8 +669,8 @@ export default function RangeSessionPage() {
 
             <div>
               <label className={LABEL_CLASS}>Rounds Fired <span className="text-[#E53935]">*</span></label>
-              <input type="number" min={1} required value={roundsFired} onChange={(e) => setRoundsFired(e.target.value)}
-                placeholder="e.g. 200" className={INPUT_CLASS} />
+              <input type="number" min={1} required value={totalEnteredRounds} readOnly
+                placeholder="e.g. 200" className={`${INPUT_CLASS} opacity-80`} />
             </div>
 
             <div>
@@ -632,9 +681,9 @@ export default function RangeSessionPage() {
                 </div>
               ) : compatibleAmmo.length === 0 ? (
                 <p className="text-sm text-vault-text-faint py-2">
-                  {selectedFirearmData
-                    ? `No ${selectedFirearmData.caliber} stocks found.`
-                    : "Select a firearm to filter compatible ammo."}
+                  {selectedCalibers.size > 0
+                    ? `No compatible stocks found for selected caliber${selectedCalibers.size > 1 ? "s" : ""}.`
+                    : "Select one or more firearms to filter compatible ammo."}
                 </p>
               ) : (
                 <div className="space-y-2">
@@ -728,8 +777,8 @@ export default function RangeSessionPage() {
                           <span className="text-[10px] font-mono text-vault-text-muted">{formatNumber(slot.accessory.roundCount)} rds total</span>
                         </div>
                       </div>
-                      {isSelected && roundsFired && (
-                        <span className="text-xs font-mono text-[#00C2FF] shrink-0">+{formatNumber(parseInt(roundsFired) || 0)}</span>
+                      {isSelected && totalEnteredRounds > 0 && (
+                        <span className="text-xs font-mono text-[#00C2FF] shrink-0">+{formatNumber(totalEnteredRounds)}</span>
                       )}
                     </label>
                   );
@@ -1076,11 +1125,11 @@ export default function RangeSessionPage() {
               {hasAmmoDeduction && (
                 <p>
                   Will deduct {formatNumber(totalAmmoToDeduct)} rounds across ammo selection
-                  {roundsFired && totalAmmoToDeduct > parseInt(roundsFired, 10) ? " (exceeds rounds fired)" : ""}
+                  {totalEnteredRounds > 0 && totalAmmoToDeduct > totalEnteredRounds ? " (exceeds rounds fired)" : ""}
                 </p>
               )}
             </div>
-            <button type="submit" disabled={submitting || !selectedFirearm || !roundsFired}
+            <button type="submit" disabled={submitting || selectedFirearmIds.length === 0 || selectedFirearmIds.some((id) => !(parseInt(roundsByFirearm[id] ?? "", 10) > 0))}
               className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-6 py-2 rounded-md text-sm font-medium transition-colors">
               {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Target className="w-4 h-4" />}
               {submitting ? "Logging..." : "Log Session"}


### PR DESCRIPTION
### Motivation
- Allow logging of range sessions that involve multiple firearms with per-firearm round counts and optional build attribution instead of a single firearm per session.
- Persist a normalized join between sessions and firearms so analytics, ammo deductions, and accessory round attribution can operate against collections of firearms.

### Description
- Added a `SessionFirearm` Prisma model and wired reverse relations on `Firearm`, `Build`, and `RangeSession` to record `{ firearmId, buildId?, roundsFired }` per session and regenerated the Prisma client. 
- Updated `POST /api/range-sessions` to accept `firearms: [{ firearmId, roundsFired, buildId? }]`, validate entries, compute the aggregate session rounds, create a `RangeSession` plus `sessionFirearms` rows inside a transaction, and attach ammo transaction links.
- Updated `GET /api/range-sessions` and `GET/PUT /api/range-sessions/[id]` to include `sessionFirearms` (with nested firearm/build select) and to validate/replace `sessionFirearms` on update while keeping the session's `roundsFired` as the sum of the collection.
- Reworked the range logging UI (`src/app/range/page.tsx`) to replace the single firearm `<select>` with a multi-select checkbox list that exposes a per-firearm rounds input, tracks selection in `selectedFirearms`/`roundsByFirearm`, validates: at least one firearm selected, each selected firearm has a valid rounds value, and ammo deduction totals do not exceed the aggregate rounds; and updated payload to send `firearms` array.
- Updated history and session detail pages (`src/app/range/history/page.tsx`, `src/app/range/[id]/page.tsx`) to render and filter by the multi-firearm `sessionFirearms` collection (names, calibers, builds, aggregate displays).

### Testing
- Ran `npx prisma generate` after schema changes, which completed successfully.
- Ran `npx eslint` against the modified files, which completed successfully (no new lint errors in changed files; a single unrelated warning was addressed during edits).
- Ran `npx tsc --noEmit`, which surfaced existing repository-wide TypeScript issues unrelated to this PR; the failure is from pre-existing type errors elsewhere and not caused by these changes.
- Launched the dev server and executed an automated Playwright smoke script that captured a screenshot of the updated range logging page to verify the multi-firearm UI was rendered (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30d3056a08326826b76f6ab5eb6bd)