### PR TITLE
Add Ballistics DOPE card feature: library, UI, sidebar link, and tests

### DIFF
--- a/src/app/range/ballistics/page.tsx
+++ b/src/app/range/ballistics/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Crosshair, Wind, Gauge, Mountain, RotateCcw } from "lucide-react";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { buildDopeCard, type BallisticsInputs } from "@/lib/ballistics";
+
+const INPUT_CLASS =
+  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
+
+const DEFAULTS: BallisticsInputs = {
+  muzzleVelocityFps: 2650,
+  ballisticCoefficientG1: 0.47,
+  zeroRangeYards: 100,
+  sightHeightInches: 1.8,
+  windSpeedMph: 10,
+  temperatureF: 59,
+  altitudeFeet: 0,
+  startRangeYards: 100,
+  endRangeYards: 800,
+  stepYards: 50,
+};
+
+function fmt(value: number, digits = 2) {
+  return Number.isFinite(value) ? value.toFixed(digits) : "-";
+}
+
+export default function BallisticsPage() {
+  const [inputs, setInputs] = useState<BallisticsInputs>(DEFAULTS);
+
+  const rows = useMemo(() => buildDopeCard(inputs), [inputs]);
+
+  function updateNumber<K extends keyof BallisticsInputs>(key: K, value: string) {
+    const parsed = Number.parseFloat(value);
+    setInputs((prev) => ({ ...prev, [key]: Number.isFinite(parsed) ? parsed : 0 }));
+  }
+
+  return (
+    <div className="min-h-full">
+      <PageHeader
+        title="BALLISTICS DOPE CARD"
+        subtitle="Generate elevation and wind holds by distance for your load"
+      />
+
+      <div className="px-6 py-8 max-w-6xl mx-auto space-y-6">
+        <div className="grid lg:grid-cols-4 sm:grid-cols-2 gap-4">
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Muzzle Velocity (fps)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.muzzleVelocityFps} onChange={(e) => updateNumber("muzzleVelocityFps", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Ballistic Coefficient (G1)</span>
+            <input className={INPUT_CLASS} type="number" step="0.01" value={inputs.ballisticCoefficientG1} onChange={(e) => updateNumber("ballisticCoefficientG1", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Zero Range (yd)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.zeroRangeYards} onChange={(e) => updateNumber("zeroRangeYards", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Sight Height (in)</span>
+            <input className={INPUT_CLASS} type="number" step="0.1" value={inputs.sightHeightInches} onChange={(e) => updateNumber("sightHeightInches", e.target.value)} />
+          </label>
+        </div>
+
+        <div className="grid lg:grid-cols-4 sm:grid-cols-2 gap-4">
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Wind Speed (mph)</span>
+            <input className={INPUT_CLASS} type="number" step="0.5" value={inputs.windSpeedMph} onChange={(e) => updateNumber("windSpeedMph", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Temperature (°F)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.temperatureF} onChange={(e) => updateNumber("temperatureF", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Altitude (ft)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.altitudeFeet} onChange={(e) => updateNumber("altitudeFeet", e.target.value)} />
+          </label>
+          <button
+            type="button"
+            onClick={() => setInputs(DEFAULTS)}
+            className="self-end h-[38px] rounded-md border border-vault-border text-vault-text-muted hover:text-vault-text hover:border-vault-text-muted/40 transition-colors inline-flex items-center justify-center gap-2"
+          >
+            <RotateCcw className="w-4 h-4" /> Reset
+          </button>
+        </div>
+
+        <div className="grid lg:grid-cols-3 gap-4">
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Start Range (yd)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.startRangeYards} onChange={(e) => updateNumber("startRangeYards", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">End Range (yd)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.endRangeYards} onChange={(e) => updateNumber("endRangeYards", e.target.value)} />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[10px] font-medium uppercase tracking-widest text-vault-text-faint">Step (yd)</span>
+            <input className={INPUT_CLASS} type="number" value={inputs.stepYards} onChange={(e) => updateNumber("stepYards", e.target.value)} />
+          </label>
+        </div>
+
+        <div className="grid sm:grid-cols-3 gap-3">
+          <div className="rounded-lg border border-vault-border bg-vault-surface p-3">
+            <div className="text-vault-text-faint text-xs flex items-center gap-2"><Crosshair className="w-4 h-4 text-[#00C2FF]" /> Zero</div>
+            <p className="mt-1 text-lg font-mono text-vault-text">{fmt(inputs.zeroRangeYards, 0)} yd / {fmt(inputs.sightHeightInches, 1)} in</p>
+          </div>
+          <div className="rounded-lg border border-vault-border bg-vault-surface p-3">
+            <div className="text-vault-text-faint text-xs flex items-center gap-2"><Wind className="w-4 h-4 text-[#00C2FF]" /> Full Value Wind</div>
+            <p className="mt-1 text-lg font-mono text-vault-text">{fmt(inputs.windSpeedMph, 1)} mph</p>
+          </div>
+          <div className="rounded-lg border border-vault-border bg-vault-surface p-3">
+            <div className="text-vault-text-faint text-xs flex items-center gap-2"><Mountain className="w-4 h-4 text-[#00C2FF]" /> Atmosphere</div>
+            <p className="mt-1 text-lg font-mono text-vault-text">{fmt(inputs.temperatureF, 0)}°F / {fmt(inputs.altitudeFeet, 0)} ft</p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-vault-border bg-vault-surface overflow-hidden">
+          <div className="px-4 py-3 border-b border-vault-border flex items-center gap-2 text-xs uppercase tracking-widest text-vault-text-faint">
+            <Gauge className="w-4 h-4 text-[#00C2FF]" /> DOPE Card
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-vault-bg/70 text-vault-text-faint text-xs uppercase tracking-wider">
+                <tr>
+                  <th className="text-left px-3 py-2">Range (yd)</th>
+                  <th className="text-right px-3 py-2">Drop (in)</th>
+                  <th className="text-right px-3 py-2">Drift (in)</th>
+                  <th className="text-right px-3 py-2">Elev (MIL)</th>
+                  <th className="text-right px-3 py-2">Wind (MIL)</th>
+                  <th className="text-right px-3 py-2">Elev (MOA)</th>
+                  <th className="text-right px-3 py-2">Wind (MOA)</th>
+                  <th className="text-right px-3 py-2">Vel (fps)</th>
+                  <th className="text-right px-3 py-2">TOF (s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.rangeYards} className="border-t border-vault-border/70">
+                    <td className="px-3 py-2 font-mono text-vault-text">{row.rangeYards}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text">{fmt(row.dropInches, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text">{fmt(row.driftInches, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-[#00C2FF]">{fmt(row.elevationMil, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-[#00C2FF]">{fmt(row.windMil, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text-muted">{fmt(row.elevationMoa, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text-muted">{fmt(row.windMoa, 2)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text">{fmt(row.velocityFps, 0)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-vault-text">{fmt(row.timeOfFlightSec, 3)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,6 +76,7 @@ const NAV_ITEMS: NavItem[] = [
       { label: "Drill Performance", href: "/range/drill-performance", icon: TrendingUp },
       { label: "Drill Library", href: "/range/drills", icon: BookOpen },
       { label: "Hit Factor Calc", href: "/range/hit-factor", icon: Calculator },
+      { label: "Ballistics DOPE", href: "/range/ballistics", icon: Crosshair },
     ],
   },
   {

--- a/src/lib/__tests__/ballistics.test.ts
+++ b/src/lib/__tests__/ballistics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildDopeCard } from "@/lib/ballistics";
+
+describe("buildDopeCard", () => {
+  it("returns a row at the zero range with near-zero elevation correction", () => {
+    const rows = buildDopeCard({
+      muzzleVelocityFps: 2650,
+      ballisticCoefficientG1: 0.47,
+      zeroRangeYards: 100,
+      sightHeightInches: 1.8,
+      windSpeedMph: 10,
+      temperatureF: 59,
+      altitudeFeet: 1200,
+      startRangeYards: 100,
+      endRangeYards: 100,
+      stepYards: 25,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(Math.abs(rows[0].elevationMil)).toBeLessThan(0.05);
+  });
+
+  it("increases drop and decreases velocity as range increases", () => {
+    const rows = buildDopeCard({
+      muzzleVelocityFps: 2800,
+      ballisticCoefficientG1: 0.5,
+      zeroRangeYards: 100,
+      sightHeightInches: 1.9,
+      windSpeedMph: 10,
+      temperatureF: 70,
+      altitudeFeet: 0,
+      startRangeYards: 100,
+      endRangeYards: 500,
+      stepYards: 100,
+    });
+
+    expect(rows).toHaveLength(5);
+    expect(rows.at(-1)?.dropInches ?? 0).toBeGreaterThan(rows[0].dropInches);
+    expect(rows.at(-1)?.velocityFps ?? 99999).toBeLessThan(rows[0].velocityFps);
+    expect(rows.at(-1)?.timeOfFlightSec ?? 0).toBeGreaterThan(rows[0].timeOfFlightSec);
+  });
+});

--- a/src/lib/ballistics.ts
+++ b/src/lib/ballistics.ts
@@ -1,0 +1,140 @@
+export interface BallisticsInputs {
+  muzzleVelocityFps: number;
+  ballisticCoefficientG1: number;
+  zeroRangeYards: number;
+  sightHeightInches: number;
+  windSpeedMph: number;
+  temperatureF: number;
+  altitudeFeet: number;
+  startRangeYards: number;
+  endRangeYards: number;
+  stepYards: number;
+}
+
+export interface DopeRow {
+  rangeYards: number;
+  dropInches: number;
+  driftInches: number;
+  elevationMil: number;
+  windMil: number;
+  elevationMoa: number;
+  windMoa: number;
+  velocityFps: number;
+  timeOfFlightSec: number;
+}
+
+const GRAVITY_FTPS2 = 32.174;
+const SEA_LEVEL_DENSITY = 1.225;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toRad(deg: number) {
+  return (deg * Math.PI) / 180;
+}
+
+function airDensityKgM3(temperatureF: number, altitudeFeet: number): number {
+  const tempC = (temperatureF - 32) * (5 / 9);
+  const tempK = tempC + 273.15;
+  const altitudeMeters = altitudeFeet * 0.3048;
+  const pressure = 101325 * Math.pow(1 - 2.25577e-5 * altitudeMeters, 5.25588);
+  const density = pressure / (287.05 * tempK);
+  return clamp(density, 0.7, 1.35);
+}
+
+function dragKPerFoot(bcG1: number, densityKgM3: number): number {
+  const densityRatio = densityKgM3 / SEA_LEVEL_DENSITY;
+  const normalizedBc = clamp(bcG1, 0.1, 1.2);
+  return (0.00004 * densityRatio) / normalizedBc;
+}
+
+function velocityAtRange(v0: number, kPerFoot: number, rangeFeet: number): number {
+  if (kPerFoot <= 0) return v0;
+  return v0 * Math.exp(-kPerFoot * rangeFeet);
+}
+
+function timeOfFlight(v0: number, kPerFoot: number, rangeFeet: number): number {
+  if (kPerFoot <= 0) return rangeFeet / v0;
+  return (Math.exp(kPerFoot * rangeFeet) - 1) / (kPerFoot * v0);
+}
+
+function bulletHeightAboveBoreInches(
+  thetaRad: number,
+  v0: number,
+  kPerFoot: number,
+  rangeFeet: number,
+): number {
+  const t = timeOfFlight(v0, kPerFoot, rangeFeet);
+  const verticalFromAngleFt = rangeFeet * Math.tan(thetaRad);
+  const dropFt = 0.5 * GRAVITY_FTPS2 * t * t;
+  return (verticalFromAngleFt - dropFt) * 12;
+}
+
+function solveMuzzleAngleRad(
+  v0: number,
+  kPerFoot: number,
+  zeroRangeFeet: number,
+  sightHeightInches: number,
+): number {
+  let low = toRad(-2);
+  let high = toRad(4);
+
+  for (let i = 0; i < 60; i += 1) {
+    const mid = (low + high) / 2;
+    const yMid = bulletHeightAboveBoreInches(mid, v0, kPerFoot, zeroRangeFeet);
+
+    if (yMid > sightHeightInches) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return (low + high) / 2;
+}
+
+export function buildDopeCard(inputs: BallisticsInputs): DopeRow[] {
+  const density = airDensityKgM3(inputs.temperatureF, inputs.altitudeFeet);
+  const k = dragKPerFoot(inputs.ballisticCoefficientG1, density);
+  const muzzleAngle = solveMuzzleAngleRad(
+    inputs.muzzleVelocityFps,
+    k,
+    inputs.zeroRangeYards * 3,
+    inputs.sightHeightInches,
+  );
+
+  const rows: DopeRow[] = [];
+
+  for (let rangeYards = inputs.startRangeYards; rangeYards <= inputs.endRangeYards; rangeYards += inputs.stepYards) {
+    const rangeFeet = rangeYards * 3;
+    const time = timeOfFlight(inputs.muzzleVelocityFps, k, rangeFeet);
+    const yInches = bulletHeightAboveBoreInches(muzzleAngle, inputs.muzzleVelocityFps, k, rangeFeet);
+    const offsetFromLosInches = yInches - inputs.sightHeightInches;
+
+    const windFps = inputs.windSpeedMph * 1.46667;
+    const driftInches = windFps * time * 12 * 0.15;
+
+    const milScaleInches = (rangeYards / 100) * 3.6;
+    const moaScaleInches = (rangeYards / 100) * 1.047;
+
+    const elevationMil = rangeYards > 0 ? -offsetFromLosInches / milScaleInches : 0;
+    const windMil = rangeYards > 0 ? driftInches / milScaleInches : 0;
+    const elevationMoa = rangeYards > 0 ? -offsetFromLosInches / moaScaleInches : 0;
+    const windMoa = rangeYards > 0 ? driftInches / moaScaleInches : 0;
+
+    rows.push({
+      rangeYards,
+      dropInches: -offsetFromLosInches,
+      driftInches,
+      elevationMil,
+      windMil,
+      elevationMoa,
+      windMoa,
+      velocityFps: velocityAtRange(inputs.muzzleVelocityFps, k, rangeFeet),
+      timeOfFlightSec: time,
+    });
+  }
+
+  return rows;
+}


### PR DESCRIPTION
### Motivation

- Provide an in-app Ballistics DOPE card generator to compute elevation and wind holds across ranges for rifle loads and expose it in the Training/Range area.

### Description

- Introduces a new ballistics library `src/lib/ballistics.ts` which defines `BallisticsInputs`, `DopeRow`, and `buildDopeCard` with simplified physics (air density, drag, velocity decay, time-of-flight, and muzzle-angle solving).
- Adds a client React page `src/app/range/ballistics/page.tsx` that renders input controls, summary cards, and a scrollable DOPE table using `buildDopeCard` and a `Reset` action.
- Adds a navigation entry to the sidebar in `src/components/layout/Sidebar.tsx` linking to `/range/ballistics` with an appropriate icon and label.
- Adds unit tests `src/lib/__tests__/ballistics.test.ts` covering zero-range behavior and monotonic drop/velocity changes across ranges.

### Testing

- Ran the unit tests with `vitest` which executed the new `buildDopeCard` tests in `src/lib/__tests__/ballistics.test.ts` and they passed.
- Verified the new UI code compiles in the app build and the page renders without runtime type errors during local development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30ecba4f48326812be57b542ce133)