### PR TITLE
Add DOPE estimate utilities and builder workflow

### DIFF
--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { PageHeader } from "@/components/shared/PageHeader";
+import {
+  applyDopeCorrections,
+  convertDropWindToAngular,
+  generateDistanceRows,
+  type AngularDopeRow,
+  type DopeRowCorrection,
+} from "@/lib/ballistics/dope";
+import { Calculator, Target } from "lucide-react";
+
+const INPUT_CLASS =
+  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
+const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+
+export default function DopeCardPage() {
+  const [startYd, setStartYd] = useState("100");
+  const [endYd, setEndYd] = useState("800");
+  const [stepYd, setStepYd] = useState("100");
+
+  const [dropPer100YdIn, setDropPer100YdIn] = useState("3.5");
+  const [windPer100YdIn, setWindPer100YdIn] = useState("1.2");
+
+  const [rows, setRows] = useState<AngularDopeRow[]>([]);
+  const [corrections, setCorrections] = useState<Record<number, DopeRowCorrection>>({});
+
+  const estimateSummary = useMemo(() => {
+    if (!rows.length) return null;
+    const confirmedCount = rows.filter((r) => r.confirmed).length;
+    return `${confirmedCount}/${rows.length} rows confirmed from impacts`;
+  }, [rows]);
+
+  function handleGenerate() {
+    const start = Number(startYd);
+    const end = Number(endYd);
+    const step = Number(stepYd);
+    const dropRate = Number(dropPer100YdIn);
+    const windRate = Number(windPer100YdIn);
+
+    const distanceRows = generateDistanceRows(start, end, step);
+    const estimatedRows = distanceRows.map(({ distanceYd }) => ({
+      distanceYd,
+      dropIn: Number(((distanceYd / 100) * dropRate).toFixed(2)),
+      windIn: Number(((distanceYd / 100) * windRate).toFixed(2)),
+    }));
+
+    const converted = convertDropWindToAngular(estimatedRows);
+    setCorrections({});
+    setRows(converted);
+  }
+
+  function updateCorrection(distanceYd: number, patch: DopeRowCorrection) {
+    const nextCorrections = {
+      ...corrections,
+      [distanceYd]: {
+        ...corrections[distanceYd],
+        ...patch,
+      },
+    };
+    setCorrections(nextCorrections);
+    setRows((prev) => applyDopeCorrections(prev, nextCorrections));
+  }
+
+  return (
+    <div className="min-h-full">
+      <PageHeader
+        title="DOPE CARD BUILDER"
+        subtitle="Generate an estimated card, then overwrite each row from confirmed impacts"
+      />
+
+      <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+        <div className="bg-[#F5A623]/10 border border-[#F5A623]/30 rounded-lg p-4">
+          <p className="text-sm text-[#F5A623] font-medium">
+            Estimate only: this builder is a starting point and is not a replacement for verified firing data.
+          </p>
+        </div>
+
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <div className="flex items-center gap-2">
+            <Calculator className="w-4 h-4 text-[#00C2FF]" />
+            <h2 className="text-xs uppercase tracking-widest text-[#00C2FF] font-mono">Auto-Populate Estimates</h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+            <div>
+              <label className={LABEL_CLASS}>Start (yd)</label>
+              <input value={startYd} onChange={(e) => setStartYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>End (yd)</label>
+              <input value={endYd} onChange={(e) => setEndYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Step (yd)</label>
+              <input value={stepYd} onChange={(e) => setStepYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Est. Drop / 100yd (in)</label>
+              <input value={dropPer100YdIn} onChange={(e) => setDropPer100YdIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Est. Wind / 100yd (in)</label>
+              <input value={windPer100YdIn} onChange={(e) => setWindPer100YdIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+            </div>
+          </div>
+
+          <button
+            onClick={handleGenerate}
+            className="px-4 py-2 text-sm rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 transition-colors"
+          >
+            Generate Estimated Rows
+          </button>
+        </section>
+
+        <section className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+          <div className="px-4 py-3 border-b border-vault-border flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Target className="w-4 h-4 text-[#00C853]" />
+              <h3 className="text-xs font-mono uppercase tracking-widest text-[#00C853]">Row Corrections from Confirmed Impacts</h3>
+            </div>
+            {estimateSummary && <p className="text-xs text-vault-text-muted">{estimateSummary}</p>}
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-vault-bg/50 text-vault-text-faint uppercase tracking-widest text-[11px]">
+                <tr>
+                  <th className="text-left px-3 py-2">Distance</th>
+                  <th className="text-left px-3 py-2">Drop (in)</th>
+                  <th className="text-left px-3 py-2">Drop (MIL)</th>
+                  <th className="text-left px-3 py-2">Drop (MOA)</th>
+                  <th className="text-left px-3 py-2">Wind (in)</th>
+                  <th className="text-left px-3 py-2">Wind (MIL)</th>
+                  <th className="text-left px-3 py-2">Wind (MOA)</th>
+                  <th className="text-left px-3 py-2">Confirmed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.distanceYd} className="border-t border-vault-border/60">
+                    <td className="px-3 py-2 font-mono">{row.distanceYd} yd</td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="number"
+                        step="0.01"
+                        className={`${INPUT_CLASS} min-w-[110px]`}
+                        value={corrections[row.distanceYd]?.dropIn ?? row.dropIn}
+                        onChange={(e) => updateCorrection(row.distanceYd, { dropIn: Number(e.target.value) })}
+                      />
+                    </td>
+                    <td className="px-3 py-2 font-mono">{row.dropMil.toFixed(2)}</td>
+                    <td className="px-3 py-2 font-mono">{row.dropMoa.toFixed(2)}</td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="number"
+                        step="0.01"
+                        className={`${INPUT_CLASS} min-w-[110px]`}
+                        value={corrections[row.distanceYd]?.windIn ?? row.windIn}
+                        onChange={(e) => updateCorrection(row.distanceYd, { windIn: Number(e.target.value) })}
+                      />
+                    </td>
+                    <td className="px-3 py-2 font-mono">{row.windMil.toFixed(2)}</td>
+                    <td className="px-3 py-2 font-mono">{row.windMoa.toFixed(2)}</td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={row.confirmed}
+                        onChange={(e) => updateCorrection(row.distanceYd, { confirmed: e.target.checked })}
+                        className="w-4 h-4 accent-[#00C853]"
+                      />
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-3 py-6 text-center text-vault-text-faint">
+                      Generate estimated rows to begin your dope card.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,6 +76,7 @@ const NAV_ITEMS: NavItem[] = [
       { label: "Drill Performance", href: "/range/drill-performance", icon: TrendingUp },
       { label: "Drill Library", href: "/range/drills", icon: BookOpen },
       { label: "Hit Factor Calc", href: "/range/hit-factor", icon: Calculator },
+      { label: "DOPE Card", href: "/range/dope-card", icon: Target },
     ],
   },
   {

--- a/src/lib/__tests__/dope.test.ts
+++ b/src/lib/__tests__/dope.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDopeCorrections,
+  convertDropWindToAngular,
+  generateDistanceRows,
+} from "@/lib/ballistics/dope";
+
+describe("generateDistanceRows", () => {
+  it("builds inclusive rows and appends end distance", () => {
+    expect(generateDistanceRows(100, 350, 100)).toEqual([
+      { distanceYd: 100 },
+      { distanceYd: 200 },
+      { distanceYd: 300 },
+      { distanceYd: 350 },
+    ]);
+  });
+
+  it("returns empty for invalid input", () => {
+    expect(generateDistanceRows(0, 600, 100)).toEqual([]);
+    expect(generateDistanceRows(600, 100, 100)).toEqual([]);
+    expect(generateDistanceRows(100, 600, 0)).toEqual([]);
+  });
+});
+
+describe("convertDropWindToAngular", () => {
+  it("converts inches to mil/moa", () => {
+    const rows = convertDropWindToAngular([{ distanceYd: 200, dropIn: 8, windIn: 4 }]);
+    expect(rows[0]).toMatchObject({
+      dropMil: 1.11,
+      dropMoa: 3.82,
+      windMil: 0.56,
+      windMoa: 1.91,
+      confirmed: false,
+    });
+  });
+});
+
+describe("applyDopeCorrections", () => {
+  it("applies manual per-row corrections and recomputes angular values", () => {
+    const generated = convertDropWindToAngular([{ distanceYd: 300, dropIn: 9, windIn: 6 }]);
+    const corrected = applyDopeCorrections(generated, {
+      300: { dropIn: 12, confirmed: true },
+    });
+
+    expect(corrected[0]).toMatchObject({
+      dropIn: 12,
+      windIn: 6,
+      dropMil: 1.11,
+      confirmed: true,
+    });
+  });
+});

--- a/src/lib/ballistics/dope.ts
+++ b/src/lib/ballistics/dope.ts
@@ -1,0 +1,98 @@
+export interface DistanceRow {
+  distanceYd: number;
+}
+
+export interface BallisticOutputRow {
+  distanceYd: number;
+  dropIn: number;
+  windIn: number;
+}
+
+export interface AngularDopeRow extends BallisticOutputRow {
+  dropMil: number;
+  dropMoa: number;
+  windMil: number;
+  windMoa: number;
+  confirmed: boolean;
+}
+
+export interface DopeRowCorrection {
+  dropIn?: number;
+  windIn?: number;
+  confirmed?: boolean;
+}
+
+const INCHES_PER_100YD_PER_MIL = 3.6;
+const INCHES_PER_100YD_PER_MOA = 1.047;
+
+function roundTo(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function toMil(inches: number, distanceYd: number): number {
+  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MIL);
+}
+
+function toMoa(inches: number, distanceYd: number): number {
+  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MOA);
+}
+
+export function generateDistanceRows(startYd: number, endYd: number, stepYd: number): DistanceRow[] {
+  if (!Number.isFinite(startYd) || !Number.isFinite(endYd) || !Number.isFinite(stepYd)) {
+    return [];
+  }
+
+  if (startYd <= 0 || endYd < startYd || stepYd <= 0) {
+    return [];
+  }
+
+  const rows: DistanceRow[] = [];
+  for (let distance = startYd; distance <= endYd; distance += stepYd) {
+    rows.push({ distanceYd: roundTo(distance, 4) });
+  }
+
+  const hasExactEnd = rows.length > 0 && rows[rows.length - 1].distanceYd === endYd;
+  if (!hasExactEnd) {
+    rows.push({ distanceYd: endYd });
+  }
+
+  return rows;
+}
+
+export function convertDropWindToAngular(rows: BallisticOutputRow[]): AngularDopeRow[] {
+  return rows
+    .filter((row) => row.distanceYd > 0)
+    .map((row) => ({
+      ...row,
+      dropMil: roundTo(toMil(row.dropIn, row.distanceYd), 2),
+      dropMoa: roundTo(toMoa(row.dropIn, row.distanceYd), 2),
+      windMil: roundTo(toMil(row.windIn, row.distanceYd), 2),
+      windMoa: roundTo(toMoa(row.windIn, row.distanceYd), 2),
+      confirmed: false,
+    }));
+}
+
+export function applyDopeCorrections(
+  rows: AngularDopeRow[],
+  correctionsByDistance: Record<number, DopeRowCorrection>
+): AngularDopeRow[] {
+  return rows.map((row) => {
+    const correction = correctionsByDistance[row.distanceYd];
+    if (!correction) return row;
+
+    const dropIn = correction.dropIn ?? row.dropIn;
+    const windIn = correction.windIn ?? row.windIn;
+
+    return {
+      ...row,
+      dropIn,
+      windIn,
+      dropMil: roundTo(toMil(dropIn, row.distanceYd), 2),
+      dropMoa: roundTo(toMoa(dropIn, row.distanceYd), 2),
+      windMil: roundTo(toMil(windIn, row.distanceYd), 2),
+      windMoa: roundTo(toMoa(windIn, row.distanceYd), 2),
+      confirmed: correction.confirmed ?? row.confirmed,
+    };
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a small, pure ballistics utility set to generate DOPE rows and convert linear drop/wind outputs into angular values so users can quickly build an estimated DOPE card. 
- Let users auto-populate a card from simple inputs then adjust individual rows from confirmed impacts, while clearly marking the output as an estimate and not a substitute for verified firing data.

### Description
- Added `src/lib/ballistics/dope.ts` which exports pure helpers and types: `generateDistanceRows(start,end,step)`, `convertDropWindToAngular(rows)`, and `applyDopeCorrections(rows, corrections)` plus related interfaces and conversion constants; values are rounded for display.
- Added a DOPE card builder UI at `src/app/range/dope-card/page.tsx` that auto-populates estimated rows from per-100yd drop/wind inputs, shows MIL/MOA conversions, and supports per-row manual corrections and confirmation toggles; the page includes a prominent estimate-only warning.
- Added unit tests at `src/lib/__tests__/dope.test.ts` covering distance row generation, conversion to MIL/MOA, and applying per-row corrections.
- Wired the page into the Training navigation by adding a `DOPE Card` entry to the sidebar (`src/components/layout/Sidebar.tsx`).

### Testing
- Ran `npm test` (Vitest) and all tests passed: 4 test files, 53 tests passed.
- Ran `npm run lint` (ESLint) and it completed successfully.
- An earlier attempt to run `npm test -- --runInBand` failed because Vitest does not recognize `--runInBand`, which does not affect the successful `npm test` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30fa8633c8326920516e3fd329305)