### PR TITLE
Add DopeCard Prisma model and migration

### DIFF
--- a/prisma/migrations/20260312191141_add_dope_card/migration.sql
+++ b/prisma/migrations/20260312191141_add_dope_card/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "DopeCard" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "firearmId" TEXT NOT NULL,
+    "buildId" TEXT,
+    "ammoStockId" TEXT,
+    "name" TEXT NOT NULL,
+    "zeroDistanceYd" REAL NOT NULL,
+    "sightHeightIn" REAL,
+    "unit" TEXT NOT NULL,
+    "temperatureF" REAL,
+    "pressureInHg" REAL,
+    "densityAltitudeFt" REAL,
+    "notes" TEXT,
+    "rows" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "DopeCard_firearmId_fkey" FOREIGN KEY ("firearmId") REFERENCES "Firearm" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DopeCard_buildId_fkey" FOREIGN KEY ("buildId") REFERENCES "Build" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "DopeCard_ammoStockId_fkey" FOREIGN KEY ("ammoStockId") REFERENCES "AmmoStock" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "DopeCard_firearmId_idx" ON "DopeCard"("firearmId");
+
+-- CreateIndex
+CREATE INDEX "DopeCard_updatedAt_idx" ON "DopeCard"("updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Firearm {
   maintenanceNotes MaintenanceNote[]
   maintenanceSchedules MaintenanceSchedule[]
   documents       Document[]
+  dopeCards       DopeCard[]
 
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
@@ -54,6 +55,7 @@ model Build {
 
   slots       BuildSlot[]
   rangeSessions RangeSession[]
+  dopeCards     DopeCard[]
 
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
@@ -308,6 +310,7 @@ model AmmoStock {
   notes           String?
 
   transactions    AmmoTransaction[]
+  dopeCards       DopeCard[]
 
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
@@ -331,6 +334,40 @@ model AmmoTransaction {
 
   @@index([stockId])
   @@index([transactedAt])
+}
+
+// ─── DOPE CARDS ──────────────────────────────────────────────
+
+model DopeCard {
+  id                  String    @id @default(cuid())
+  firearmId           String
+  firearm             Firearm   @relation(fields: [firearmId], references: [id], onDelete: Cascade)
+  buildId             String?
+  build               Build?    @relation(fields: [buildId], references: [id], onDelete: SetNull)
+  ammoStockId         String?
+  ammoStock           AmmoStock? @relation(fields: [ammoStockId], references: [id], onDelete: SetNull)
+
+  name                String
+  zeroDistanceYd      Float
+  sightHeightIn       Float?
+  // unit: "MIL" | "MOA"
+  unit                String
+
+  temperatureF        Float?
+  pressureInHg        Float?
+  densityAltitudeFt   Float?
+  notes               String?
+
+  // Example row structure:
+  // [{"distanceYd": 100, "elevation": 0.0, "wind10mph": 0.4, "velocity": 2700, "energy": 2500}]
+  // JSON-encoded rows payload for SQLite compatibility
+  rows                String
+
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  @@index([firearmId])
+  @@index([updatedAt])
 }
 
 // ─── IMAGE CACHE ──────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Introduce a first-class DopeCard entity to persist ballistic/DOPE tables tied to firearms, builds, and ammo stocks.
- Provide a structured place for metadata, environmental conditions, and tabular rows for range/zeroing data.

### Description
- Added a new `DopeCard` model to `prisma/schema.prisma` with `id`, `firearmId`, optional `buildId`, optional `ammoStockId`, metadata fields (`name`, `zeroDistanceYd`, `sightHeightIn`, `unit`), condition fields (`temperatureF`, `pressureInHg`, `densityAltitudeFt`, `notes`), a `rows` field for the table payload, and `createdAt`/`updatedAt` timestamps.
- Implemented `rows` as a JSON-encoded `String` for SQLite compatibility (project uses Prisma + SQLite which does not support the `Json` scalar).
- Added reverse relations from `Firearm`, `Build`, and `AmmoStock` to `DopeCard` and indexed `firearmId` and `updatedAt` for query performance.
- Generated and applied a Prisma migration that creates the `DopeCard` table with foreign keys and indexes.

### Testing
- Ran the migration flow with `DATABASE_URL='file:./dev.db' npx prisma migrate dev --name add_dope_card`, which completed successfully and applied the new migration.
- Prisma Client generation ran successfully as part of the migrate step and the configured `prisma/seed.ts` executed successfully during the migrate command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30fae086c8326a4362d6c8a8927b7)