### PR TITLE
Avoid floating-point edge bugs in generateDistanceRows

### DIFF
--- a/src/lib/__tests__/dope.test.ts
+++ b/src/lib/__tests__/dope.test.ts
@@ -20,6 +20,18 @@ describe("generateDistanceRows", () => {
     expect(generateDistanceRows(600, 100, 100)).toEqual([]);
     expect(generateDistanceRows(100, 600, 0)).toEqual([]);
   });
+
+
+  it("handles decimal ranges without duplicating end distance and keeps order", () => {
+    const rows = generateDistanceRows(100, 550, 33.3);
+
+    expect(rows[rows.length - 1]).toEqual({ distanceYd: 550 });
+    expect(rows.filter((row) => row.distanceYd === 550)).toHaveLength(1);
+
+    for (let index = 1; index < rows.length; index += 1) {
+      expect(rows[index].distanceYd).toBeGreaterThan(rows[index - 1].distanceYd);
+    }
+  });
 });
 
 describe("convertDropWindToAngular", () => {

--- a/src/lib/ballistics/dope.ts
+++ b/src/lib/ballistics/dope.ts
@@ -24,6 +24,7 @@ export interface DopeRowCorrection {
 
 const INCHES_PER_100YD_PER_MIL = 3.6;
 const INCHES_PER_100YD_PER_MOA = 1.047;
+const DISTANCE_EPSILON = 1e-6;
 
 function roundTo(value: number, digits: number): number {
   const factor = 10 ** digits;
@@ -47,17 +48,28 @@ export function generateDistanceRows(startYd: number, endYd: number, stepYd: num
     return [];
   }
 
+  const normalizedEndYd = roundTo(endYd, 4);
   const rows: DistanceRow[] = [];
+
   for (let distance = startYd; distance <= endYd; distance += stepYd) {
-    rows.push({ distanceYd: roundTo(distance, 4) });
+    const normalizedDistance = roundTo(distance, 4);
+    rows.push({ distanceYd: normalizedDistance });
   }
 
-  const hasExactEnd = rows.length > 0 && rows[rows.length - 1].distanceYd === endYd;
+  const hasExactEnd =
+    rows.length > 0 &&
+    Math.abs(rows[rows.length - 1].distanceYd - normalizedEndYd) < DISTANCE_EPSILON;
+
   if (!hasExactEnd) {
-    rows.push({ distanceYd: endYd });
+    rows.push({ distanceYd: normalizedEndYd });
   }
 
-  return rows;
+  return rows
+    .sort((a, b) => a.distanceYd - b.distanceYd)
+    .filter((row, index, allRows) => {
+      if (index === 0) return true;
+      return Math.abs(row.distanceYd - allRows[index - 1].distanceYd) >= DISTANCE_EPSILON;
+    });
 }
 
 export function convertDropWindToAngular(rows: BallisticOutputRow[]): AngularDopeRow[] {


### PR DESCRIPTION
### Motivation
- Floating-point loop accumulation could miss or duplicate the exact `endYd` and produce non-monotonic or duplicated rows for decimal steps. 
- Equality checks against raw loop values are brittle for fractional steps like `33.3` and need normalization and tolerance. 

### Description
- Introduced `DISTANCE_EPSILON` and use `roundTo(..., 4)` to normalize both loop-generated distances and `endYd` before comparisons. 
- Reworked `generateDistanceRows` to push rounded loop values, compare the final entry to the rounded `endYd` using the epsilon, and append the normalized end only when needed. 
- Ensure the final result is sorted and de-duplicated using the epsilon-based comparison so the end row appears exactly once. 
- Added a test in `src/lib/__tests__/dope.test.ts` that exercises a decimal-stepped range (`start=100`, `end=550`, `step=33.3`) and asserts a single end distance and strictly increasing rows. 

### Testing
- Ran `npm test -- src/lib/__tests__/dope.test.ts` and the test file passed with all tests green (1 file, 5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b408e8a4bc83268c4890a7b17c038c)