### PR TITLE
Add one-click GitHub pull updates in Settings

### DIFF
--- a/src/app/api/system-update/route.ts
+++ b/src/app/api/system-update/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(args: string[]) {
+  return execFileAsync("git", args, {
+    cwd: process.cwd(),
+    maxBuffer: 1024 * 1024,
+  });
+}
+
+export async function POST() {
+  try {
+    const insideRepo = await runGit(["rev-parse", "--is-inside-work-tree"]);
+    if (insideRepo.stdout.trim() !== "true") {
+      return NextResponse.json({ error: "Application is not running from a Git repository." }, { status: 400 });
+    }
+
+    const branchResult = await runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+    const branch = branchResult.stdout.trim();
+
+    const remoteResult = await runGit(["remote", "get-url", "origin"]);
+    const remote = remoteResult.stdout.trim();
+
+    const pullResult = await runGit(["pull", "--ff-only", "origin", branch]);
+    const output = `${pullResult.stdout}${pullResult.stderr}`.trim();
+
+    return NextResponse.json({
+      branch,
+      remote,
+      output: output || "Already up to date.",
+      message: "Git update completed. Restart the app if dependencies or runtime files changed.",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to pull updates from GitHub.";
+    return NextResponse.json(
+      {
+        error: "Failed to pull updates from GitHub.",
+        details: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -85,6 +85,9 @@ export default function SettingsPage() {
   const [autoBackupStatus, setAutoBackupStatus] = useState<string | null>(null);
   const [autoBackupError, setAutoBackupError] = useState<string | null>(null);
   const [autoBackupRunning, setAutoBackupRunning] = useState(false);
+  const [updateBusy, setUpdateBusy] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [updateOutput, setUpdateOutput] = useState<string | null>(null);
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -443,6 +446,33 @@ export default function SettingsPage() {
       setAutoBackupRunning(false);
     }
   }, [includeDocumentFilesInBackup]);
+
+  async function handlePullUpdates() {
+    setUpdateBusy(true);
+    setUpdateError(null);
+    setUpdateOutput(null);
+
+    try {
+      const res = await fetch("/api/system-update", { method: "POST" });
+      const json = await res.json();
+
+      if (!res.ok) {
+        const details = typeof json.details === "string" ? `\n\n${json.details}` : "";
+        setUpdateError(`${json.error ?? "Failed to pull updates from GitHub."}${details}`);
+        return;
+      }
+
+      const remoteLine = json.remote ? `Remote: ${json.remote}` : null;
+      const branchLine = json.branch ? `Branch: ${json.branch}` : null;
+      const outputLine = json.output ? `\n\n${json.output}` : "";
+      const header = [remoteLine, branchLine].filter(Boolean).join("\n");
+      setUpdateOutput(`${header}${outputLine}`.trim());
+    } catch {
+      setUpdateError("Network error. Please try again.");
+    } finally {
+      setUpdateBusy(false);
+    }
+  }
 
   useEffect(() => {
     if (!autoBackupEnabled) return;
@@ -904,6 +934,49 @@ export default function SettingsPage() {
                 Ensure the container port is mapped with <code className="font-mono">-p 3000:3000</code> or equivalent in docker-compose.yml.
               </p>
             </div>
+          </fieldset>
+
+          {/* ── GitHub Updates ─────────────────────────────── */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+              <DownloadCloud className="w-3.5 h-3.5" />
+              GitHub Updates
+            </legend>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              Pull the latest commits from your configured <code className="font-mono text-vault-text-faint">origin</code> remote with one click.
+            </p>
+
+            {updateError && (
+              <div className="flex items-start gap-2 rounded-md border border-[#E53935]/30 bg-[#E53935]/10 px-3 py-2">
+                <AlertCircle className="h-3.5 w-3.5 text-[#E53935] mt-0.5 shrink-0" />
+                <p className="text-xs text-[#E53935] whitespace-pre-wrap">{updateError}</p>
+              </div>
+            )}
+
+            {updateOutput && (
+              <div className="rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2 space-y-2">
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-[#00C853]" />
+                  <p className="text-xs text-[#00C853]">Update check completed.</p>
+                </div>
+                <pre className="text-[11px] text-vault-text-faint whitespace-pre-wrap break-words font-mono">{updateOutput}</pre>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={handlePullUpdates}
+              disabled={updateBusy}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 disabled:cursor-not-allowed text-xs transition-colors"
+            >
+              {updateBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
+              {updateBusy ? "Pulling updates..." : "Pull Updates from GitHub"}
+            </button>
+
+            <p className="text-[11px] text-vault-text-faint">
+              This performs a fast-forward-only <code className="font-mono">git pull origin &lt;current-branch&gt;</code>. If files changed, restart BlackVault to apply updates.
+            </p>
           </fieldset>
 
           {/* ── Setup Wizard ───────────────────────────────── */}


### PR DESCRIPTION
### Motivation
- Provide a simple, one-click way for a running instance to pull updates from the configured `origin` Git remote so administrators can fetch new commits without shelling into the host.
- Surface the update result (branch, remote, and pull output) in the Settings UI so the operator can see success or failure details.

### Description
- Added a new backend API route `POST /api/system-update` implemented in `src/app/api/system-update/route.ts` that verifies the app is inside a Git repository, detects the current branch and `origin` URL, runs a fast-forward-only pull (`git pull --ff-only origin <branch>`), and returns structured output or an error payload.
- Extended the Settings UI in `src/app/settings/page.tsx` with new state (`updateBusy`, `updateError`, `updateOutput`), a `handlePullUpdates` handler that calls the new API, and a new **GitHub Updates** fieldset containing a single-click `Pull Updates from GitHub` button and success/error output panel.
- The UI presents readable diagnostics returned by the API (remote, branch, and pull output) and shows a note indicating a restart is required if files changed.

### Testing
- Ran lint with `npm run lint`, which completed successfully.
- Ran unit tests with `npm run test` (Vitest), and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4077208a083268a8eb5c0f6dfd156)