### PR TITLE
Fix slot race condition, dope card silent failure, and toMil/toMoa di…

### DIFF
--- a/src/app/api/builds/[id]/slots/route.ts
+++ b/src/app/api/builds/[id]/slots/route.ts
@@ -35,9 +35,8 @@ export async function PUT(
       return NextResponse.json({ error: "Build not found" }, { status: 404 });
     }
 
-    // If assigning an accessory (not removing), validate it
+    // If assigning an accessory (not removing), validate existence first (outside transaction — read-only, cheap)
     if (accessoryId !== null && accessoryId !== undefined) {
-      // Verify the accessory exists
       const accessory = await prisma.accessory.findUnique({
         where: { id: accessoryId },
       });
@@ -47,59 +46,47 @@ export async function PUT(
           { status: 404 }
         );
       }
-
-      // Check if this accessory is already assigned to another active slot
-      // (across all builds, or more precisely in any slot that belongs to an active build)
-      const existingSlot = await prisma.buildSlot.findFirst({
-        where: {
-          accessoryId,
-          // Exclude the current slot being updated (same buildId + slotType)
-          NOT: {
-            AND: [{ buildId }, { slotType }],
-          },
-          build: {
-            isActive: true,
-          },
-        },
-        include: {
-          build: {
-            select: { id: true, name: true, firearmId: true },
-          },
-        },
-      });
-
-      if (existingSlot) {
-        return NextResponse.json(
-          {
-            error: `This accessory is already assigned to an active build slot (Build: "${existingSlot.build.name}", Slot: ${existingSlot.slotType})`,
-            conflictingSlot: {
-              buildId: existingSlot.buildId,
-              buildName: existingSlot.build.name,
-              slotType: existingSlot.slotType,
-            },
-          },
-          { status: 409 }
-        );
-      }
     }
 
-    // Upsert the slot: create if not exists, update if exists
-    const slot = await prisma.buildSlot.upsert({
-      where: {
-        buildId_slotType: { buildId, slotType },
-      },
-      create: {
-        buildId,
-        slotType,
-        accessoryId: accessoryId ?? null,
-      },
-      update: {
-        accessoryId: accessoryId ?? null,
-      },
-      include: {
-        accessory: true,
-      },
-    });
+    // Wrap the conflict-check + upsert in a transaction so no concurrent request
+    // can slip the same accessory into a second slot between the two operations.
+    let slot;
+    try {
+      slot = await prisma.$transaction(async (tx) => {
+        if (accessoryId !== null && accessoryId !== undefined) {
+          const existingSlot = await tx.buildSlot.findFirst({
+            where: {
+              accessoryId,
+              NOT: { AND: [{ buildId }, { slotType }] },
+              build: { isActive: true },
+            },
+            include: {
+              build: { select: { id: true, name: true, firearmId: true } },
+            },
+          });
+
+          if (existingSlot) {
+            throw Object.assign(
+              new Error(`This accessory is already assigned to an active build slot (Build: "${existingSlot.build.name}", Slot: ${existingSlot.slotType})`),
+              { code: "CONFLICT", conflictingSlot: { buildId: existingSlot.buildId, buildName: existingSlot.build.name, slotType: existingSlot.slotType } }
+            );
+          }
+        }
+
+        return tx.buildSlot.upsert({
+          where: { buildId_slotType: { buildId, slotType } },
+          create: { buildId, slotType, accessoryId: accessoryId ?? null },
+          update: { accessoryId: accessoryId ?? null },
+          include: { accessory: true },
+        });
+      });
+    } catch (txError) {
+      if ((txError as { code?: string }).code === "CONFLICT") {
+        const err = txError as { message: string; conflictingSlot: unknown };
+        return NextResponse.json({ error: err.message, conflictingSlot: err.conflictingSlot }, { status: 409 });
+      }
+      throw txError;
+    }
 
     return NextResponse.json(slot);
   } catch (error) {

--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -44,6 +44,7 @@ export default function DopeCardPage() {
 
   const [rows, setRows] = useState<AngularDopeRow[]>([]);
   const [corrections, setCorrections] = useState<Record<number, DopeRowCorrection>>({});
+  const [generateError, setGenerateError] = useState<string | null>(null);
   const estimationModel = "Physics-based nonlinear stepper";
 
   const estimateSummary = useMemo(() => {
@@ -54,6 +55,11 @@ export default function DopeCardPage() {
 
   function handleGenerate() {
     const distanceRows = generateDistanceRows(Number(startYd), Number(endYd), Number(stepYd));
+    if (!distanceRows.length) {
+      setGenerateError("Invalid distance range. Start must be ≥ 1, end must be ≥ start, and step must be > 0.");
+      return;
+    }
+    setGenerateError(null);
     const solvedRows = solveTrajectoryRows(distanceRows, {
       muzzleVelocityFps: Number(muzzleVelocityFps),
       ballisticCoefficient: Number(ballisticCoefficient),
@@ -196,6 +202,9 @@ export default function DopeCardPage() {
           >
             Generate Estimated Rows
           </button>
+          {generateError && (
+            <p role="alert" className="text-xs text-[#E53935] mt-1">{generateError}</p>
+          )}
         </section>
 
         <section className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">

--- a/src/lib/ballistics/dope.ts
+++ b/src/lib/ballistics/dope.ts
@@ -32,10 +32,12 @@ function roundTo(value: number, digits: number): number {
 }
 
 function toMil(inches: number, distanceYd: number): number {
+  if (distanceYd <= 0) return 0;
   return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MIL);
 }
 
 function toMoa(inches: number, distanceYd: number): number {
+  if (distanceYd <= 0) return 0;
   return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MOA);
 }
 


### PR DESCRIPTION
…v-by-zero

- slots/route.ts: wrap conflict-check + upsert in a $transaction to prevent a concurrent request from assigning the same accessory to two active slots between the read and the write (TOCTOU race condition)
- dope-card/page.tsx: handleGenerate now shows an inline error when generateDistanceRows returns [] (invalid range) instead of silently no-oping
- dope.ts: add distanceYd <= 0 guard to toMil/toMoa to prevent Infinity output if callers bypass the existing filter in convertDropWindToAngular