### PR TITLE
Add nonlinear ballistics solver to DOPE card generator

### DIFF
--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -9,6 +9,7 @@ import {
   type AngularDopeRow,
   type DopeRowCorrection,
 } from "@/lib/ballistics/dope";
+import { solveTrajectoryRows, type DragModel } from "@/lib/ballistics/solver";
 import { Calculator, Target } from "lucide-react";
 
 const INPUT_CLASS =
@@ -20,11 +21,22 @@ export default function DopeCardPage() {
   const [endYd, setEndYd] = useState("800");
   const [stepYd, setStepYd] = useState("100");
 
-  const [dropPer100YdIn, setDropPer100YdIn] = useState("3.5");
-  const [windPer100YdIn, setWindPer100YdIn] = useState("1.2");
+  const [muzzleVelocityFps, setMuzzleVelocityFps] = useState("2650");
+  const [ballisticCoefficient, setBallisticCoefficient] = useState("0.275");
+  const [dragModel, setDragModel] = useState<DragModel>("G7");
+  const [zeroRangeYd, setZeroRangeYd] = useState("100");
+  const [sightHeightIn, setSightHeightIn] = useState("1.9");
+  const [twistIn, setTwistIn] = useState("8");
+  const [temperatureF, setTemperatureF] = useState("59");
+  const [pressureInHg, setPressureInHg] = useState("29.92");
+  const [densityAltitudeFt, setDensityAltitudeFt] = useState("");
+  const [humidityPercent, setHumidityPercent] = useState("45");
+  const [windSpeedMph, setWindSpeedMph] = useState("10");
+  const [windAngleDeg, setWindAngleDeg] = useState("90");
 
   const [rows, setRows] = useState<AngularDopeRow[]>([]);
   const [corrections, setCorrections] = useState<Record<number, DopeRowCorrection>>({});
+  const estimationModel = "Physics-based nonlinear stepper";
 
   const estimateSummary = useMemo(() => {
     if (!rows.length) return null;
@@ -33,22 +45,24 @@ export default function DopeCardPage() {
   }, [rows]);
 
   function handleGenerate() {
-    const start = Number(startYd);
-    const end = Number(endYd);
-    const step = Number(stepYd);
-    const dropRate = Number(dropPer100YdIn);
-    const windRate = Number(windPer100YdIn);
+    const distanceRows = generateDistanceRows(Number(startYd), Number(endYd), Number(stepYd));
+    const solvedRows = solveTrajectoryRows(distanceRows, {
+      muzzleVelocityFps: Number(muzzleVelocityFps),
+      ballisticCoefficient: Number(ballisticCoefficient),
+      dragModel,
+      zeroRangeYd: Number(zeroRangeYd),
+      sightHeightIn: Number(sightHeightIn),
+      twistIn: Number(twistIn),
+      temperatureF: Number(temperatureF),
+      pressureInHg: Number(pressureInHg),
+      densityAltitudeFt: densityAltitudeFt ? Number(densityAltitudeFt) : undefined,
+      humidityPercent: Number(humidityPercent),
+      windSpeedMph: Number(windSpeedMph),
+      windAngleDeg: Number(windAngleDeg),
+    });
 
-    const distanceRows = generateDistanceRows(start, end, step);
-    const estimatedRows = distanceRows.map(({ distanceYd }) => ({
-      distanceYd,
-      dropIn: Number(((distanceYd / 100) * dropRate).toFixed(2)),
-      windIn: Number(((distanceYd / 100) * windRate).toFixed(2)),
-    }));
-
-    const converted = convertDropWindToAngular(estimatedRows);
     setCorrections({});
-    setRows(converted);
+    setRows(convertDropWindToAngular(solvedRows));
   }
 
   function updateCorrection(distanceYd: number, patch: DopeRowCorrection) {
@@ -71,10 +85,11 @@ export default function DopeCardPage() {
       />
 
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
-        <div className="bg-[#F5A623]/10 border border-[#F5A623]/30 rounded-lg p-4">
+        <div className="bg-[#F5A623]/10 border border-[#F5A623]/30 rounded-lg p-4 space-y-1">
           <p className="text-sm text-[#F5A623] font-medium">
             Estimate only: this builder is a starting point and is not a replacement for verified firing data.
           </p>
+          <p className="text-xs text-vault-text-muted">Estimation model: {estimationModel}</p>
         </div>
 
         <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
@@ -83,7 +98,7 @@ export default function DopeCardPage() {
             <h2 className="text-xs uppercase tracking-widest text-[#00C2FF] font-mono">Auto-Populate Estimates</h2>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
             <div>
               <label className={LABEL_CLASS}>Start (yd)</label>
               <input value={startYd} onChange={(e) => setStartYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
@@ -97,12 +112,55 @@ export default function DopeCardPage() {
               <input value={stepYd} onChange={(e) => setStepYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
             </div>
             <div>
-              <label className={LABEL_CLASS}>Est. Drop / 100yd (in)</label>
-              <input value={dropPer100YdIn} onChange={(e) => setDropPer100YdIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+              <label className={LABEL_CLASS}>Drag Model</label>
+              <select value={dragModel} onChange={(e) => setDragModel(e.target.value as DragModel)} className={INPUT_CLASS}>
+                <option value="G1">G1</option>
+                <option value="G7">G7</option>
+              </select>
             </div>
             <div>
-              <label className={LABEL_CLASS}>Est. Wind / 100yd (in)</label>
-              <input value={windPer100YdIn} onChange={(e) => setWindPer100YdIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+              <label className={LABEL_CLASS}>Muzzle Velocity (fps)</label>
+              <input value={muzzleVelocityFps} onChange={(e) => setMuzzleVelocityFps(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>BC</label>
+              <input value={ballisticCoefficient} onChange={(e) => setBallisticCoefficient(e.target.value)} type="number" step="0.001" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Zero Range (yd)</label>
+              <input value={zeroRangeYd} onChange={(e) => setZeroRangeYd(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Sight Height (in)</label>
+              <input value={sightHeightIn} onChange={(e) => setSightHeightIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Twist (in/rev)</label>
+              <input value={twistIn} onChange={(e) => setTwistIn(e.target.value)} type="number" step="0.1" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Temp (°F)</label>
+              <input value={temperatureF} onChange={(e) => setTemperatureF(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Pressure (inHg)</label>
+              <input value={pressureInHg} onChange={(e) => setPressureInHg(e.target.value)} type="number" step="0.01" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Density Altitude (ft, optional)</label>
+              <input value={densityAltitudeFt} onChange={(e) => setDensityAltitudeFt(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Humidity (%)</label>
+              <input value={humidityPercent} onChange={(e) => setHumidityPercent(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Wind Speed (mph)</label>
+              <input value={windSpeedMph} onChange={(e) => setWindSpeedMph(e.target.value)} type="number" className={INPUT_CLASS} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Wind Angle (deg)</label>
+              <input value={windAngleDeg} onChange={(e) => setWindAngleDeg(e.target.value)} type="number" className={INPUT_CLASS} />
             </div>
           </div>
 

--- a/src/lib/__tests__/solver.test.ts
+++ b/src/lib/__tests__/solver.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { generateDistanceRows } from "@/lib/ballistics/dope";
+import { solveTrajectoryRows } from "@/lib/ballistics/solver";
+
+describe("solveTrajectoryRows", () => {
+  it("produces realistic benchmark trajectory trend for 6.5CM-like profile", () => {
+    const rows = solveTrajectoryRows(generateDistanceRows(100, 800, 100), {
+      muzzleVelocityFps: 2650,
+      ballisticCoefficient: 0.275,
+      dragModel: "G7",
+      zeroRangeYd: 100,
+      sightHeightIn: 1.9,
+      twistIn: 8,
+      temperatureF: 59,
+      pressureInHg: 29.92,
+      humidityPercent: 50,
+      windSpeedMph: 10,
+      windAngleDeg: 90,
+    });
+
+    const dropAt300 = rows.find((row) => row.distanceYd === 300)?.dropIn;
+    const dropAt600 = rows.find((row) => row.distanceYd === 600)?.dropIn;
+    const dropAt800 = rows.find((row) => row.distanceYd === 800)?.dropIn;
+
+    expect(dropAt300).toBeGreaterThan(10);
+    expect(dropAt300).toBeLessThan(25);
+    expect(dropAt600).toBeGreaterThan(70);
+    expect(dropAt600).toBeLessThan(130);
+    expect(dropAt800).toBeGreaterThan(150);
+    expect(dropAt800).toBeLessThan(280);
+  });
+
+  it("increases wind drift when crosswind and distance increase", () => {
+    const rows = solveTrajectoryRows(generateDistanceRows(100, 600, 100), {
+      muzzleVelocityFps: 2750,
+      ballisticCoefficient: 0.23,
+      dragModel: "G7",
+      zeroRangeYd: 100,
+      sightHeightIn: 1.8,
+      twistIn: 7,
+      temperatureF: 75,
+      pressureInHg: 29.5,
+      humidityPercent: 35,
+      windSpeedMph: 12,
+      windAngleDeg: 90,
+    });
+
+    expect(rows[0].windIn).toBeGreaterThan(0);
+    expect(rows[5].windIn).toBeGreaterThan(rows[0].windIn);
+  });
+});

--- a/src/lib/ballistics/solver.ts
+++ b/src/lib/ballistics/solver.ts
@@ -1,0 +1,131 @@
+import type { BallisticOutputRow, DistanceRow } from "@/lib/ballistics/dope";
+
+export type DragModel = "G1" | "G7";
+
+export interface SolverInput {
+  muzzleVelocityFps: number;
+  ballisticCoefficient: number;
+  dragModel: DragModel;
+  zeroRangeYd: number;
+  sightHeightIn: number;
+  twistIn: number;
+  temperatureF: number;
+  pressureInHg?: number;
+  densityAltitudeFt?: number;
+  humidityPercent: number;
+  windSpeedMph: number;
+  windAngleDeg: number;
+}
+
+const FT_PER_YD = 3;
+const IN_PER_FT = 12;
+const G_FTPS2 = 32.174;
+const SEA_LEVEL_AIR_DENSITY = 0.0023769; // slug/ft^3
+const SEA_LEVEL_TEMP_R = 518.67;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toRadians(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+function estimateAirDensity(input: SolverInput): number {
+  if (Number.isFinite(input.densityAltitudeFt)) {
+    const da = input.densityAltitudeFt as number;
+    return SEA_LEVEL_AIR_DENSITY * Math.exp(-da / 30000);
+  }
+
+  const pressureInHg = input.pressureInHg ?? 29.92;
+  const tempR = input.temperatureF + 459.67;
+  const humidityFactor = 1 - clamp(input.humidityPercent, 0, 100) * 0.0015;
+
+  const densityRatio = (pressureInHg / 29.92) * (SEA_LEVEL_TEMP_R / tempR) * humidityFactor;
+  return SEA_LEVEL_AIR_DENSITY * densityRatio;
+}
+
+function dragConstant(input: SolverInput, airDensity: number): number {
+  const modelFactor = input.dragModel === "G7" ? 0.65 : 1;
+  return (0.000042 * (airDensity / SEA_LEVEL_AIR_DENSITY) * modelFactor) / Math.max(input.ballisticCoefficient, 0.01);
+}
+
+interface IntegratedState {
+  xFt: number;
+  tS: number;
+  yFt: number;
+  vyFps: number;
+  velocityFps: number;
+}
+
+function integrateToDistance(targetYd: number, launchAngleRad: number, input: SolverInput): IntegratedState {
+  const targetFt = targetYd * FT_PER_YD;
+  const stepFt = 3;
+  const airDensity = estimateAirDensity(input);
+  const k = dragConstant(input, airDensity);
+
+  let xFt = 0;
+  let yFt = -input.sightHeightIn / IN_PER_FT;
+  let vyFps = input.muzzleVelocityFps * Math.sin(launchAngleRad);
+  let velocityFps = input.muzzleVelocityFps * Math.cos(launchAngleRad);
+  let tS = 0;
+
+  while (xFt < targetFt) {
+    const dx = Math.min(stepFt, targetFt - xFt);
+    const v = Math.max(velocityFps, 400);
+    const vNext = Math.max(v - k * v * v * (dx / v), 300);
+    const dt = dx / ((v + vNext) * 0.5);
+
+    vyFps -= G_FTPS2 * dt;
+    yFt += vyFps * dt;
+
+    xFt += dx;
+    tS += dt;
+    velocityFps = vNext;
+  }
+
+  return { xFt, tS, yFt, vyFps, velocityFps };
+}
+
+function solveZeroLaunchAngle(input: SolverInput): number {
+  let low = -0.03;
+  let high = 0.08;
+
+  for (let i = 0; i < 30; i += 1) {
+    const mid = (low + high) / 2;
+    const yMid = integrateToDistance(input.zeroRangeYd, mid, input).yFt;
+    if (yMid > 0) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return (low + high) / 2;
+}
+
+function computeSpinDriftIn(distanceYd: number, timeS: number, input: SolverInput): number {
+  const twistSign = input.twistIn >= 0 ? 1 : -1;
+  const twistRate = Math.abs(input.twistIn) > 0 ? 12 / Math.abs(input.twistIn) : 0;
+  const distanceFactor = (distanceYd / 1000) ** 1.4;
+  return twistSign * 0.8 * twistRate * distanceFactor * timeS;
+}
+
+export function solveTrajectoryRows(distances: DistanceRow[], input: SolverInput): BallisticOutputRow[] {
+  if (!distances.length) return [];
+
+  const launchAngle = solveZeroLaunchAngle(input);
+  const windFps = input.windSpeedMph * 1.46667 * Math.sin(toRadians(input.windAngleDeg));
+
+  return distances.map(({ distanceYd }) => {
+    const state = integrateToDistance(distanceYd, launchAngle, input);
+    const dropIn = Math.max(0, -state.yFt * IN_PER_FT);
+    const windIn = windFps * state.tS * IN_PER_FT * 0.9 + computeSpinDriftIn(distanceYd, state.tS, input);
+
+    return {
+      distanceYd,
+      dropIn: Math.round(dropIn * 100) / 100,
+      windIn: Math.round(windIn * 100) / 100,
+    };
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a physics-based trajectory estimator to replace the previous linear placeholder so DOPE cards can be generated from muzzle/BC/atmospherics/wind inputs. 
- Expose a typed solver surface so future improvements (more accurate drag models, interpolation, etc.) can be added safely.

### Description
- Add a new typed solver module `solveTrajectoryRows` in `src/lib/ballistics/solver.ts` implementing a nonlinear stepper (time-of-flight, deceleration, drop, and drift) and types including `SolverInput` and `DragModel`.
- Wire solver outputs into the DOPE UI by replacing the previous linear estimate inputs with solver-backed controls and feeding solver inch outputs into the existing `convertDropWindToAngular` flow in `src/app/range/dope-card/page.tsx`.
- Preserve and reuse `convertDropWindToAngular` for MIL/MOA display and add an `Estimation model` label in the UI to indicate the physics-based estimator.
- Add benchmark/trend tests in `src/lib/__tests__/solver.test.ts` to validate trajectory drop ranges and crosswind drift behavior.

### Testing
- Ran `npm test -- src/lib/__tests__/dope.test.ts src/lib/__tests__/solver.test.ts` and both test files passed (all tests green).
- Ran `npm run lint` and the project linter completed without errors.
- Started the dev server with `npm run dev` and captured a UI screenshot, but the application shell produced runtime Prisma/DB warnings because `DATABASE_URL` was not set in this environment; the solver UI changes render but the app shell may show those unrelated warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b409a50cc48326b5c6472803feeeec)