### PR TITLE
feat(dope-card): consolidate validation, UX profiles, truing, convers…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,6 +223,26 @@ body {
     min-height: 5.5in;
   }
 
+  .dope-print-compact {
+    width: 3in;
+    min-height: 7in;
+  }
+
+  .dope-print-bold-mode table td:first-child,
+  .dope-print-bold-mode table td:nth-child(2) {
+    font-weight: 700 !important;
+    font-size: 0.9rem !important;
+  }
+
+  .dope-print-bold-mode table th:nth-child(3),
+  .dope-print-bold-mode table th:nth-child(5),
+  .dope-print-bold-mode table td:nth-child(3),
+  .dope-print-bold-mode table td:nth-child(5),
+  .dope-print-bold-mode table th:nth-child(6),
+  .dope-print-bold-mode table td:nth-child(6) {
+    display: none !important;
+  }
+
   .dope-print-monochrome,
   .dope-print-monochrome * {
     color: #000 !important;

--- a/src/app/range/dope-card/page.test.ts
+++ b/src/app/range/dope-card/page.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { validateGeneratorInputs } from "@/app/range/dope-card/page";
+
+const VALID_INPUTS = {
+  startYd: "100",
+  endYd: "800",
+  stepYd: "100",
+  muzzleVelocityFps: "2650",
+  ballisticCoefficient: "0.275",
+  zeroRangeYd: "100",
+  sightHeightIn: "1.9",
+};
+
+describe("validateGeneratorInputs", () => {
+  it("accepts valid generator values", () => {
+    expect(validateGeneratorInputs(VALID_INPUTS)).toEqual([]);
+  });
+
+  it("rejects non-positive start/end/step and end before start", () => {
+    const errors = validateGeneratorInputs({
+      ...VALID_INPUTS,
+      startYd: "0",
+      endYd: "-10",
+      stepYd: "0",
+    });
+
+    expect(errors).toContain("Start distance must be greater than 0.");
+    expect(errors).toContain("End distance must be greater than 0.");
+    expect(errors).toContain("Step distance must be greater than 0.");
+    expect(errors).toContain("End distance must be greater than or equal to start distance.");
+  });
+
+  it("rejects non-positive muzzle velocity and ballistic coefficient", () => {
+    const errors = validateGeneratorInputs({
+      ...VALID_INPUTS,
+      muzzleVelocityFps: "0",
+      ballisticCoefficient: "-0.1",
+    });
+
+    expect(errors).toContain("Muzzle velocity must be greater than 0.");
+    expect(errors).toContain("Ballistic coefficient must be greater than 0.");
+  });
+
+  it("rejects non-positive zero range and sight height", () => {
+    const errors = validateGeneratorInputs({
+      ...VALID_INPUTS,
+      zeroRangeYd: "0",
+      sightHeightIn: "-1",
+    });
+
+    expect(errors).toContain("Zero range must be greater than 0.");
+    expect(errors).toContain("Sight height must be greater than 0.");
+  });
+});

--- a/src/app/range/dope-card/page.tsx
+++ b/src/app/range/dope-card/page.tsx
@@ -1,34 +1,100 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import {
   applyDopeCorrections,
   convertDropWindToAngular,
   generateDistanceRows,
   type AngularDopeRow,
+  type BallisticOutputRow,
   type DopeRowCorrection,
+  type WindDirectionUnit,
+  type WindZoneInput,
 } from "@/lib/ballistics/dope";
 import { solveTrajectoryRows, type DragModel } from "@/lib/ballistics/solver";
-import { Calculator, Target } from "lucide-react";
+import { trueBallisticProfile, type TruingParameter } from "@/lib/ballistics/truing";
+import { Calculator, Download, Target, Upload } from "lucide-react";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
 const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+const STORAGE_KEY = "pbv-dope-card-profiles-v1";
+
+interface SavedProfile {
+  name: string;
+  payload: {
+    startYd: string;
+    endYd: string;
+    stepYd: string;
+    muzzleVelocityFps: string;
+    ballisticCoefficient: string;
+    dragModel: DragModel;
+    zeroRangeYd: string;
+    sightHeightIn: string;
+    twistIn: string;
+    temperatureF: string;
+    pressureInHg: string;
+    densityAltitudeFt: string;
+    humidityPercent: string;
+    windSpeedMph: string;
+    windAngleDeg: string;
+    baseRows: AngularDopeRow[];
+    corrections: Record<number, DopeRowCorrection>;
+  };
+}
 
 function parseOptionalNumber(value: string): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function createZone(startYd: number, endYd: number | null): WindZoneInput {
+  return { startYd, endYd, speedMph: 0, directionValue: 90, directionUnit: "degrees" };
+}
+
+function formatDirection(value: number, unit: WindDirectionUnit): string {
+  return unit === "clock" ? `${value} o'clock` : `${value}°`;
+}
+
+export function validateGeneratorInputs(values: {
+  startYd: string;
+  endYd: string;
+  stepYd: string;
+  muzzleVelocityFps: string;
+  ballisticCoefficient: string;
+  zeroRangeYd: string;
+  sightHeightIn: string;
+}): string[] {
+  const errors: string[] = [];
+  const start = Number(values.startYd);
+  const end = Number(values.endYd);
+  const step = Number(values.stepYd);
+  const mv = Number(values.muzzleVelocityFps);
+  const bc = Number(values.ballisticCoefficient);
+  const zero = Number(values.zeroRangeYd);
+  const sh = Number(values.sightHeightIn);
+
+  if (!(start > 0)) errors.push("Start distance must be greater than 0.");
+  if (!(end > 0)) errors.push("End distance must be greater than 0.");
+  if (!(step > 0)) errors.push("Step distance must be greater than 0.");
+  if (Number.isFinite(start) && Number.isFinite(end) && end < start)
+    errors.push("End distance must be greater than or equal to start distance.");
+  if (!(mv > 0)) errors.push("Muzzle velocity must be greater than 0.");
+  if (!(bc > 0)) errors.push("Ballistic coefficient must be greater than 0.");
+  if (!(zero > 0)) errors.push("Zero range must be greater than 0.");
+  if (!(sh > 0)) errors.push("Sight height must be greater than 0.");
+
+  return errors;
+}
+
 export default function DopeCardPage() {
+  // --- Solver inputs ---
   const [startYd, setStartYd] = useState("100");
   const [endYd, setEndYd] = useState("800");
   const [stepYd, setStepYd] = useState("100");
-
   const [muzzleVelocityFps, setMuzzleVelocityFps] = useState("2650");
   const [ballisticCoefficient, setBallisticCoefficient] = useState("0.275");
   const [dragModel, setDragModel] = useState<DragModel>("G7");
@@ -42,10 +108,62 @@ export default function DopeCardPage() {
   const [windSpeedMph, setWindSpeedMph] = useState("10");
   const [windAngleDeg, setWindAngleDeg] = useState("90");
 
-  const [rows, setRows] = useState<AngularDopeRow[]>([]);
+  // --- Wind zones (branch 6) ---
+  const [defaultWindDirectionUnit, setDefaultWindDirectionUnit] = useState<WindDirectionUnit>("degrees");
+  const [useZones, setUseZones] = useState(false);
+  const [zones, setZones] = useState<WindZoneInput[]>([
+    createZone(0, 300),
+    createZone(300, 700),
+    createZone(700, null),
+  ]);
+
+  // --- Reactive data flow (branch 5): base rows + corrections → derived rows ---
+  const [baseRows, setBaseRows] = useState<AngularDopeRow[]>([]);
   const [corrections, setCorrections] = useState<Record<number, DopeRowCorrection>>({});
-  const [generateError, setGenerateError] = useState<string | null>(null);
+  const rows = useMemo(
+    () => applyDopeCorrections(baseRows, corrections),
+    [baseRows, corrections]
+  );
+
+  // --- Truing (branch 3) ---
+  const [untunedRows, setUntunedRows] = useState<AngularDopeRow[]>([]);
+  const [truingParameter, setTruingParameter] = useState<TruingParameter>("mv");
+  const [truingDistanceYd, setTruingDistanceYd] = useState("");
+  const [observedElevationMil, setObservedElevationMil] = useState("");
+  const [truedMv, setTruedMv] = useState<number | null>(null);
+  const [truedBc, setTruedBc] = useState<number | null>(null);
+
+  // --- Profiles (branch 2) ---
+  const [profileName, setProfileName] = useState("");
+  const [profiles, setProfiles] = useState<SavedProfile[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+  const [selectedProfile, setSelectedProfile] = useState("");
+  const importRef = useRef<HTMLInputElement | null>(null);
+
+  // --- Validation (branch 1) ---
+  const validationErrors = useMemo(
+    () =>
+      validateGeneratorInputs({
+        startYd, endYd, stepYd,
+        muzzleVelocityFps, ballisticCoefficient, zeroRangeYd, sightHeightIn,
+      }),
+    [startYd, endYd, stepYd, muzzleVelocityFps, ballisticCoefficient, zeroRangeYd, sightHeightIn]
+  );
+
+
   const estimationModel = "Physics-based nonlinear stepper";
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+  }, [profiles]);
 
   const estimateSummary = useMemo(() => {
     if (!rows.length) return null;
@@ -53,13 +171,32 @@ export default function DopeCardPage() {
     return `${confirmedCount}/${rows.length} rows confirmed from impacts`;
   }, [rows]);
 
+  const windAssumptionSummary = useMemo(() => {
+    const defaultSummary = `${windSpeedMph || 0} mph @ ${formatDirection(Number(windAngleDeg) || 0, defaultWindDirectionUnit)}`;
+    if (!useZones) return `Single wind: ${defaultSummary}`;
+    const zoneSummary = zones
+      .map((zone) => {
+        const endLabel = zone.endYd == null ? "+" : `-${zone.endYd}`;
+        return `${zone.startYd}${endLabel} yd: ${zone.speedMph} mph @ ${formatDirection(zone.directionValue, zone.directionUnit)}`;
+      })
+      .join(" • ");
+    return `Zone winds: ${zoneSummary}`;
+  }, [defaultWindDirectionUnit, windAngleDeg, windSpeedMph, useZones, zones]);
+
+  const confirmedRows = rows.filter((row) => row.confirmed);
+  const isTrued = truedMv !== null || truedBc !== null;
+
+  function updateZone(index: number, patch: Partial<WindZoneInput>) {
+    setZones((prev) => prev.map((zone, i) => (i === index ? { ...zone, ...patch } : zone)));
+  }
+
   function handleGenerate() {
+    if (validationErrors.length > 0) return;
+
     const distanceRows = generateDistanceRows(Number(startYd), Number(endYd), Number(stepYd));
-    if (!distanceRows.length) {
-      setGenerateError("Invalid distance range. Start must be ≥ 1, end must be ≥ start, and step must be > 0.");
-      return;
-    }
-    setGenerateError(null);
+    if (distanceRows.length === 0) return;
+
+
     const solvedRows = solveTrajectoryRows(distanceRows, {
       muzzleVelocityFps: Number(muzzleVelocityFps),
       ballisticCoefficient: Number(ballisticCoefficient),
@@ -75,38 +212,135 @@ export default function DopeCardPage() {
       windAngleDeg: Number(windAngleDeg),
     });
 
+    const converted = convertDropWindToAngular(solvedRows);
     setCorrections({});
-    setRows(convertDropWindToAngular(solvedRows));
+    setUntunedRows(converted);
+    setBaseRows(converted);
+    setTruedMv(null);
+    setTruedBc(null);
   }
 
   function updateCorrection(distanceYd: number, patch: DopeRowCorrection) {
     const existing = corrections[distanceYd] ?? {};
-    const merged: DopeRowCorrection = {
-      ...existing,
-      ...patch,
-    };
+    const merged: DopeRowCorrection = { ...existing, ...patch };
 
-    if (patch.dropIn === undefined) {
-      delete merged.dropIn;
-    }
-
-    if (patch.windIn === undefined) {
-      delete merged.windIn;
-    }
+    if (patch.dropIn === undefined) delete merged.dropIn;
+    if (patch.windIn === undefined) delete merged.windIn;
 
     const hasAnyCorrection =
       merged.dropIn !== undefined || merged.windIn !== undefined || merged.confirmed !== undefined;
-    const nextCorrections = {
-      ...corrections,
-      ...(hasAnyCorrection ? { [distanceYd]: merged } : {}),
-    };
-
-    if (!hasAnyCorrection) {
-      delete nextCorrections[distanceYd];
-    }
+    const nextCorrections = { ...corrections, ...(hasAnyCorrection ? { [distanceYd]: merged } : {}) };
+    if (!hasAnyCorrection) delete nextCorrections[distanceYd];
 
     setCorrections(nextCorrections);
-    setRows((prev) => applyDopeCorrections(prev, nextCorrections));
+  }
+
+  function handleTrueProfile() {
+    const baselineMv = Number(muzzleVelocityFps);
+    const baselineBc = Number(ballisticCoefficient);
+    const targetDistanceYd = Number(truingDistanceYd);
+    const observedMil = Number(observedElevationMil);
+
+    const baseSourceRows: BallisticOutputRow[] = untunedRows.map((row) => ({
+      distanceYd: row.distanceYd,
+      dropIn: row.dropIn,
+      windIn: row.windIn,
+    }));
+
+    const trued = trueBallisticProfile({
+      rows: baseSourceRows,
+      baselineMv,
+      baselineBc,
+      targetDistanceYd,
+      observedElevationMil: observedMil,
+      adjust: truingParameter,
+    });
+
+    if (!trued) return;
+
+    const angularTruedRows = convertDropWindToAngular(trued.rows);
+    setBaseRows(angularTruedRows);
+    setTruedMv(trued.truedMv);
+    setTruedBc(trued.truedBc);
+  }
+
+  function resetTruing() {
+    setTruedMv(null);
+    setTruedBc(null);
+    setBaseRows(untunedRows);
+  }
+
+  function saveProfile() {
+    const name = profileName.trim();
+    if (!name) return;
+    const payload = {
+      startYd, endYd, stepYd,
+      muzzleVelocityFps, ballisticCoefficient, dragModel,
+      zeroRangeYd, sightHeightIn, twistIn, temperatureF, pressureInHg,
+      densityAltitudeFt, humidityPercent, windSpeedMph, windAngleDeg,
+      baseRows, corrections,
+    };
+    setProfiles((current) => [...current.filter((p) => p.name !== name), { name, payload }]);
+    setSelectedProfile(name);
+  }
+
+  function loadProfile() {
+    const profile = profiles.find((p) => p.name === selectedProfile);
+    if (!profile) return;
+    const p = profile.payload;
+    setStartYd(p.startYd); setEndYd(p.endYd); setStepYd(p.stepYd);
+    setMuzzleVelocityFps(p.muzzleVelocityFps);
+    setBallisticCoefficient(p.ballisticCoefficient);
+    setDragModel(p.dragModel);
+    setZeroRangeYd(p.zeroRangeYd); setSightHeightIn(p.sightHeightIn);
+    setTwistIn(p.twistIn); setTemperatureF(p.temperatureF);
+    setPressureInHg(p.pressureInHg); setDensityAltitudeFt(p.densityAltitudeFt);
+    setHumidityPercent(p.humidityPercent);
+    setWindSpeedMph(p.windSpeedMph); setWindAngleDeg(p.windAngleDeg);
+    setBaseRows(p.baseRows); setCorrections(p.corrections);
+    setProfileName(profile.name);
+  }
+
+  function handleExport() {
+    if (!rows.length) return;
+    const lines = [
+      "DOPE CARD EXPORT",
+      `Wind assumptions: ${windAssumptionSummary}`,
+      "distance_yd,drop_in,drop_mil,drop_moa,wind_in,wind_mil,wind_moa,confirmed",
+      ...rows.map((row) =>
+        [row.distanceYd, row.dropIn, row.dropMil, row.dropMoa, row.windIn, row.windMil, row.windMoa, row.confirmed ? "yes" : "no"].join(",")
+      ),
+    ];
+    const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "dope-card.csv"; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleImport(file?: File) {
+    if (!file) return;
+    file.text().then((text) => {
+      if (file.name.endsWith(".json")) {
+        const parsed = JSON.parse(text);
+        if (Array.isArray(parsed.baseRows)) setBaseRows(parsed.baseRows);
+        if (parsed.corrections) setCorrections(parsed.corrections);
+        if (parsed.startYd) setStartYd(parsed.startYd);
+        if (parsed.endYd) setEndYd(parsed.endYd);
+      } else {
+        const lines = text.trim().split("\n").filter((l) => !l.startsWith("DOPE") && !l.startsWith("Wind") && !l.startsWith("distance_yd"));
+        const importedRows: AngularDopeRow[] = lines.map((line) => {
+          const [distanceYd, dropIn, dropMil, dropMoa, windIn, windMil, windMoa, confirmed] = line.split(",");
+          return {
+            distanceYd: Number(distanceYd), dropIn: Number(dropIn),
+            dropMil: Number(dropMil), dropMoa: Number(dropMoa),
+            windIn: Number(windIn), windMil: Number(windMil), windMoa: Number(windMoa),
+            confirmed: confirmed?.trim() === "yes" || confirmed?.trim() === "true",
+          };
+        });
+        setBaseRows(importedRows);
+      }
+    });
   }
 
   return (
@@ -117,6 +351,7 @@ export default function DopeCardPage() {
       />
 
       <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+        {/* Warning banner */}
         <div className="bg-[#F5A623]/10 border border-[#F5A623]/30 rounded-lg p-4 space-y-1">
           <p className="text-sm text-[#F5A623] font-medium">
             Estimate only: this builder is a starting point and is not a replacement for verified firing data.
@@ -124,6 +359,7 @@ export default function DopeCardPage() {
           <p className="text-xs text-vault-text-muted">Estimation model: {estimationModel}</p>
         </div>
 
+        {/* Solver inputs */}
         <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
           <div className="flex items-center gap-2">
             <Calculator className="w-4 h-4 text-[#00C2FF]" />
@@ -194,26 +430,207 @@ export default function DopeCardPage() {
               <label className={LABEL_CLASS}>Wind Angle (deg)</label>
               <input value={windAngleDeg} onChange={(e) => setWindAngleDeg(e.target.value)} type="number" className={INPUT_CLASS} />
             </div>
+            <div>
+              <label className={LABEL_CLASS}>Wind Direction Unit</label>
+              <select value={defaultWindDirectionUnit} onChange={(e) => setDefaultWindDirectionUnit(e.target.value as WindDirectionUnit)} className={INPUT_CLASS}>
+                <option value="degrees">Degrees</option>
+                <option value="clock">Clock</option>
+              </select>
+            </div>
           </div>
 
-          <button
-            onClick={handleGenerate}
-            className="px-4 py-2 text-sm rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 transition-colors"
-          >
-            Generate Estimated Rows
-          </button>
-          {generateError && (
-            <p role="alert" className="text-xs text-[#E53935] mt-1">{generateError}</p>
+          {validationErrors.length > 0 && (
+            <div role="alert" className="rounded-md bg-[#E53935]/10 border border-[#E53935]/30 p-3 space-y-1">
+              {validationErrors.map((err) => (
+                <p key={err} className="text-xs text-[#E53935]">{err}</p>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              onClick={handleGenerate}
+              disabled={validationErrors.length > 0}
+              className="px-4 py-2 text-sm rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Generate Estimated Rows
+            </button>
+            <button
+              onClick={handleExport}
+              disabled={!rows.length}
+              className="flex items-center gap-2 px-4 py-2 text-sm rounded-md border border-vault-border text-vault-text-muted hover:text-vault-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Export CSV
+            </button>
+          </div>
+        </section>
+
+        {/* Wind zones panel (branch 6) */}
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <label className="inline-flex items-center gap-2 text-sm text-vault-text-muted">
+            <input type="checkbox" checked={useZones} onChange={(e) => setUseZones(e.target.checked)} className="accent-[#00C2FF]" />
+            Enable multi-zone winds (0-300, 300-700, 700+)
+          </label>
+
+          {useZones && (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {zones.map((zone, index) => (
+                <div key={`${zone.startYd}-${zone.endYd ?? "plus"}`} className="border border-vault-border rounded-md p-3 space-y-2">
+                  <p className="text-xs text-vault-text-muted font-mono">
+                    Zone {zone.startYd}-{zone.endYd ?? "+"} yd
+                  </p>
+                  <input
+                    className={INPUT_CLASS}
+                    type="number"
+                    step="0.1"
+                    value={zone.speedMph}
+                    onChange={(e) => updateZone(index, { speedMph: Number(e.target.value) })}
+                    placeholder="Speed (mph)"
+                  />
+                  <input
+                    className={INPUT_CLASS}
+                    type="number"
+                    value={zone.directionValue}
+                    onChange={(e) => updateZone(index, { directionValue: Number(e.target.value) })}
+                    placeholder={zone.directionUnit === "clock" ? "Clock (1-12)" : "Direction (deg)"}
+                  />
+                  <select
+                    className={INPUT_CLASS}
+                    value={zone.directionUnit}
+                    onChange={(e) => updateZone(index, { directionUnit: e.target.value as WindDirectionUnit })}
+                  >
+                    <option value="degrees">Degrees</option>
+                    <option value="clock">Clock</option>
+                  </select>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {rows.length > 0 && (
+            <p className="text-xs text-vault-text-muted">{windAssumptionSummary}</p>
           )}
         </section>
 
+        {/* Truing panel (branch 3) */}
+        {rows.length > 0 && (
+          <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <h2 className="text-xs uppercase tracking-widest text-[#00C2FF] font-mono">Ballistic Truing</h2>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div>
+                <label className={LABEL_CLASS}>Adjust</label>
+                <select value={truingParameter} onChange={(e) => setTruingParameter(e.target.value as TruingParameter)} className={INPUT_CLASS}>
+                  <option value="mv">Muzzle Velocity</option>
+                  <option value="bc">Ballistic Coefficient</option>
+                </select>
+              </div>
+              <div>
+                <label className={LABEL_CLASS}>Confirmed Distance Row</label>
+                <select value={truingDistanceYd} onChange={(e) => setTruingDistanceYd(e.target.value)} className={INPUT_CLASS}>
+                  <option value="">Select row</option>
+                  {confirmedRows.map((row) => (
+                    <option key={row.distanceYd} value={row.distanceYd}>
+                      {row.distanceYd} yd
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={LABEL_CLASS}>Observed Elevation (mil)</label>
+                <input
+                  value={observedElevationMil}
+                  onChange={(e) => setObservedElevationMil(e.target.value)}
+                  type="number"
+                  step="0.01"
+                  className={INPUT_CLASS}
+                />
+              </div>
+              <div className="flex items-end gap-2">
+                <button
+                  onClick={handleTrueProfile}
+                  className="px-4 py-2 text-sm rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 transition-colors"
+                >
+                  Apply Truing
+                </button>
+                <button
+                  onClick={resetTruing}
+                  className="px-4 py-2 text-sm rounded-md border border-vault-border text-vault-text-muted hover:text-vault-text transition-colors"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+            {isTrued && (
+              <p className="text-xs text-vault-text-muted">
+                Trued values — MV: {truedMv?.toFixed(1)} fps, BC: {truedBc?.toFixed(4)} (untuned preserved for reset).
+              </p>
+            )}
+          </section>
+        )}
+
+        {/* Profile management panel (branch 2) */}
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <h2 className="text-xs uppercase tracking-widest text-vault-text-muted font-mono">Profiles</h2>
+          <div className="flex items-center gap-2 flex-wrap">
+            <input
+              value={profileName}
+              onChange={(e) => setProfileName(e.target.value)}
+              placeholder="Profile name"
+              className={`${INPUT_CLASS} max-w-[200px]`}
+            />
+            <button onClick={saveProfile} className="px-3 py-2 rounded-md border border-vault-border text-xs text-vault-text-muted hover:text-vault-text transition-colors">
+              Save
+            </button>
+          </div>
+          {profiles.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <select value={selectedProfile} onChange={(e) => setSelectedProfile(e.target.value)} className={`${INPUT_CLASS} max-w-[200px]`}>
+                <option value="">Select profile</option>
+                {profiles.map((p) => (
+                  <option key={p.name} value={p.name}>{p.name}</option>
+                ))}
+              </select>
+              <button onClick={loadProfile} className="px-3 py-2 rounded-md border border-vault-border text-xs text-vault-text-muted hover:text-vault-text transition-colors">
+                Load
+              </button>
+              <button
+                onClick={() => setProfiles((prev) => prev.filter((p) => p.name !== selectedProfile))}
+                className="px-3 py-2 rounded-md border border-[#E53935]/30 text-xs text-[#E53935] hover:bg-[#E53935]/10 transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => importRef.current?.click()}
+              className="flex items-center gap-2 px-3 py-2 rounded-md border border-vault-border text-xs text-vault-text-muted hover:text-vault-text transition-colors"
+            >
+              <Upload className="w-3.5 h-3.5" />
+              Import CSV/JSON
+            </button>
+            <input
+              ref={importRef}
+              type="file"
+              accept=".csv,.json"
+              className="hidden"
+              onChange={(e) => handleImport(e.target.files?.[0])}
+            />
+          </div>
+        </section>
+
+        {/* Row corrections table */}
         <section className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
           <div className="px-4 py-3 border-b border-vault-border flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Target className="w-4 h-4 text-[#00C853]" />
               <h3 className="text-xs font-mono uppercase tracking-widest text-[#00C853]">Row Corrections from Confirmed Impacts</h3>
             </div>
-            {estimateSummary && <p className="text-xs text-vault-text-muted">{estimateSummary}</p>}
+            <div className="flex items-center gap-3">
+              {isTrued && <span className="text-[11px] uppercase tracking-widest text-[#00C853]">Trued</span>}
+              {estimateSummary && <p className="text-xs text-vault-text-muted">{estimateSummary}</p>}
+            </div>
           </div>
 
           <div className="overflow-x-auto">

--- a/src/lib/__tests__/dope.test.ts
+++ b/src/lib/__tests__/dope.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   applyDopeCorrections,
   convertDropWindToAngular,
+  effectiveCrosswindMph,
+  estimateWindDriftIn,
   generateDistanceRows,
+  windDirectionToDegrees,
 } from "@/lib/ballistics/dope";
 
 describe("generateDistanceRows", () => {
@@ -97,5 +100,60 @@ describe("applyDopeCorrections", () => {
     expect(Number.isNaN(corrected[0].dropMoa)).toBe(false);
     expect(Number.isNaN(corrected[0].windMil)).toBe(false);
     expect(Number.isNaN(corrected[0].windMoa)).toBe(false);
+  });
+});
+
+describe("wind angle decomposition", () => {
+  it("handles 0°, 45°, and 90° crosswind components", () => {
+    expect(effectiveCrosswindMph(10, 0)).toBeCloseTo(0, 5);
+    expect(effectiveCrosswindMph(10, 45)).toBeCloseTo(7.07, 2);
+    expect(effectiveCrosswindMph(10, 90)).toBeCloseTo(10, 5);
+  });
+
+  it("supports clock direction values", () => {
+    expect(windDirectionToDegrees(3, "clock")).toBe(90);
+    expect(windDirectionToDegrees(12, "clock")).toBe(0);
+  });
+});
+
+describe("wind zones", () => {
+  it("applies zone-based wind settings by distance segment", () => {
+    const input = {
+      windDriftPerMphPer100YdIn: 0.1,
+      defaultWind: { speedMph: 10, directionValue: 90, directionUnit: "degrees" as const },
+      zones: [
+        { startYd: 0, endYd: 300, speedMph: 5, directionValue: 90, directionUnit: "degrees" as const },
+        { startYd: 300, endYd: 700, speedMph: 10, directionValue: 45, directionUnit: "degrees" as const },
+        { startYd: 700, endYd: null, speedMph: 12, directionValue: 90, directionUnit: "degrees" as const },
+      ],
+    };
+
+    expect(estimateWindDriftIn(200, input)).toBe(1);
+    expect(estimateWindDriftIn(500, input)).toBe(3.54);
+    expect(estimateWindDriftIn(800, input)).toBe(9.6);
+  });
+});
+
+describe("derived rows pattern", () => {
+  it("stays stable across repeated correction edits when recalculated from base rows", () => {
+    const baseRows = [
+      { distanceYd: 100, dropIn: 3.5, windIn: 1.2 },
+      { distanceYd: 200, dropIn: 7, windIn: 2.4 },
+    ];
+
+    const deriveRows = (corrections: Record<number, { dropIn?: number; windIn?: number; confirmed?: boolean }>) =>
+      applyDopeCorrections(convertDropWindToAngular(baseRows), corrections);
+
+    let rows = deriveRows({});
+    expect(rows[0]).toMatchObject({ dropIn: 3.5, windIn: 1.2, confirmed: false });
+
+    rows = deriveRows({ 100: { dropIn: 4.1 } });
+    expect(rows[0]).toMatchObject({ dropIn: 4.1, windIn: 1.2, confirmed: false });
+
+    rows = deriveRows({ 100: { dropIn: 4.1, confirmed: true } });
+    expect(rows[0]).toMatchObject({ dropIn: 4.1, windIn: 1.2, confirmed: true });
+
+    rows = deriveRows({ 100: { windIn: 1.8, confirmed: false } });
+    expect(rows[0]).toMatchObject({ dropIn: 3.5, windIn: 1.8, confirmed: false });
   });
 });

--- a/src/lib/__tests__/truing.test.ts
+++ b/src/lib/__tests__/truing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { trueBallisticProfile } from "@/lib/ballistics/truing";
+
+const baseRows = [
+  { distanceYd: 100, dropIn: 3.5, windIn: 1.2 },
+  { distanceYd: 200, dropIn: 7, windIn: 2.4 },
+  { distanceYd: 300, dropIn: 10.5, windIn: 3.6 },
+  { distanceYd: 400, dropIn: 14, windIn: 4.8 },
+];
+
+describe("trueBallisticProfile", () => {
+  it("converges when truing muzzle velocity from an observed impact", () => {
+    const result = trueBallisticProfile({
+      rows: baseRows,
+      baselineMv: 2750,
+      baselineBc: 0.5,
+      targetDistanceYd: 400,
+      observedElevationMil: 1.2,
+      adjust: "mv",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.truedMv).toBeCloseTo(2475.28, 2);
+    expect(result!.truedBc).toBe(0.5);
+    expect(Math.abs(result!.targetErrorMil)).toBeLessThan(0.0001);
+  });
+
+  it("returns deterministic output for repeated runs", () => {
+    const runA = trueBallisticProfile({
+      rows: baseRows,
+      baselineMv: 2750,
+      baselineBc: 0.5,
+      targetDistanceYd: 300,
+      observedElevationMil: 1.1,
+      adjust: "bc",
+    });
+
+    const runB = trueBallisticProfile({
+      rows: baseRows,
+      baselineMv: 2750,
+      baselineBc: 0.5,
+      targetDistanceYd: 300,
+      observedElevationMil: 1.1,
+      adjust: "bc",
+    });
+
+    expect(runA).toEqual(runB);
+    expect(runA!.truedBc).toBeCloseTo(0.442, 3);
+  });
+});

--- a/src/lib/ballistics/conversions.ts
+++ b/src/lib/ballistics/conversions.ts
@@ -1,0 +1,27 @@
+const INCHES_PER_100YD_PER_MIL = 3.6;
+const INCHES_PER_100YD_PER_MOA = 1.047;
+
+export function roundTo(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+export function yardsToFeet(yards: number): number {
+  return yards * 3;
+}
+
+export function mphToFps(mph: number): number {
+  return mph * 1.4666666667;
+}
+
+export function degreesToRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+export function inchesToMil(inches: number, distanceYd: number): number {
+  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MIL);
+}
+
+export function inchesToMoa(inches: number, distanceYd: number): number {
+  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MOA);
+}

--- a/src/lib/ballistics/dope.ts
+++ b/src/lib/ballistics/dope.ts
@@ -1,3 +1,24 @@
+import { roundTo, inchesToMil, inchesToMoa } from "@/lib/ballistics/conversions";
+
+export type WindDirectionUnit = "degrees" | "clock";
+
+export interface WindInput {
+  speedMph: number;
+  directionValue: number;
+  directionUnit: WindDirectionUnit;
+}
+
+export interface WindZoneInput extends WindInput {
+  startYd: number;
+  endYd: number | null;
+}
+
+export interface WindSolverInput {
+  windDriftPerMphPer100YdIn: number;
+  defaultWind: WindInput;
+  zones?: WindZoneInput[];
+}
+
 export interface DistanceRow {
   distanceYd: number;
 }
@@ -22,28 +43,53 @@ export interface DopeRowCorrection {
   confirmed?: boolean;
 }
 
-const INCHES_PER_100YD_PER_MIL = 3.6;
-const INCHES_PER_100YD_PER_MOA = 1.047;
 const DISTANCE_EPSILON = 1e-6;
-
-function roundTo(value: number, digits: number): number {
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
-}
-
-function toMil(inches: number, distanceYd: number): number {
-  if (distanceYd <= 0) return 0;
-  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MIL);
-}
-
-function toMoa(inches: number, distanceYd: number): number {
-  if (distanceYd <= 0) return 0;
-  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MOA);
-}
 
 function safeInches(value: number): number {
   // Keep conversions stable even if a caller passes invalid correction/input values.
   return Number.isFinite(value) ? value : 0;
+}
+
+export function windDirectionToDegrees(directionValue: number, directionUnit: WindDirectionUnit): number {
+  if (!Number.isFinite(directionValue)) return 0;
+  if (directionUnit === "clock") {
+    const clock = ((directionValue % 12) + 12) % 12;
+    return clock * 30;
+  }
+
+  const normalized = directionValue % 360;
+  return normalized < 0 ? normalized + 360 : normalized;
+}
+
+export function effectiveCrosswindMph(speedMph: number, directionDegrees: number): number {
+  if (!Number.isFinite(speedMph) || !Number.isFinite(directionDegrees)) {
+    return 0;
+  }
+
+  const radians = (directionDegrees * Math.PI) / 180;
+  return Math.abs(speedMph * Math.sin(radians));
+}
+
+function resolveWindForDistance(distanceYd: number, input: WindSolverInput): WindInput {
+  const zone = input.zones?.find((candidate) => {
+    const withinStart = distanceYd >= candidate.startYd;
+    const withinEnd = candidate.endYd == null || distanceYd < candidate.endYd;
+    return withinStart && withinEnd;
+  });
+
+  return zone ?? input.defaultWind;
+}
+
+export function estimateWindDriftIn(distanceYd: number, input: WindSolverInput): number {
+  if (!Number.isFinite(distanceYd) || distanceYd <= 0 || !Number.isFinite(input.windDriftPerMphPer100YdIn)) {
+    return 0;
+  }
+
+  const wind = resolveWindForDistance(distanceYd, input);
+  const directionDegrees = windDirectionToDegrees(wind.directionValue, wind.directionUnit);
+  const crosswindMph = effectiveCrosswindMph(wind.speedMph, directionDegrees);
+
+  return roundTo((distanceYd / 100) * input.windDriftPerMphPer100YdIn * crosswindMph, 2);
 }
 
 export function generateDistanceRows(startYd: number, endYd: number, stepYd: number): DistanceRow[] {
@@ -90,10 +136,10 @@ export function convertDropWindToAngular(rows: BallisticOutputRow[]): AngularDop
         ...row,
         dropIn,
         windIn,
-        dropMil: roundTo(toMil(dropIn, row.distanceYd), 2),
-        dropMoa: roundTo(toMoa(dropIn, row.distanceYd), 2),
-        windMil: roundTo(toMil(windIn, row.distanceYd), 2),
-        windMoa: roundTo(toMoa(windIn, row.distanceYd), 2),
+        dropMil: roundTo(inchesToMil(dropIn, row.distanceYd), 2),
+        dropMoa: roundTo(inchesToMoa(dropIn, row.distanceYd), 2),
+        windMil: roundTo(inchesToMil(windIn, row.distanceYd), 2),
+        windMoa: roundTo(inchesToMoa(windIn, row.distanceYd), 2),
         confirmed: false,
       };
     });
@@ -114,10 +160,10 @@ export function applyDopeCorrections(
       ...row,
       dropIn,
       windIn,
-      dropMil: roundTo(toMil(dropIn, row.distanceYd), 2),
-      dropMoa: roundTo(toMoa(dropIn, row.distanceYd), 2),
-      windMil: roundTo(toMil(windIn, row.distanceYd), 2),
-      windMoa: roundTo(toMoa(windIn, row.distanceYd), 2),
+      dropMil: roundTo(inchesToMil(dropIn, row.distanceYd), 2),
+      dropMoa: roundTo(inchesToMoa(dropIn, row.distanceYd), 2),
+      windMil: roundTo(inchesToMil(windIn, row.distanceYd), 2),
+      windMoa: roundTo(inchesToMoa(windIn, row.distanceYd), 2),
       confirmed: correction.confirmed ?? row.confirmed,
     };
   });

--- a/src/lib/ballistics/truing.ts
+++ b/src/lib/ballistics/truing.ts
@@ -1,0 +1,107 @@
+import type { BallisticOutputRow } from "@/lib/ballistics/dope";
+
+const INCHES_PER_100YD_PER_MIL = 3.6;
+
+export type TruingParameter = "mv" | "bc";
+
+export interface TrueProfileInput {
+  rows: BallisticOutputRow[];
+  baselineMv: number;
+  baselineBc: number;
+  targetDistanceYd: number;
+  observedElevationMil: number;
+  adjust: TruingParameter;
+}
+
+export interface TruedProfile {
+  rows: BallisticOutputRow[];
+  truedMv: number;
+  truedBc: number;
+  targetErrorMil: number;
+}
+
+function toMil(inches: number, distanceYd: number): number {
+  return inches / ((distanceYd / 100) * INCHES_PER_100YD_PER_MIL);
+}
+
+function scaleRows(
+  rows: BallisticOutputRow[],
+  baselineMv: number,
+  baselineBc: number,
+  candidateMv: number,
+  candidateBc: number
+): BallisticOutputRow[] {
+  const scale = (baselineMv / candidateMv) ** 2 * (baselineBc / candidateBc);
+  return rows.map((row) => ({
+    ...row,
+    dropIn: row.dropIn * scale,
+    windIn: row.windIn * scale,
+  }));
+}
+
+export function trueBallisticProfile(input: TrueProfileInput): TruedProfile | null {
+  const { rows, baselineMv, baselineBc, targetDistanceYd, observedElevationMil, adjust } = input;
+  if (!rows.length || baselineMv <= 0 || baselineBc <= 0 || targetDistanceYd <= 0 || observedElevationMil <= 0) {
+    return null;
+  }
+
+  const targetRow = rows.find((row) => row.distanceYd === targetDistanceYd);
+  if (!targetRow) return null;
+
+  const evaluate = (candidate: number): number => {
+    const scaled =
+      adjust === "mv"
+        ? scaleRows(rows, baselineMv, baselineBc, candidate, baselineBc)
+        : scaleRows(rows, baselineMv, baselineBc, baselineMv, candidate);
+    const row = scaled.find((r) => r.distanceYd === targetDistanceYd);
+    if (!row) return Number.POSITIVE_INFINITY;
+    return toMil(row.dropIn, row.distanceYd) - observedElevationMil;
+  };
+
+  let low = adjust === "mv" ? baselineMv * 0.5 : baselineBc * 0.5;
+  let high = adjust === "mv" ? baselineMv * 1.5 : baselineBc * 1.5;
+  let lowErr = evaluate(low);
+  let highErr = evaluate(high);
+
+  let expands = 0;
+  while (lowErr * highErr > 0 && expands < 8) {
+    low *= 0.8;
+    high *= 1.2;
+    lowErr = evaluate(low);
+    highErr = evaluate(high);
+    expands += 1;
+  }
+
+  if (lowErr * highErr > 0) return null;
+
+  for (let i = 0; i < 40; i += 1) {
+    const mid = (low + high) / 2;
+    const midErr = evaluate(mid);
+    if (Math.abs(midErr) < 1e-6) {
+      low = mid;
+      high = mid;
+      break;
+    }
+
+    if (lowErr * midErr <= 0) {
+      high = mid;
+      highErr = midErr;
+    } else {
+      low = mid;
+      lowErr = midErr;
+    }
+  }
+
+  const tunedValue = (low + high) / 2;
+  const truedMv = adjust === "mv" ? tunedValue : baselineMv;
+  const truedBc = adjust === "bc" ? tunedValue : baselineBc;
+  const truedRows = scaleRows(rows, baselineMv, baselineBc, truedMv, truedBc);
+  const targetErrorMil = evaluate(tunedValue);
+
+  return {
+    rows: truedRows,
+    truedMv,
+    truedBc,
+    targetErrorMil,
+  };
+}


### PR DESCRIPTION
…ions, reactive rows, wind zones

- Add conversions.ts module (roundTo, inchesToMil, inchesToMoa, mphToFps, degreesToRadians)
- Refactor dope.ts to import from conversions; add wind types and functions (WindDirectionUnit, WindInput, WindZoneInput, WindSolverInput, windDirectionToDegrees, effectiveCrosswindMph, estimateWindDriftIn)
- Add truing.ts with binary-search ballistic profile truer (TruingParameter, trueBallisticProfile)
- Extend dope.test.ts with wind angle decomposition, wind zones, and derived-rows stability tests
- Add truing.test.ts
- Unify dope-card page.tsx with all 6 feature branches:
  - Reactive data flow: baseRows state + rows as useMemo (branch 5)
  - Form validation: validateGeneratorInputs export + disabled button + error display (branch 1)
  - Wind zones: multi-zone UI with per-zone speed/direction/unit inputs (branch 6)
  - Ballistic truing: Apply Truing / Reset panel using truing.ts (branch 3)
  - Profile management: save/load/delete via localStorage + CSV/JSON import (branch 2)
  - CSV export with wind assumption summary in header (branches 2 + 6)
- Add page.test.ts for validateGeneratorInputs
- Append dope-print-compact and dope-print-bold-mode classes to globals.css (branch 2)

Closes: codex/improve-form-validation-in-dope-card, codex/enhance-dope-card-ux-features,
        codex/extend-dope-card-for-true-mv/bc-support,
        codex/upgrade-estimate-generation-with-calculator-module,
        codex/refactor-data-flow-in-dope-card, codex/improve-wind-handling-in-dope-card