### PR TITLE
Enhance DOPE card UX with click conversion, profile persistence, and export/import

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,6 +223,27 @@ body {
     min-height: 5.5in;
   }
 
+
+  .dope-print-compact {
+    width: 3in;
+    min-height: 7in;
+  }
+
+  .dope-print-bold-mode table td:first-child,
+  .dope-print-bold-mode table td:nth-child(2) {
+    font-weight: 700 !important;
+    font-size: 0.9rem !important;
+  }
+
+  .dope-print-bold-mode table th:nth-child(3),
+  .dope-print-bold-mode table th:nth-child(5),
+  .dope-print-bold-mode table td:nth-child(3),
+  .dope-print-bold-mode table td:nth-child(5),
+  .dope-print-bold-mode table th:nth-child(6),
+  .dope-print-bold-mode table td:nth-child(6) {
+    display: none !important;
+  }
+
   .dope-print-monochrome,
   .dope-print-monochrome * {
     color: #000 !important;

--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import {
   applyDopeCorrections,
@@ -10,16 +10,46 @@ import {
   type DopeRowCorrection,
 } from "@/lib/ballistics/dope";
 import { solveTrajectoryRows, type DragModel } from "@/lib/ballistics/solver";
-import { Calculator, Target } from "lucide-react";
+import { Calculator, Download, Target, Upload } from "lucide-react";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
 const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+const STORAGE_KEY = "pbv-dope-card-profiles-v1";
+
+type DistanceUnit = "yd" | "m";
+type AngularUnit = "mil" | "moa";
+
+interface SavedProfile {
+  name: string;
+  payload: {
+    startYd: string;
+    endYd: string;
+    stepYd: string;
+    muzzleVelocityFps: string;
+    ballisticCoefficient: string;
+    dragModel: DragModel;
+    zeroRangeYd: string;
+    sightHeightIn: string;
+    twistIn: string;
+    temperatureF: string;
+    pressureInHg: string;
+    densityAltitudeFt: string;
+    humidityPercent: string;
+    windSpeedMph: string;
+    windAngleDeg: string;
+    distanceUnit: DistanceUnit;
+    angularUnit: AngularUnit;
+    milClickValue: string;
+    moaClickValue: string;
+    rows: AngularDopeRow[];
+    corrections: Record<number, DopeRowCorrection>;
+  };
+}
 
 function parseOptionalNumber(value: string): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
@@ -42,9 +72,32 @@ export default function DopeCardPage() {
   const [windSpeedMph, setWindSpeedMph] = useState("10");
   const [windAngleDeg, setWindAngleDeg] = useState("90");
 
+  const [distanceUnit, setDistanceUnit] = useState<DistanceUnit>("yd");
+  const [angularUnit, setAngularUnit] = useState<AngularUnit>("mil");
+  const [milClickValue, setMilClickValue] = useState("0.1");
+  const [moaClickValue, setMoaClickValue] = useState("0.25");
+
   const [rows, setRows] = useState<AngularDopeRow[]>([]);
   const [corrections, setCorrections] = useState<Record<number, DopeRowCorrection>>({});
+  const [profileName, setProfileName] = useState("");
+  const [profiles, setProfiles] = useState<SavedProfile[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+  const [selectedProfile, setSelectedProfile] = useState("");
+  const importRef = useRef<HTMLInputElement | null>(null);
+
   const estimationModel = "Physics-based nonlinear stepper";
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+  }, [profiles]);
 
   const estimateSummary = useMemo(() => {
     if (!rows.length) return null;
@@ -52,8 +105,15 @@ export default function DopeCardPage() {
     return `${confirmedCount}/${rows.length} rows confirmed from impacts`;
   }, [rows]);
 
+  const activeClickValue = angularUnit === "mil" ? Number(milClickValue) : Number(moaClickValue);
+
   function handleGenerate() {
-    const distanceRows = generateDistanceRows(Number(startYd), Number(endYd), Number(stepYd));
+    const toYd = distanceUnit === "m" ? 1.09361 : 1;
+    const distanceRows = generateDistanceRows(
+      Number(startYd) * toYd,
+      Number(endYd) * toYd,
+      Number(stepYd) * toYd,
+    );
     const solvedRows = solveTrajectoryRows(distanceRows, {
       muzzleVelocityFps: Number(muzzleVelocityFps),
       ballisticCoefficient: Number(ballisticCoefficient),
@@ -75,18 +135,10 @@ export default function DopeCardPage() {
 
   function updateCorrection(distanceYd: number, patch: DopeRowCorrection) {
     const existing = corrections[distanceYd] ?? {};
-    const merged: DopeRowCorrection = {
-      ...existing,
-      ...patch,
-    };
+    const merged: DopeRowCorrection = { ...existing, ...patch };
 
-    if (patch.dropIn === undefined) {
-      delete merged.dropIn;
-    }
-
-    if (patch.windIn === undefined) {
-      delete merged.windIn;
-    }
+    if (patch.dropIn === undefined) delete merged.dropIn;
+    if (patch.windIn === undefined) delete merged.windIn;
 
     const hasAnyCorrection =
       merged.dropIn !== undefined || merged.windIn !== undefined || merged.confirmed !== undefined;
@@ -94,20 +146,101 @@ export default function DopeCardPage() {
       ...corrections,
       ...(hasAnyCorrection ? { [distanceYd]: merged } : {}),
     };
-
-    if (!hasAnyCorrection) {
-      delete nextCorrections[distanceYd];
-    }
+    if (!hasAnyCorrection) delete nextCorrections[distanceYd];
 
     setCorrections(nextCorrections);
     setRows((prev) => applyDopeCorrections(prev, nextCorrections));
+  }
+
+  function saveProfile() {
+    const name = profileName.trim();
+    if (!name) return;
+    const payload = {
+      startYd, endYd, stepYd,
+      muzzleVelocityFps, ballisticCoefficient, dragModel,
+      zeroRangeYd, sightHeightIn, twistIn, temperatureF, pressureInHg,
+      densityAltitudeFt, humidityPercent, windSpeedMph, windAngleDeg,
+      distanceUnit, angularUnit, milClickValue, moaClickValue,
+      rows, corrections,
+    };
+    setProfiles((current) => [...current.filter((p) => p.name !== name), { name, payload }]);
+    setSelectedProfile(name);
+  }
+
+  function loadProfile() {
+    const profile = profiles.find((p) => p.name === selectedProfile);
+    if (!profile) return;
+    const p = profile.payload;
+    setStartYd(p.startYd); setEndYd(p.endYd); setStepYd(p.stepYd);
+    setMuzzleVelocityFps(p.muzzleVelocityFps);
+    setBallisticCoefficient(p.ballisticCoefficient);
+    setDragModel(p.dragModel);
+    setZeroRangeYd(p.zeroRangeYd); setSightHeightIn(p.sightHeightIn);
+    setTwistIn(p.twistIn); setTemperatureF(p.temperatureF);
+    setPressureInHg(p.pressureInHg); setDensityAltitudeFt(p.densityAltitudeFt);
+    setHumidityPercent(p.humidityPercent);
+    setWindSpeedMph(p.windSpeedMph); setWindAngleDeg(p.windAngleDeg);
+    setDistanceUnit(p.distanceUnit); setAngularUnit(p.angularUnit);
+    setMilClickValue(p.milClickValue); setMoaClickValue(p.moaClickValue);
+    setRows(p.rows); setCorrections(p.corrections);
+    setProfileName(profile.name);
+  }
+
+  function exportJson() {
+    const data = {
+      rows, corrections, startYd, endYd, stepYd,
+      muzzleVelocityFps, ballisticCoefficient, dragModel,
+      zeroRangeYd, sightHeightIn, distanceUnit, angularUnit, milClickValue, moaClickValue,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "dope-card.json"; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function exportCsv() {
+    const lines = ["distanceYd,dropIn,dropMil,dropMoa,windIn,windMil,windMoa,confirmed"];
+    rows.forEach((row) =>
+      lines.push([row.distanceYd, row.dropIn, row.dropMil, row.dropMoa, row.windIn, row.windMil, row.windMoa, row.confirmed].join(","))
+    );
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "dope-card.csv"; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importFile(file?: File) {
+    if (!file) return;
+    file.text().then((text) => {
+      if (file.name.endsWith(".json")) {
+        const parsed = JSON.parse(text);
+        if (Array.isArray(parsed.rows)) setRows(parsed.rows);
+        if (parsed.corrections) setCorrections(parsed.corrections);
+        if (parsed.startYd) setStartYd(parsed.startYd);
+        if (parsed.endYd) setEndYd(parsed.endYd);
+      } else {
+        const [, ...data] = text.trim().split("\n");
+        const importedRows = data.map((line) => {
+          const [distanceYd, dropIn, dropMil, dropMoa, windIn, windMil, windMoa, confirmed] = line.split(",");
+          return {
+            distanceYd: Number(distanceYd), dropIn: Number(dropIn),
+            dropMil: Number(dropMil), dropMoa: Number(dropMoa),
+            windIn: Number(windIn), windMil: Number(windMil), windMoa: Number(windMoa),
+            confirmed: confirmed === "true",
+          };
+        });
+        setRows(importedRows);
+      }
+    });
   }
 
   return (
     <div className="min-h-full">
       <PageHeader
         title="DOPE CARD BUILDER"
-        subtitle="Generate an estimated card, then overwrite each row from confirmed impacts"
+        subtitle="Generate estimates, convert to clicks, and save/share complete card profiles"
       />
 
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
@@ -118,6 +251,54 @@ export default function DopeCardPage() {
           <p className="text-xs text-vault-text-muted">Estimation model: {estimationModel}</p>
         </div>
 
+        {/* Profile & Display Settings */}
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <div>
+              <label className={LABEL_CLASS}>Distance Unit</label>
+              <div className="flex gap-2">
+                <button onClick={() => setDistanceUnit("yd")} className={`px-3 py-2 rounded-md border text-xs ${distanceUnit === "yd" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>Yards</button>
+                <button onClick={() => setDistanceUnit("m")} className={`px-3 py-2 rounded-md border text-xs ${distanceUnit === "m" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>Meters</button>
+              </div>
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Scope Click Display</label>
+              <div className="flex gap-2">
+                <button onClick={() => setAngularUnit("mil")} className={`px-3 py-2 rounded-md border text-xs ${angularUnit === "mil" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>MIL</button>
+                <button onClick={() => setAngularUnit("moa")} className={`px-3 py-2 rounded-md border text-xs ${angularUnit === "moa" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>MOA</button>
+              </div>
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>MIL Click Value</label>
+              <input className={INPUT_CLASS} value={milClickValue} onChange={(e) => setMilClickValue(e.target.value)} />
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>MOA Click Value</label>
+              <input className={INPUT_CLASS} value={moaClickValue} onChange={(e) => setMoaClickValue(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              className={`${INPUT_CLASS} max-w-56`}
+              placeholder="Profile name"
+              value={profileName}
+              onChange={(e) => setProfileName(e.target.value)}
+            />
+            <button onClick={saveProfile} className="px-3 py-2 rounded-md border border-vault-border text-xs">Save Profile</button>
+            <select value={selectedProfile} onChange={(e) => setSelectedProfile(e.target.value)} className={`${INPUT_CLASS} max-w-56`}>
+              <option value="">Load saved profile…</option>
+              {profiles.map((p) => <option key={p.name} value={p.name}>{p.name}</option>)}
+            </select>
+            <button onClick={loadProfile} className="px-3 py-2 rounded-md border border-vault-border text-xs">Load</button>
+            <button onClick={exportCsv} className="px-3 py-2 rounded-md border border-vault-border text-xs inline-flex items-center gap-1"><Download className="w-3 h-3" />CSV</button>
+            <button onClick={exportJson} className="px-3 py-2 rounded-md border border-vault-border text-xs inline-flex items-center gap-1"><Download className="w-3 h-3" />JSON</button>
+            <button onClick={() => importRef.current?.click()} className="px-3 py-2 rounded-md border border-vault-border text-xs inline-flex items-center gap-1"><Upload className="w-3 h-3" />Import</button>
+            <input ref={importRef} type="file" accept=".csv,.json" className="hidden" onChange={(e) => importFile(e.target.files?.[0])} />
+          </div>
+        </section>
+
+        {/* Ballistic Inputs */}
         <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
           <div className="flex items-center gap-2">
             <Calculator className="w-4 h-4 text-[#00C2FF]" />
@@ -126,15 +307,15 @@ export default function DopeCardPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
             <div>
-              <label className={LABEL_CLASS}>Start (yd)</label>
+              <label className={LABEL_CLASS}>Start ({distanceUnit})</label>
               <input value={startYd} onChange={(e) => setStartYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
             </div>
             <div>
-              <label className={LABEL_CLASS}>End (yd)</label>
+              <label className={LABEL_CLASS}>End ({distanceUnit})</label>
               <input value={endYd} onChange={(e) => setEndYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
             </div>
             <div>
-              <label className={LABEL_CLASS}>Step (yd)</label>
+              <label className={LABEL_CLASS}>Step ({distanceUnit})</label>
               <input value={stepYd} onChange={(e) => setStepYd(e.target.value)} type="number" min={1} className={INPUT_CLASS} />
             </div>
             <div>
@@ -198,6 +379,7 @@ export default function DopeCardPage() {
           </button>
         </section>
 
+        {/* DOPE Table */}
         <section className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
           <div className="px-4 py-3 border-b border-vault-border flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -213,52 +395,59 @@ export default function DopeCardPage() {
                 <tr>
                   <th className="text-left px-3 py-2">Distance</th>
                   <th className="text-left px-3 py-2">Drop (in)</th>
-                  <th className="text-left px-3 py-2">Drop (MIL)</th>
-                  <th className="text-left px-3 py-2">Drop (MOA)</th>
+                  <th className="text-left px-3 py-2">Drop ({angularUnit.toUpperCase()})</th>
                   <th className="text-left px-3 py-2">Wind (in)</th>
-                  <th className="text-left px-3 py-2">Wind (MIL)</th>
-                  <th className="text-left px-3 py-2">Wind (MOA)</th>
+                  <th className="text-left px-3 py-2">Wind ({angularUnit.toUpperCase()})</th>
+                  <th className="text-left px-3 py-2">Clicks Up</th>
+                  <th className="text-left px-3 py-2">Clicks Wind</th>
                   <th className="text-left px-3 py-2">Confirmed</th>
                 </tr>
               </thead>
               <tbody>
-                {rows.map((row) => (
-                  <tr key={row.distanceYd} className="border-t border-vault-border/60">
-                    <td className="px-3 py-2 font-mono">{row.distanceYd} yd</td>
-                    <td className="px-3 py-2">
-                      <input
-                        type="number"
-                        step="0.01"
-                        className={`${INPUT_CLASS} min-w-[110px]`}
-                        value={corrections[row.distanceYd]?.dropIn ?? ""}
-                        placeholder={String(row.dropIn)}
-                        onChange={(e) => updateCorrection(row.distanceYd, { dropIn: parseOptionalNumber(e.target.value) })}
-                      />
-                    </td>
-                    <td className="px-3 py-2 font-mono">{row.dropMil.toFixed(2)}</td>
-                    <td className="px-3 py-2 font-mono">{row.dropMoa.toFixed(2)}</td>
-                    <td className="px-3 py-2">
-                      <input
-                        type="number"
-                        step="0.01"
-                        className={`${INPUT_CLASS} min-w-[110px]`}
-                        value={corrections[row.distanceYd]?.windIn ?? ""}
-                        placeholder={String(row.windIn)}
-                        onChange={(e) => updateCorrection(row.distanceYd, { windIn: parseOptionalNumber(e.target.value) })}
-                      />
-                    </td>
-                    <td className="px-3 py-2 font-mono">{row.windMil.toFixed(2)}</td>
-                    <td className="px-3 py-2 font-mono">{row.windMoa.toFixed(2)}</td>
-                    <td className="px-3 py-2">
-                      <input
-                        type="checkbox"
-                        checked={row.confirmed}
-                        onChange={(e) => updateCorrection(row.distanceYd, { confirmed: e.target.checked })}
-                        className="w-4 h-4 accent-[#00C853]"
-                      />
-                    </td>
-                  </tr>
-                ))}
+                {rows.map((row) => {
+                  const displayDistance = distanceUnit === "m" ? row.distanceYd / 1.09361 : row.distanceYd;
+                  const dropAngular = angularUnit === "mil" ? row.dropMil : row.dropMoa;
+                  const windAngular = angularUnit === "mil" ? row.windMil : row.windMoa;
+                  const clickUp = activeClickValue > 0 ? Math.round(dropAngular / activeClickValue) : 0;
+                  const clickWind = activeClickValue > 0 ? Math.round(windAngular / activeClickValue) : 0;
+                  return (
+                    <tr key={row.distanceYd} className="border-t border-vault-border/60">
+                      <td className="px-3 py-2 font-mono">{displayDistance.toFixed(0)} {distanceUnit}</td>
+                      <td className="px-3 py-2">
+                        <input
+                          type="number"
+                          step="0.01"
+                          className={`${INPUT_CLASS} min-w-[110px]`}
+                          value={corrections[row.distanceYd]?.dropIn ?? ""}
+                          placeholder={String(row.dropIn)}
+                          onChange={(e) => updateCorrection(row.distanceYd, { dropIn: parseOptionalNumber(e.target.value) })}
+                        />
+                      </td>
+                      <td className="px-3 py-2 font-mono">{dropAngular.toFixed(2)}</td>
+                      <td className="px-3 py-2">
+                        <input
+                          type="number"
+                          step="0.01"
+                          className={`${INPUT_CLASS} min-w-[110px]`}
+                          value={corrections[row.distanceYd]?.windIn ?? ""}
+                          placeholder={String(row.windIn)}
+                          onChange={(e) => updateCorrection(row.distanceYd, { windIn: parseOptionalNumber(e.target.value) })}
+                        />
+                      </td>
+                      <td className="px-3 py-2 font-mono">{windAngular.toFixed(2)}</td>
+                      <td className="px-3 py-2 font-mono">{clickUp}</td>
+                      <td className="px-3 py-2 font-mono">{clickWind}</td>
+                      <td className="px-3 py-2">
+                        <input
+                          type="checkbox"
+                          checked={row.confirmed}
+                          onChange={(e) => updateCorrection(row.distanceYd, { confirmed: e.target.checked })}
+                          className="w-4 h-4 accent-[#00C853]"
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
                 {rows.length === 0 && (
                   <tr>
                     <td colSpan={8} className="px-3 py-6 text-center text-vault-text-faint">

--- a/src/app/range/dope-cards/[id]/page.tsx
+++ b/src/app/range/dope-cards/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { useState } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Printer } from "lucide-react";
 
@@ -15,52 +16,45 @@ const SAMPLE_ROWS = [
 
 export default function DopeCardDetailPage() {
   const params = useParams<{ id: string }>();
+  const [cardSize, setCardSize] = useState<"index" | "half" | "compact">("half");
+  const [boldMode, setBoldMode] = useState(true);
+  const [clickValue] = useState("0.1");
 
   return (
     <main className="min-h-screen bg-vault-bg pb-10">
       <PageHeader
         title={`DOPE Card Preview #${params.id}`}
-        subtitle="Saved-card preview optimized for print output."
+        subtitle="Saved-card preview optimized for compact and bold print output."
         actions={
           <>
-            <Link href="/range/dope-cards" className="rounded-md border border-vault-border px-3 py-2 text-xs text-vault-text-muted hover:bg-vault-muted">
-              Back to Cards
-            </Link>
-            <button
-              type="button"
-              onClick={() => window.print()}
-              className="inline-flex items-center gap-2 rounded-md bg-[#00C2FF] px-3 py-2 text-xs font-semibold text-black hover:bg-[#44d4ff]"
-            >
-              <Printer className="h-3.5 w-3.5" />
-              Print Card
-            </button>
+            <Link href="/range/dope-cards" className="rounded-md border border-vault-border px-3 py-2 text-xs text-vault-text-muted hover:bg-vault-muted">Back to Cards</Link>
+            <button type="button" onClick={() => window.print()} className="inline-flex items-center gap-2 rounded-md bg-[#00C2FF] px-3 py-2 text-xs font-semibold text-black hover:bg-[#44d4ff]"><Printer className="h-3.5 w-3.5" />Print Card</button>
           </>
         }
       />
 
-      <div className="mx-auto w-full max-w-4xl p-4">
-        <section className="dope-print-card dope-print-half dope-print-monochrome overflow-hidden rounded-md border border-vault-border bg-vault-surface">
+      <div className="mx-auto w-full max-w-4xl p-4 space-y-3">
+        <div className="print:hidden flex gap-2">
+          <button onClick={() => setCardSize("index")} className={`rounded-md border px-3 py-2 text-xs ${cardSize === "index" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>Index</button>
+          <button onClick={() => setCardSize("half")} className={`rounded-md border px-3 py-2 text-xs ${cardSize === "half" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>Half</button>
+          <button onClick={() => setCardSize("compact")} className={`rounded-md border px-3 py-2 text-xs ${cardSize === "compact" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`}>Compact</button>
+          <label className="inline-flex items-center gap-2 text-xs"><input type="checkbox" checked={boldMode} onChange={(e) => setBoldMode(e.target.checked)} />Bold distance + elevation</label>
+        </div>
+
+        <section className={`dope-print-card dope-print-${cardSize} dope-print-monochrome ${boldMode ? "dope-print-bold-mode" : ""} overflow-hidden rounded-md border border-vault-border bg-vault-surface`}>
           <div className="border-b border-vault-border bg-vault-surface-2 px-3 py-2">
             <h2 className="text-sm font-semibold">Mk12 SPR • 77gr OTM</h2>
-            <p className="text-xs text-vault-text-muted">Zero 100 yd • Temp 59°F • Alt 0 ft • Wind 10 mph @ 90°</p>
+            <p className="text-xs text-vault-text-muted">Zero 100 yd • Temp 59°F • Alt 0 ft • Wind 10 mph @ 90° • MIL click {clickValue}</p>
           </div>
 
           <table className="w-full text-xs">
             <thead className="bg-vault-surface-2 text-left text-vault-text-muted">
-              <tr>
-                <th className="px-3 py-2">Distance (yd)</th>
-                <th className="px-3 py-2">Elevation (MIL)</th>
-                <th className="px-3 py-2">Wind (MIL)</th>
-                <th className="px-3 py-2">Notes</th>
-              </tr>
+              <tr><th className="px-3 py-2">Distance (yd)</th><th className="px-3 py-2">Elevation (MIL)</th><th className="px-3 py-2">Wind (MIL)</th><th className="px-3 py-2">Clicks Up</th><th className="px-3 py-2">Clicks Wind</th><th className="px-3 py-2">Notes</th></tr>
             </thead>
             <tbody>
               {SAMPLE_ROWS.map((row) => (
                 <tr key={row.distance} className="border-t border-vault-border">
-                  <td className="px-3 py-2">{row.distance}</td>
-                  <td className="px-3 py-2">{row.elevation}</td>
-                  <td className="px-3 py-2">{row.wind}</td>
-                  <td className="px-3 py-2">{row.note || "-"}</td>
+                  <td className="px-3 py-2">{row.distance}</td><td className="px-3 py-2">{row.elevation}</td><td className="px-3 py-2">{row.wind}</td><td className="px-3 py-2">{Math.round(Number(row.elevation) / Number(clickValue))}</td><td className="px-3 py-2">{Math.round(Number(row.wind) / Number(clickValue))}</td><td className="px-3 py-2">{row.note || "-"}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/app/range/dope-cards/page.tsx
+++ b/src/app/range/dope-cards/page.tsx
@@ -1,41 +1,18 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
-import { Plus, Printer, Trash2 } from "lucide-react";
+import { Download, Plus, Printer, Trash2, Upload } from "lucide-react";
 
-interface Firearm {
-  id: string;
-  name: string;
-  caliber: string;
-}
+interface Firearm { id: string; name: string; caliber: string; }
+interface Build { id: string; name: string; isActive: boolean; }
+interface AmmoStock { id: string; brand: string; caliber: string; grainWeight: number | null; bulletType: string | null; }
+interface DopeRow { id: string; distance: string; elevation: string; wind: string; note: string; }
 
-interface Build {
-  id: string;
-  name: string;
-  isActive: boolean;
-}
-
-interface AmmoStock {
-  id: string;
-  brand: string;
-  caliber: string;
-  grainWeight: number | null;
-  bulletType: string | null;
-}
-
-interface DopeRow {
-  id: string;
-  distance: string;
-  elevation: string;
-  wind: string;
-  note: string;
-}
-
-const INPUT_CLASS =
-  "w-full rounded-md border border-vault-border bg-vault-surface px-3 py-2 text-sm text-vault-text placeholder-vault-text-faint focus:border-[#00C2FF] focus:outline-none";
+const INPUT_CLASS = "w-full rounded-md border border-vault-border bg-vault-surface px-3 py-2 text-sm text-vault-text placeholder-vault-text-faint focus:border-[#00C2FF] focus:outline-none";
 const LABEL_CLASS = "mb-1 block text-xs font-semibold uppercase tracking-widest text-vault-text-muted";
+const STORAGE_KEY = "pbv-dope-cards-profiles-v1";
 
 const PRESET_TEMPLATES = {
   "100-1000 yd (100 yd)": Array.from({ length: 10 }, (_, i) => 100 + i * 100),
@@ -44,13 +21,30 @@ const PRESET_TEMPLATES = {
 };
 
 function buildRowsFromDistances(distances: number[]): DopeRow[] {
-  return distances.map((distance) => ({
-    id: crypto.randomUUID(),
-    distance: String(distance),
-    elevation: "",
-    wind: "",
-    note: "",
-  }));
+  return distances.map((distance) => ({ id: crypto.randomUUID(), distance: String(distance), elevation: "", wind: "", note: "" }));
+}
+
+type DistanceUnit = "yd" | "m";
+type AngularUnit = "mil" | "moa";
+
+interface SavedCardProfile {
+  name: string;
+  payload: {
+    selectedFirearm: string;
+    selectedBuild: string;
+    selectedAmmo: string;
+    zeroDistance: string;
+    unit: DistanceUnit;
+    angularUnit: AngularUnit;
+    clickValue: string;
+    temperature: string;
+    altitude: string;
+    wind: string;
+    cardSize: "index" | "half" | "compact";
+    monochrome: boolean;
+    boldDistanceElevation: boolean;
+    rows: DopeRow[];
+  };
 }
 
 export default function DopeCardsPage() {
@@ -63,30 +57,42 @@ export default function DopeCardsPage() {
   const [selectedAmmo, setSelectedAmmo] = useState("");
 
   const [zeroDistance, setZeroDistance] = useState("100");
-  const [unit, setUnit] = useState<"yd" | "m">("yd");
+  const [unit, setUnit] = useState<DistanceUnit>("yd");
+  const [angularUnit, setAngularUnit] = useState<AngularUnit>("mil");
+  const [clickValue, setClickValue] = useState("0.1");
   const [temperature, setTemperature] = useState("59");
   const [altitude, setAltitude] = useState("0");
   const [wind, setWind] = useState("0");
 
-  const [cardSize, setCardSize] = useState<"index" | "half">("index");
+  const [cardSize, setCardSize] = useState<"index" | "half" | "compact">("index");
   const [monochrome, setMonochrome] = useState(true);
+  const [boldDistanceElevation, setBoldDistanceElevation] = useState(false);
   const [rows, setRows] = useState<DopeRow[]>(buildRowsFromDistances(PRESET_TEMPLATES["100-1000 yd (100 yd)"]));
+  const [profileName, setProfileName] = useState("");
+  const [savedProfiles, setSavedProfiles] = useState<SavedCardProfile[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+  const [selectedProfile, setSelectedProfile] = useState("");
+  const importRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    fetch("/api/firearms")
-      .then((res) => res.json())
-      .then((data) => setFirearms(Array.isArray(data) ? data : []))
-      .catch(() => setFirearms([]));
-
-    fetch("/api/ammo")
-      .then((res) => res.json())
-      .then((data) => setAmmoProfiles(Array.isArray(data?.all) ? data.all : []))
-      .catch(() => setAmmoProfiles([]));
+    fetch("/api/firearms").then((res) => res.json()).then((data) => setFirearms(Array.isArray(data) ? data : [])).catch(() => setFirearms([]));
+    fetch("/api/ammo").then((res) => res.json()).then((data) => setAmmoProfiles(Array.isArray(data?.all) ? data.all : [])).catch(() => setAmmoProfiles([]));
   }, []);
 
   useEffect(() => {
-    if (!selectedFirearm) return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(savedProfiles));
+  }, [savedProfiles]);
 
+  useEffect(() => {
+    if (!selectedFirearm) return;
     fetch(`/api/builds?firearmId=${selectedFirearm}`)
       .then((res) => res.json())
       .then((data) => {
@@ -108,212 +114,182 @@ export default function DopeCardsPage() {
     return parts.filter(Boolean).join(" • ");
   }, [ammoProfiles, selectedAmmo]);
 
-  const updateRow = (id: string, field: keyof Omit<DopeRow, "id">, value: string) => {
-    setRows((current) => current.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
-  };
+  const updateRow = (id: string, field: keyof Omit<DopeRow, "id">, value: string) => setRows((current) => current.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
+  const addRow = () => setRows((current) => [...current, { id: crypto.randomUUID(), distance: "", elevation: "", wind: "", note: "" }]);
+  const removeRow = (id: string) => setRows((current) => current.filter((row) => row.id !== id));
 
-  const addRow = () => {
-    setRows((current) => [
-      ...current,
-      {
-        id: crypto.randomUUID(),
-        distance: "",
-        elevation: "",
-        wind: "",
-        note: "",
-      },
-    ]);
-  };
+  function saveProfile() {
+    const name = profileName.trim();
+    if (!name) return;
+    const payload = { selectedFirearm, selectedBuild, selectedAmmo, zeroDistance, unit, angularUnit, clickValue, temperature, altitude, wind, cardSize, monochrome, boldDistanceElevation, rows };
+    setSavedProfiles((current) => [...current.filter((p) => p.name !== name), { name, payload }]);
+    setSelectedProfile(name);
+  }
 
-  const removeRow = (id: string) => {
-    setRows((current) => current.filter((row) => row.id !== id));
-  };
+  function loadProfile() {
+    const profile = savedProfiles.find((p) => p.name === selectedProfile);
+    if (!profile) return;
+    const p = profile.payload;
+    setSelectedFirearm(p.selectedFirearm);
+    setSelectedBuild(p.selectedBuild);
+    setSelectedAmmo(p.selectedAmmo);
+    setZeroDistance(p.zeroDistance);
+    setUnit(p.unit);
+    setAngularUnit(p.angularUnit);
+    setClickValue(p.clickValue);
+    setTemperature(p.temperature);
+    setAltitude(p.altitude);
+    setWind(p.wind);
+    setCardSize(p.cardSize);
+    setMonochrome(p.monochrome);
+    setBoldDistanceElevation(p.boldDistanceElevation);
+    setRows(p.rows);
+    setProfileName(profile.name);
+  }
+
+  function exportJson() {
+    const blob = new Blob([JSON.stringify({ selectedFirearm, selectedBuild, selectedAmmo, zeroDistance, unit, angularUnit, clickValue, temperature, altitude, wind, cardSize, monochrome, boldDistanceElevation, rows }, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "dope-cards.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function exportCsv() {
+    const lines = ["distance,elevation,wind,note,clicksUp,clicksWind"];
+    rows.forEach((r) => {
+      const clicksUp = clickValue ? Math.round((Number(r.elevation) || 0) / Number(clickValue)) : 0;
+      const clicksWind = clickValue ? Math.round((Number(r.wind) || 0) / Number(clickValue)) : 0;
+      lines.push([r.distance, r.elevation, r.wind, `"${r.note.replace(/"/g, '""')}"`, clicksUp, clicksWind].join(","));
+    });
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "dope-cards.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importFile(file?: File) {
+    if (!file) return;
+    file.text().then((text) => {
+      if (file.name.endsWith(".json")) {
+        const parsed = JSON.parse(text);
+        if (Array.isArray(parsed.rows)) setRows(parsed.rows.map((r: DopeRow) => ({ ...r, id: r.id || crypto.randomUUID() })));
+        if (parsed.unit) setUnit(parsed.unit);
+        if (parsed.angularUnit) setAngularUnit(parsed.angularUnit);
+        if (parsed.clickValue) setClickValue(parsed.clickValue);
+      } else {
+        const [, ...data] = text.trim().split("\n");
+        const imported = data.map((line) => {
+          const [distance, elevation, windValue, ...noteParts] = line.split(",");
+          return { id: crypto.randomUUID(), distance: distance || "", elevation: elevation || "", wind: windValue || "", note: noteParts.join(",").replace(/^"|"$/g, "") };
+        });
+        setRows(imported);
+      }
+    });
+  }
 
   return (
     <main className="min-h-screen bg-vault-bg pb-10">
-      <PageHeader
-        title="DOPE Cards"
-        subtitle="Build quick-reference hold cards and print in field-ready formats."
-        actions={
-          <>
-            <Link href="/range" className="rounded-md border border-vault-border px-3 py-2 text-xs text-vault-text-muted hover:bg-vault-muted">
-              Back to Range
-            </Link>
-            <button
-              type="button"
-              onClick={() => window.print()}
-              className="inline-flex items-center gap-2 rounded-md bg-[#00C2FF] px-3 py-2 text-xs font-semibold text-black hover:bg-[#44d4ff]"
-            >
-              <Printer className="h-3.5 w-3.5" />
-              Print Card
-            </button>
-          </>
-        }
-      />
+      <PageHeader title="DOPE Cards" subtitle="Build, print, save, and share quick-reference hold cards." actions={<><Link href="/range" className="rounded-md border border-vault-border px-3 py-2 text-xs text-vault-text-muted hover:bg-vault-muted">Back to Range</Link><button type="button" onClick={() => window.print()} className="inline-flex items-center gap-2 rounded-md bg-[#00C2FF] px-3 py-2 text-xs font-semibold text-black hover:bg-[#44d4ff]"><Printer className="h-3.5 w-3.5" />Print Card</button></>} />
 
       <div className="mx-auto grid w-full max-w-6xl gap-6 p-4 lg:grid-cols-[minmax(360px,420px)_1fr]">
         <section className="print:hidden rounded-lg border border-vault-border bg-vault-surface p-4">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Card Setup</h2>
-
           <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-2">
+              <button className={`rounded-md border px-3 py-2 text-xs ${unit === "yd" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`} onClick={() => setUnit("yd")}>Yards</button>
+              <button className={`rounded-md border px-3 py-2 text-xs ${unit === "m" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`} onClick={() => setUnit("m")}>Meters</button>
+              <button className={`rounded-md border px-3 py-2 text-xs ${angularUnit === "mil" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`} onClick={() => setAngularUnit("mil")}>MIL</button>
+              <button className={`rounded-md border px-3 py-2 text-xs ${angularUnit === "moa" ? "border-[#00C2FF] text-[#00C2FF]" : "border-vault-border"}`} onClick={() => setAngularUnit("moa")}>MOA</button>
+            </div>
+            <div>
+              <label className={LABEL_CLASS}>Scope Click Value ({angularUnit.toUpperCase()})</label>
+              <input className={INPUT_CLASS} value={clickValue} onChange={(e) => setClickValue(e.target.value)} />
+            </div>
             <div>
               <label className={LABEL_CLASS}>Firearm</label>
-              <select
-                className={INPUT_CLASS}
-                value={selectedFirearm}
-                onChange={(e) => {
-                  const firearmId = e.target.value;
-                  setSelectedFirearm(firearmId);
-                  if (!firearmId) {
-                    setBuilds([]);
-                    setSelectedBuild("");
-                  }
-                }}
-              >
+              <select className={INPUT_CLASS} value={selectedFirearm} onChange={(e) => { const firearmId = e.target.value; setSelectedFirearm(firearmId); if (!firearmId) { setBuilds([]); setSelectedBuild(""); } }}>
                 <option value="">Select firearm</option>
-                {firearms.map((firearm) => (
-                  <option key={firearm.id} value={firearm.id}>
-                    {firearm.name} ({firearm.caliber})
-                  </option>
-                ))}
+                {firearms.map((firearm) => <option key={firearm.id} value={firearm.id}>{firearm.name} • {firearm.caliber}</option>)}
               </select>
             </div>
-
             <div>
-              <label className={LABEL_CLASS}>Build Profile</label>
-              <select className={INPUT_CLASS} value={selectedBuild} onChange={(e) => setSelectedBuild(e.target.value)}>
-                <option value="">Select build</option>
-                {builds.map((build) => (
-                  <option key={build.id} value={build.id}>
-                    {build.name}
-                  </option>
-                ))}
-              </select>
+              <label className={LABEL_CLASS}>Rifle Build</label>
+              <select className={INPUT_CLASS} value={selectedBuild} onChange={(e) => setSelectedBuild(e.target.value)} disabled={!selectedFirearm}><option value="">Select build</option>{builds.map((build) => <option key={build.id} value={build.id}>{build.name}</option>)}</select>
             </div>
-
             <div>
-              <label className={LABEL_CLASS}>Ammo Profile</label>
+              <label className={LABEL_CLASS}>Ammo</label>
               <select className={INPUT_CLASS} value={selectedAmmo} onChange={(e) => setSelectedAmmo(e.target.value)}>
                 <option value="">Select ammo</option>
-                {ammoProfiles.map((ammo) => (
-                  <option key={ammo.id} value={ammo.id}>
-                    {ammo.brand} {ammo.caliber} {ammo.grainWeight ? `${ammo.grainWeight}gr` : ""}
-                  </option>
-                ))}
+                {ammoProfiles.map((ammo) => <option key={ammo.id} value={ammo.id}>{[ammo.brand, ammo.caliber, ammo.grainWeight ? `${ammo.grainWeight}gr` : ""].filter(Boolean).join(" • ")}</option>)}
               </select>
             </div>
-
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className={LABEL_CLASS}>Zero Distance</label>
-                <input className={INPUT_CLASS} value={zeroDistance} onChange={(e) => setZeroDistance(e.target.value)} />
-              </div>
-              <div>
-                <label className={LABEL_CLASS}>Unit</label>
-                <select className={INPUT_CLASS} value={unit} onChange={(e) => setUnit(e.target.value as "yd" | "m")}>
-                  <option value="yd">Yards</option>
-                  <option value="m">Meters</option>
-                </select>
-              </div>
-              <div>
-                <label className={LABEL_CLASS}>Temp (°F)</label>
-                <input className={INPUT_CLASS} value={temperature} onChange={(e) => setTemperature(e.target.value)} />
-              </div>
-              <div>
-                <label className={LABEL_CLASS}>Altitude (ft)</label>
-                <input className={INPUT_CLASS} value={altitude} onChange={(e) => setAltitude(e.target.value)} />
-              </div>
-              <div className="col-span-2">
-                <label className={LABEL_CLASS}>Wind (mph @ 90°)</label>
-                <input className={INPUT_CLASS} value={wind} onChange={(e) => setWind(e.target.value)} />
-              </div>
+              <div><label className={LABEL_CLASS}>Zero Distance</label><input className={INPUT_CLASS} value={zeroDistance} onChange={(e) => setZeroDistance(e.target.value)} /></div>
+              <div><label className={LABEL_CLASS}>Temp (°F)</label><input className={INPUT_CLASS} value={temperature} onChange={(e) => setTemperature(e.target.value)} /></div>
+              <div><label className={LABEL_CLASS}>Altitude (ft)</label><input className={INPUT_CLASS} value={altitude} onChange={(e) => setAltitude(e.target.value)} /></div>
+              <div><label className={LABEL_CLASS}>Wind (mph @ 90°)</label><input className={INPUT_CLASS} value={wind} onChange={(e) => setWind(e.target.value)} /></div>
             </div>
 
-            <div>
-              <p className={LABEL_CLASS}>Preset Templates</p>
-              <div className="flex flex-wrap gap-2">
-                {Object.entries(PRESET_TEMPLATES).map(([name, distances]) => (
-                  <button
-                    key={name}
-                    type="button"
-                    onClick={() => setRows(buildRowsFromDistances(distances))}
-                    className="rounded-md border border-vault-border px-2.5 py-1.5 text-xs text-vault-text hover:bg-vault-muted"
-                  >
-                    {name}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <div><p className={LABEL_CLASS}>Preset Templates</p><div className="flex flex-wrap gap-2">{Object.entries(PRESET_TEMPLATES).map(([name, distances]) => <button key={name} type="button" onClick={() => setRows(buildRowsFromDistances(distances))} className="rounded-md border border-vault-border px-2.5 py-1.5 text-xs text-vault-text hover:bg-vault-muted">{name}</button>)}</div></div>
 
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3">
               <div>
                 <label className={LABEL_CLASS}>Print Card Size</label>
-                <select className={INPUT_CLASS} value={cardSize} onChange={(e) => setCardSize(e.target.value as "index" | "half")}>
-                  <option value="index">Index Card (3x5&quot;)</option>
-                  <option value="half">Half Page (5.5x8.5&quot;)</option>
+                <select className={INPUT_CLASS} value={cardSize} onChange={(e) => setCardSize(e.target.value as "index" | "half" | "compact")}>
+                  <option value="index">Index Card (3x5&quot;)</option><option value="half">Half Page (5.5x8.5&quot;)</option><option value="compact">Compact Strip</option>
                 </select>
               </div>
-              <label className="mt-6 inline-flex items-center gap-2 text-sm text-vault-text">
-                <input type="checkbox" checked={monochrome} onChange={(e) => setMonochrome(e.target.checked)} />
-                High contrast monochrome
-              </label>
+              <label className="inline-flex items-center gap-2 text-sm text-vault-text"><input type="checkbox" checked={monochrome} onChange={(e) => setMonochrome(e.target.checked)} />High contrast monochrome</label>
+              <label className="inline-flex items-center gap-2 text-sm text-vault-text"><input type="checkbox" checked={boldDistanceElevation} onChange={(e) => setBoldDistanceElevation(e.target.checked)} />Bold distance + elevation hold mode</label>
+            </div>
+
+            <div className="space-y-2 border-t border-vault-border pt-3">
+              <label className={LABEL_CLASS}>Saved Profiles (solver + rifle + ammo)</label>
+              <div className="flex flex-wrap gap-2">
+                <input className={INPUT_CLASS + " max-w-56"} placeholder="Profile name" value={profileName} onChange={(e) => setProfileName(e.target.value)} />
+                <button onClick={saveProfile} type="button" className="rounded-md border border-vault-border px-3 py-2 text-xs">Save</button>
+                <select value={selectedProfile} onChange={(e) => setSelectedProfile(e.target.value)} className={INPUT_CLASS + " max-w-56"}><option value="">Load profile…</option>{savedProfiles.map((p) => <option key={p.name} value={p.name}>{p.name}</option>)}</select>
+                <button onClick={loadProfile} type="button" className="rounded-md border border-vault-border px-3 py-2 text-xs">Load</button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button onClick={exportCsv} type="button" className="inline-flex items-center gap-1 rounded-md border border-vault-border px-3 py-2 text-xs"><Download className="h-3.5 w-3.5" />Export CSV</button>
+                <button onClick={exportJson} type="button" className="inline-flex items-center gap-1 rounded-md border border-vault-border px-3 py-2 text-xs"><Download className="h-3.5 w-3.5" />Export JSON</button>
+                <button onClick={() => importRef.current?.click()} type="button" className="inline-flex items-center gap-1 rounded-md border border-vault-border px-3 py-2 text-xs"><Upload className="h-3.5 w-3.5" />Import CSV/JSON</button>
+                <input ref={importRef} type="file" accept=".csv,.json" className="hidden" onChange={(e) => importFile(e.target.files?.[0])} />
+              </div>
             </div>
           </div>
         </section>
 
         <section className="rounded-lg border border-vault-border bg-vault-surface p-4">
-          <div className="mb-3 flex items-center justify-between print:hidden">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Distance / Hold Rows</h2>
-            <button
-              type="button"
-              onClick={addRow}
-              className="inline-flex items-center gap-1 rounded-md border border-vault-border px-2.5 py-1.5 text-xs text-vault-text hover:bg-vault-muted"
-            >
-              <Plus className="h-3.5 w-3.5" /> Add Row
-            </button>
-          </div>
+          <div className="mb-3 flex items-center justify-between print:hidden"><h2 className="text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Distance / Hold Rows</h2><button type="button" onClick={addRow} className="inline-flex items-center gap-1 rounded-md border border-vault-border px-2.5 py-1.5 text-xs text-vault-text hover:bg-vault-muted"><Plus className="h-3.5 w-3.5" /> Add Row</button></div>
 
-          <div className={`dope-print-card dope-print-${cardSize} ${monochrome ? "dope-print-monochrome" : ""} overflow-hidden rounded-md border border-vault-border`}>
-            <div className="border-b border-vault-border bg-vault-surface-2 px-3 py-2">
-              <h3 className="text-sm font-semibold">DOPE Card</h3>
-              <p className="text-xs text-vault-text-muted">
-                Zero {zeroDistance} {unit} • {selectedAmmoLabel || "Ammo not selected"}
-              </p>
-              <p className="text-xs text-vault-text-muted">Temp {temperature}°F • Alt {altitude} ft • Wind {wind} mph</p>
-            </div>
-
+          <div className={`dope-print-card dope-print-${cardSize} ${monochrome ? "dope-print-monochrome" : ""} ${boldDistanceElevation ? "dope-print-bold-mode" : ""} overflow-hidden rounded-md border border-vault-border`}>
+            <div className="border-b border-vault-border bg-vault-surface-2 px-3 py-2"><h3 className="text-sm font-semibold">DOPE Card</h3><p className="text-xs text-vault-text-muted">Zero {zeroDistance} {unit} • {selectedAmmoLabel || "Ammo not selected"}</p><p className="text-xs text-vault-text-muted">Temp {temperature}°F • Alt {altitude} ft • Wind {wind} mph • {angularUnit.toUpperCase()} clicks {clickValue}</p></div>
             <table className="w-full text-xs">
-              <thead className="bg-vault-surface-2 text-left text-vault-text-muted">
-                <tr>
-                  <th className="px-3 py-2">Distance ({unit})</th>
-                  <th className="px-3 py-2">Elevation</th>
-                  <th className="px-3 py-2">Wind</th>
-                  <th className="px-3 py-2">Notes</th>
-                  <th className="w-10 px-2 py-2 print:hidden" />
-                </tr>
-              </thead>
+              <thead className="bg-vault-surface-2 text-left text-vault-text-muted"><tr><th className="px-3 py-2">Distance ({unit})</th><th className="px-3 py-2">Elevation ({angularUnit.toUpperCase()})</th><th className="px-3 py-2">Wind ({angularUnit.toUpperCase()})</th><th className="px-3 py-2">Clicks Up</th><th className="px-3 py-2">Clicks Wind</th><th className="px-3 py-2">Notes</th><th className="w-10 px-2 py-2 print:hidden" /></tr></thead>
               <tbody>
-                {rows.map((row) => (
-                  <tr key={row.id} className="border-t border-vault-border">
-                    <td className="p-1.5">
-                      <input className={INPUT_CLASS} value={row.distance} onChange={(e) => updateRow(row.id, "distance", e.target.value)} />
-                    </td>
-                    <td className="p-1.5">
-                      <input className={INPUT_CLASS} value={row.elevation} onChange={(e) => updateRow(row.id, "elevation", e.target.value)} />
-                    </td>
-                    <td className="p-1.5">
-                      <input className={INPUT_CLASS} value={row.wind} onChange={(e) => updateRow(row.id, "wind", e.target.value)} />
-                    </td>
-                    <td className="p-1.5">
-                      <input className={INPUT_CLASS} value={row.note} onChange={(e) => updateRow(row.id, "note", e.target.value)} />
-                    </td>
-                    <td className="p-1.5 print:hidden">
-                      <button type="button" onClick={() => removeRow(row.id)} className="rounded-md p-1.5 text-vault-text-muted hover:bg-vault-muted hover:text-vault-text">
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                {rows.map((row) => {
+                  const clicksUp = clickValue ? Math.round((Number(row.elevation) || 0) / Number(clickValue)) : 0;
+                  const clicksWind = clickValue ? Math.round((Number(row.wind) || 0) / Number(clickValue)) : 0;
+                  return (
+                    <tr key={row.id} className="border-t border-vault-border">
+                      <td className="p-1.5"><input className={INPUT_CLASS} value={row.distance} onChange={(e) => updateRow(row.id, "distance", e.target.value)} /></td>
+                      <td className="p-1.5"><input className={INPUT_CLASS} value={row.elevation} onChange={(e) => updateRow(row.id, "elevation", e.target.value)} /></td>
+                      <td className="p-1.5"><input className={INPUT_CLASS} value={row.wind} onChange={(e) => updateRow(row.id, "wind", e.target.value)} /></td>
+                      <td className="px-3 py-2 font-mono">{clicksUp}</td>
+                      <td className="px-3 py-2 font-mono">{clicksWind}</td>
+                      <td className="p-1.5"><input className={INPUT_CLASS} value={row.note} onChange={(e) => updateRow(row.id, "note", e.target.value)} /></td>
+                      <td className="p-1.5 print:hidden"><button type="button" onClick={() => removeRow(row.id)} className="rounded-md p-1.5 text-vault-text-muted hover:bg-vault-muted hover:text-vault-text"><Trash2 className="h-3.5 w-3.5" /></button></td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
### Motivation
- Improve DOPE card builder and print workflows by adding scope-click workflows, unit toggles, compact print modes, profile persistence, and sharing/export tools to support fast field usage and offline backup.
- Provide a consistent UX across the builder, the card list, and saved-card previews so users can convert measured drops/wind into scope clicks and print optimized cards quickly.

### Description
- Added one-tap toggles for yards/meters and MIL/MOA, per-unit click value inputs, and computed "Clicks Up" and "Clicks Wind" columns derived from angular holds in `src/app/range/dope-card/page.tsx` and `src/app/range/dope-cards/page.tsx`.
- Implemented local profile save/load (localStorage-backed) for solver/rifle/ammo/card settings plus UI to save/select profiles and functions to export/import JSON and CSV for sharing and offline backup.
- Added compact print size and optional bold "distance + elevation" print mode and updated the DOPE card preview to show click columns and compact/bold options, with new print CSS in `src/app/globals.css` to support compact and bold modes.
- Implemented CSV/JSON import handlers and client-side export blob generation for both the builder and cards pages, and adjusted unit conversion and click computation logic to respect chosen distance/angle units.

### Testing
- Ran linting with `npm run lint -- src/app/range/dope-card/page.tsx src/app/range/dope-cards/page.tsx src/app/range/dope-cards/[id]/page.tsx`, which completed successfully after fixes.
- Launched the dev server with `npm run dev` and verified pages rendered and behaviors interactively in-browser.
- Captured UI verification screenshots of `/range/dope-cards` and `/range/dope-card` using a headless browser to confirm layout and print-mode visuals (screenshots saved during verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b409a99e788326826f25a4d6626846)