### PR TITLE
Add dope-cards API endpoints with CRUD and print payload

### DIFF
--- a/src/app/api/dope-cards/[id]/print/route.ts
+++ b/src/app/api/dope-cards/[id]/print/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const prismaClient = prisma as unknown as {
+  dopeCard: {
+    findUnique: (args: unknown) => Promise<unknown>;
+  };
+};
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+const sanitizeJson = (value: unknown, depth = 0): JsonValue => {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (depth >= 6) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 500).map((item) => sanitizeJson(item, depth + 1));
+  }
+
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const sanitized: JsonObject = {};
+    for (const [key, item] of Object.entries(obj)) {
+      if (key.toLowerCase().includes("password") || key.toLowerCase().includes("secret")) continue;
+      sanitized[key] = sanitizeJson(item, depth + 1);
+    }
+    return sanitized;
+  }
+
+  return null;
+};
+
+// GET /api/dope-cards/[id]/print
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const card = (await prismaClient.dopeCard.findUnique({
+      where: { id },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+      },
+    })) as {
+      id: string;
+      name: string | null;
+      notes: string | null;
+      zeroRangeYd: number | null;
+      profile: unknown;
+      firearm?: { id: string; name: string; caliber: string | null };
+      updatedAt?: string | Date;
+      confirmedAt?: string | Date | null;
+    } | null;
+
+    if (!card) {
+      return NextResponse.json({ error: "Dope card not found" }, { status: 404 });
+    }
+
+    const printPayload = {
+      id: card.id,
+      title: card.name,
+      notes: card.notes,
+      zeroRangeYd: card.zeroRangeYd,
+      confirmedAt: card.confirmedAt ?? null,
+      updatedAt: card.updatedAt ?? null,
+      firearm: card.firearm
+        ? {
+            id: card.firearm.id,
+            name: card.firearm.name,
+            caliber: card.firearm.caliber ?? null,
+          }
+        : null,
+      profile: sanitizeJson(card.profile),
+    };
+
+    return NextResponse.json(printPayload);
+  } catch (error) {
+    console.error("GET /api/dope-cards/[id]/print error:", error);
+    return NextResponse.json({ error: "Failed to generate print payload" }, { status: 500 });
+  }
+}

--- a/src/app/api/dope-cards/[id]/route.ts
+++ b/src/app/api/dope-cards/[id]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const prismaClient = prisma as unknown as {
+  dopeCard: {
+    findUnique: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+    delete: (args: unknown) => Promise<unknown>;
+  };
+};
+
+const toOptionalString = (value: unknown, maxLength: number) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (typeof value !== "string") return null;
+  return value.slice(0, maxLength);
+};
+
+const toOptionalNumber = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const parsed = parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toOptionalDate = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const toOptionalObject = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return typeof value === "object" && !Array.isArray(value) ? value : null;
+};
+
+const isNotFoundError = (error: unknown) => {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: string };
+  return candidate.code === "P2025";
+};
+
+// GET /api/dope-cards/[id]
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const card = await prismaClient.dopeCard.findUnique({
+      where: { id },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+      },
+    });
+
+    if (!card) {
+      return NextResponse.json({ error: "Dope card not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(card);
+  } catch (error) {
+    console.error("GET /api/dope-cards/[id] error:", error);
+    return NextResponse.json({ error: "Failed to fetch dope card" }, { status: 500 });
+  }
+}
+
+// PUT /api/dope-cards/[id]
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { firearmId, name, notes, zeroRangeYd, profile, confirmedAt } = body ?? {};
+
+    const card = await prismaClient.dopeCard.update({
+      where: { id },
+      data: {
+        firearmId: firearmId !== undefined ? firearmId || null : undefined,
+        name: toOptionalString(name, 200),
+        notes: toOptionalString(notes, 5000),
+        zeroRangeYd: toOptionalNumber(zeroRangeYd),
+        profile: toOptionalObject(profile),
+        confirmedAt: toOptionalDate(confirmedAt),
+      },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+      },
+    });
+
+    return NextResponse.json(card);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return NextResponse.json({ error: "Dope card not found" }, { status: 404 });
+    }
+    console.error("PUT /api/dope-cards/[id] error:", error);
+    return NextResponse.json({ error: "Failed to update dope card" }, { status: 500 });
+  }
+}
+
+// DELETE /api/dope-cards/[id]
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    await prismaClient.dopeCard.delete({ where: { id } });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return NextResponse.json({ error: "Dope card not found" }, { status: 404 });
+    }
+    console.error("DELETE /api/dope-cards/[id] error:", error);
+    return NextResponse.json({ error: "Failed to delete dope card" }, { status: 500 });
+  }
+}

--- a/src/app/api/dope-cards/route.ts
+++ b/src/app/api/dope-cards/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const prismaClient = prisma as unknown as {
+  dopeCard: {
+    findMany: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+};
+
+const toOptionalString = (value: unknown, maxLength: number) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (typeof value !== "string") return null;
+  return value.slice(0, maxLength);
+};
+
+const toOptionalNumber = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const parsed = parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toOptionalDate = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const toOptionalObject = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return typeof value === "object" && !Array.isArray(value) ? value : null;
+};
+
+// GET /api/dope-cards - List cards, optional ?firearmId= filter, optional ?limit=
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const firearmId = searchParams.get("firearmId");
+    const limitRaw = parseInt(searchParams.get("limit") ?? "", 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : undefined;
+
+    const cards = await prismaClient.dopeCard.findMany({
+      where: firearmId ? { firearmId } : undefined,
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: limit,
+    });
+
+    return NextResponse.json(cards);
+  } catch (error) {
+    console.error("GET /api/dope-cards error:", error);
+    return NextResponse.json({ error: "Failed to fetch dope cards" }, { status: 500 });
+  }
+}
+
+// POST /api/dope-cards - Create a new dope card
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { firearmId, name, notes, zeroRangeYd, profile, confirmedAt } = body ?? {};
+
+    if (!firearmId) {
+      return NextResponse.json({ error: "Missing required field: firearmId" }, { status: 400 });
+    }
+
+    const card = await prismaClient.dopeCard.create({
+      data: {
+        firearmId,
+        name: toOptionalString(name, 200),
+        notes: toOptionalString(notes, 5000),
+        zeroRangeYd: toOptionalNumber(zeroRangeYd),
+        profile: toOptionalObject(profile),
+        confirmedAt: toOptionalDate(confirmedAt),
+      },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+      },
+    });
+
+    return NextResponse.json(card, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/dope-cards error:", error);
+    return NextResponse.json({ error: "Failed to create dope card" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a RESTful API for managing dope cards consistent with existing app conventions (e.g. `range-sessions` endpoints). 
- Ensure input validation and consistent `undefined` vs `null` behavior for partial updates and created records. 
- Offer a print-safe representation that sanitizes nested profile data and strips secret-like keys.

### Description
- Add `src/app/api/dope-cards/route.ts` implementing `GET /api/dope-cards` with optional `firearmId` and `limit` filters and `POST /api/dope-cards` with required `firearmId` validation and input normalizers. 
- Add `src/app/api/dope-cards/[id]/route.ts` implementing `GET`, `PUT`, and `DELETE` for single-card operations, with `PUT` honoring `undefined` (leave unchanged) vs explicit `null`/empty (persist as `null`) semantics and mapping invalid values to `null`. 
- Add `src/app/api/dope-cards/[id]/print/route.ts` implementing `GET` that returns a sanitized print payload containing firearm summary and a depth/size-limited, secret-filtered `profile`. 
- Implement small helper normalizers (`toOptionalString`, `toOptionalNumber`, `toOptionalDate`, `toOptionalObject`) and a Prisma client narrowing to allow early implementation while keeping behavior consistent with other APIs.

### Testing
- Ran lint against the new files with `npm run lint -- src/app/api/dope-cards/route.ts src/app/api/dope-cards/[id]/route.ts src/app/api/dope-cards/[id]/print/route.ts`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30fabf844832681f4f6dc4fa8da4d)