### PR TITLE
Handle invalid/empty dope correction inputs safely

### DIFF
--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -15,6 +15,14 @@ const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
 const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
 
+function parseOptionalNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export default function DopeCardPage() {
   const [startYd, setStartYd] = useState("100");
   const [endYd, setEndYd] = useState("800");
@@ -52,13 +60,31 @@ export default function DopeCardPage() {
   }
 
   function updateCorrection(distanceYd: number, patch: DopeRowCorrection) {
+    const existing = corrections[distanceYd] ?? {};
+    const merged: DopeRowCorrection = {
+      ...existing,
+      ...patch,
+    };
+
+    if (patch.dropIn === undefined) {
+      delete merged.dropIn;
+    }
+
+    if (patch.windIn === undefined) {
+      delete merged.windIn;
+    }
+
+    const hasAnyCorrection =
+      merged.dropIn !== undefined || merged.windIn !== undefined || merged.confirmed !== undefined;
     const nextCorrections = {
       ...corrections,
-      [distanceYd]: {
-        ...corrections[distanceYd],
-        ...patch,
-      },
+      ...(hasAnyCorrection ? { [distanceYd]: merged } : {}),
     };
+
+    if (!hasAnyCorrection) {
+      delete nextCorrections[distanceYd];
+    }
+
     setCorrections(nextCorrections);
     setRows((prev) => applyDopeCorrections(prev, nextCorrections));
   }
@@ -146,8 +172,9 @@ export default function DopeCardPage() {
                         type="number"
                         step="0.01"
                         className={`${INPUT_CLASS} min-w-[110px]`}
-                        value={corrections[row.distanceYd]?.dropIn ?? row.dropIn}
-                        onChange={(e) => updateCorrection(row.distanceYd, { dropIn: Number(e.target.value) })}
+                        value={corrections[row.distanceYd]?.dropIn ?? ""}
+                        placeholder={String(row.dropIn)}
+                        onChange={(e) => updateCorrection(row.distanceYd, { dropIn: parseOptionalNumber(e.target.value) })}
                       />
                     </td>
                     <td className="px-3 py-2 font-mono">{row.dropMil.toFixed(2)}</td>
@@ -157,8 +184,9 @@ export default function DopeCardPage() {
                         type="number"
                         step="0.01"
                         className={`${INPUT_CLASS} min-w-[110px]`}
-                        value={corrections[row.distanceYd]?.windIn ?? row.windIn}
-                        onChange={(e) => updateCorrection(row.distanceYd, { windIn: Number(e.target.value) })}
+                        value={corrections[row.distanceYd]?.windIn ?? ""}
+                        placeholder={String(row.windIn)}
+                        onChange={(e) => updateCorrection(row.distanceYd, { windIn: parseOptionalNumber(e.target.value) })}
                       />
                     </td>
                     <td className="px-3 py-2 font-mono">{row.windMil.toFixed(2)}</td>

--- a/src/lib/__tests__/dope.test.ts
+++ b/src/lib/__tests__/dope.test.ts
@@ -33,6 +33,23 @@ describe("convertDropWindToAngular", () => {
       confirmed: false,
     });
   });
+
+  it("coerces invalid drop/wind values to 0 so angular values stay finite", () => {
+    const rows = convertDropWindToAngular([{ distanceYd: 200, dropIn: Number.NaN, windIn: Number.POSITIVE_INFINITY }]);
+
+    expect(rows[0]).toMatchObject({
+      dropIn: 0,
+      windIn: 0,
+      dropMil: 0,
+      dropMoa: 0,
+      windMil: 0,
+      windMoa: 0,
+    });
+    expect(Number.isNaN(rows[0].dropMil)).toBe(false);
+    expect(Number.isNaN(rows[0].dropMoa)).toBe(false);
+    expect(Number.isNaN(rows[0].windMil)).toBe(false);
+    expect(Number.isNaN(rows[0].windMoa)).toBe(false);
+  });
 });
 
 describe("applyDopeCorrections", () => {
@@ -48,5 +65,25 @@ describe("applyDopeCorrections", () => {
       dropMil: 1.11,
       confirmed: true,
     });
+  });
+
+  it("falls back to generated values when correction fields are undefined", () => {
+    const generated = convertDropWindToAngular([{ distanceYd: 300, dropIn: 9, windIn: 6 }]);
+    const corrected = applyDopeCorrections(generated, {
+      300: { dropIn: undefined, windIn: undefined },
+    });
+
+    expect(corrected[0]).toMatchObject({
+      dropIn: 9,
+      windIn: 6,
+      dropMil: 0.83,
+      dropMoa: 2.87,
+      windMil: 0.56,
+      windMoa: 1.91,
+    });
+    expect(Number.isNaN(corrected[0].dropMil)).toBe(false);
+    expect(Number.isNaN(corrected[0].dropMoa)).toBe(false);
+    expect(Number.isNaN(corrected[0].windMil)).toBe(false);
+    expect(Number.isNaN(corrected[0].windMoa)).toBe(false);
   });
 });

--- a/src/lib/ballistics/dope.ts
+++ b/src/lib/ballistics/dope.ts
@@ -38,6 +38,11 @@ function toMoa(inches: number, distanceYd: number): number {
   return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MOA);
 }
 
+function safeInches(value: number): number {
+  // Keep conversions stable even if a caller passes invalid correction/input values.
+  return Number.isFinite(value) ? value : 0;
+}
+
 export function generateDistanceRows(startYd: number, endYd: number, stepYd: number): DistanceRow[] {
   if (!Number.isFinite(startYd) || !Number.isFinite(endYd) || !Number.isFinite(stepYd)) {
     return [];
@@ -63,14 +68,21 @@ export function generateDistanceRows(startYd: number, endYd: number, stepYd: num
 export function convertDropWindToAngular(rows: BallisticOutputRow[]): AngularDopeRow[] {
   return rows
     .filter((row) => row.distanceYd > 0)
-    .map((row) => ({
-      ...row,
-      dropMil: roundTo(toMil(row.dropIn, row.distanceYd), 2),
-      dropMoa: roundTo(toMoa(row.dropIn, row.distanceYd), 2),
-      windMil: roundTo(toMil(row.windIn, row.distanceYd), 2),
-      windMoa: roundTo(toMoa(row.windIn, row.distanceYd), 2),
-      confirmed: false,
-    }));
+    .map((row) => {
+      const dropIn = safeInches(row.dropIn);
+      const windIn = safeInches(row.windIn);
+
+      return {
+        ...row,
+        dropIn,
+        windIn,
+        dropMil: roundTo(toMil(dropIn, row.distanceYd), 2),
+        dropMoa: roundTo(toMoa(dropIn, row.distanceYd), 2),
+        windMil: roundTo(toMil(windIn, row.distanceYd), 2),
+        windMoa: roundTo(toMoa(windIn, row.distanceYd), 2),
+        confirmed: false,
+      };
+    });
 }
 
 export function applyDopeCorrections(
@@ -81,8 +93,8 @@ export function applyDopeCorrections(
     const correction = correctionsByDistance[row.distanceYd];
     if (!correction) return row;
 
-    const dropIn = correction.dropIn ?? row.dropIn;
-    const windIn = correction.windIn ?? row.windIn;
+    const dropIn = safeInches(correction.dropIn ?? row.dropIn);
+    const windIn = safeInches(correction.windIn ?? row.windIn);
 
     return {
       ...row,


### PR DESCRIPTION
### Motivation
- Correction input fields could produce blank, `NaN`, or `Infinity` values which propagated into angular conversions and produced `NaN` outputs. 
- Blanking a correction previously could not reliably remove an override and fall back to generated values.

### Description
- Add `parseOptionalNumber(value: string): number | undefined` in `src/app/range/dope-card/page.tsx` to trim input and return `undefined` for empty or non-finite values. 
- Update correction `<input>` handlers for `dropIn` and `windIn` to call `parseOptionalNumber` and use the generated value as a `placeholder` when no override is present. 
- Change `updateCorrection` to merge patches, remove `dropIn`/`windIn` keys when the patch sets them to `undefined`, and remove the per-distance override entirely if no fields remain so generated values are used. 
- Add `safeInches` in `src/lib/ballistics/dope.ts` and coerce non-finite `dropIn`/`windIn` to `0` in both `convertDropWindToAngular` and `applyDopeCorrections` to prevent `NaN` angular outputs. 
- Add tests in `src/lib/__tests__/dope.test.ts` that verify coercion of invalid inputs and that undefined correction fields fall back to generated values while asserting no `NaN` in `dropMil`, `dropMoa`, `windMil`, or `windMoa`.

### Testing
- Ran `npm test -- src/lib/__tests__/dope.test.ts`, and all tests passed (`6` tests passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b408e718d483268b6d6719ffca7185)