### PR TITLE
Add automated unresolved merge-conflict marker check

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "db:reset": "prisma migrate reset"
+    "db:reset": "prisma migrate reset",
+    "check:merge-conflicts": "./scripts/check-merge-conflicts.sh"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/check-merge-conflicts.sh
+++ b/scripts/check-merge-conflicts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if rg -n --hidden --no-ignore \
+  "^(<<<<<<<|>>>>>>>|\|\|\|\|\|\|\|)( .*)?$" \
+  --glob '!.git/**' \
+  --glob '!node_modules/**' \
+  --glob '!package-lock.json' \
+  .; then
+  echo "\n❌ Merge conflict markers found. Resolve them before merging."
+  exit 1
+fi
+
+echo "✅ No unresolved merge conflict markers found."


### PR DESCRIPTION
### Motivation
- Prevent unresolved merge conflict markers from being merged by adding a fast, repeatable check that can run locally or in CI.

### Description
- Add `scripts/check-merge-conflicts.sh` which scans tracked files (excluding `.git` and `node_modules`) for `<<<<<<<`, `>>>>>>>`, and `|||||||` markers and add an npm script `check:merge-conflicts` to `package.json` to run the check.

### Testing
- Ran `npm run check:merge-conflicts` which passed, `npm test` (Vitest) which passed all tests, and `npm run lint` (ESLint) which passed; note that `npm test -- --runInBand` fails because Vitest does not support the `--runInBand` option.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b312730aec8326843937f683cdcb5f)