### PR TITLE
Add SafeImage component and use it across vault, accessories, dashboard, and builds

### DIFF
--- a/src/app/accessories/page.tsx
+++ b/src/app/accessories/page.tsx
@@ -4,8 +4,8 @@ export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { SafeImage } from "@/components/shared/SafeImage";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import { Plus, Crosshair, Shield, ExternalLink, Loader2, ChevronDown } from "lucide-react";
 import { SLOT_TYPE_LABELS, SlotType, SLOT_TYPES } from "@/lib/types";
@@ -164,11 +164,15 @@ export default function AccessoriesPage() {
                       <tr key={accessory.id} className="hover:bg-vault-surface-2 transition-colors group">
                         <td className="px-4 py-3">
                           <div className="relative w-9 h-9 rounded bg-vault-bg border border-vault-border overflow-hidden flex items-center justify-center shrink-0">
-                            {accessory.imageUrl ? (
-                              <Image src={accessory.imageUrl} alt={accessory.name} fill sizes="36px" loading="lazy" className="w-full h-full object-cover" />
-                            ) : (
-                              <Shield className="w-4 h-4 text-vault-text-faint" />
-                            )}
+                            <SafeImage
+                              src={accessory.imageUrl}
+                              alt={accessory.name}
+                              fill
+                              sizes="36px"
+                              loading="lazy"
+                              className="w-full h-full object-cover"
+                              fallback={<Shield className="w-4 h-4 text-vault-text-faint" />}
+                            />
                           </div>
                         </td>
                         <td className="px-4 py-3">

--- a/src/app/vault/[id]/builds/[buildId]/page.tsx
+++ b/src/app/vault/[id]/builds/[buildId]/page.tsx
@@ -18,6 +18,7 @@ import {
   Save,
 } from "lucide-react";
 import { SLOTS_BY_FIREARM_TYPE, SLOT_TYPE_LABELS, FirearmType, SlotType } from "@/lib/types";
+import { SafeImage } from "@/components/shared/SafeImage";
 import { SLOT_ICONS } from "@/lib/configurator/slot-icons";
 
 // ─── Types ────────────────────────────────────────────────────
@@ -506,12 +507,15 @@ function AccessoryBrowserModal({
                       className="flex items-center gap-3 text-left w-full bg-vault-bg border border-vault-border hover:border-[#00C2FF]/40 hover:bg-[#00C2FF]/5 rounded-lg p-3 transition-all disabled:opacity-60 disabled:cursor-not-allowed group"
                     >
                       <div className="w-14 h-14 shrink-0 rounded-md overflow-hidden bg-vault-surface border border-vault-border flex items-center justify-center">
-                        {acc.imageUrl ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img src={acc.imageUrl} alt={acc.name} className="w-full h-full object-contain p-1" />
-                        ) : (
-                          <SlotIcon className="w-6 h-6" style={{ color: slotIconConfig?.color ?? "#4A5A6B" }} />
-                        )}
+                        <SafeImage
+                          src={acc.imageUrl}
+                          alt={acc.name}
+                          width={56}
+                          height={56}
+                          loading="lazy"
+                          className="w-full h-full object-contain p-1"
+                          fallback={<SlotIcon className="w-6 h-6" style={{ color: slotIconConfig?.color ?? "#4A5A6B" }} />}
+                        />
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium text-vault-text truncate group-hover:text-[#00C2FF] transition-colors">

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { SafeImage } from "@/components/shared/SafeImage";
 import { formatCurrency, formatNumber } from "@/lib/utils";
 import {
   Shield,
@@ -115,25 +115,24 @@ function FirearmCard({ firearm, editMode, editBuilds, onDeleteBuild }: FirearmCa
     <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden hover:border-[#00C2FF]/30 transition-colors group flex flex-col">
       {/* Image / Placeholder */}
       <div className="h-40 bg-vault-bg relative overflow-hidden border-b border-vault-border">
-        {firearm.imageUrl ? (
-          <Image
-            src={firearm.imageUrl}
-            alt={firearm.name}
-            fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
-            loading="lazy"
-            className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center tactical-grid">
-            <div className="flex flex-col items-center gap-2 opacity-40">
-              <FirearmTypeIcon type={firearm.type} />
-              <span className="text-xs font-mono uppercase text-vault-text-faint tracking-widest">
-                {typeLabel}
-              </span>
+        <SafeImage
+          src={firearm.imageUrl}
+          alt={firearm.name}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+          loading="lazy"
+          className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
+          fallback={
+            <div className="w-full h-full flex items-center justify-center tactical-grid">
+              <div className="flex flex-col items-center gap-2 opacity-40">
+                <FirearmTypeIcon type={firearm.type} />
+                <span className="text-xs font-mono uppercase text-vault-text-faint tracking-widest">
+                  {typeLabel}
+                </span>
+              </div>
             </div>
-          </div>
-        )}
+          }
+        />
         {/* Type badge overlay */}
         <div className="absolute top-2 right-2">
           <span className={`text-[10px] px-2 py-0.5 rounded border font-mono uppercase bg-vault-bg/80 backdrop-blur-sm ${typeBadge}`}>

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import {
   DndContext,
   closestCenter,
@@ -19,6 +18,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { StatCard } from "@/components/shared/StatCard";
+import { SafeImage } from "@/components/shared/SafeImage";
 import { formatCurrency, formatNumber, formatDate } from "@/lib/utils";
 import {
   Shield,
@@ -326,18 +326,15 @@ function RecentWidget({ firearms }: { firearms: RecentFirearm[] }) {
                 className="flex items-center gap-3 px-4 py-3 hover:bg-vault-surface-2 transition-colors group"
               >
                 <div className="relative w-10 h-10 rounded bg-vault-border border border-vault-border overflow-hidden shrink-0 flex items-center justify-center">
-                  {firearm.imageUrl ? (
-                    <Image
-                      src={firearm.imageUrl}
-                      alt={firearm.name}
-                      fill
-                      sizes="40px"
-                      loading="lazy"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <Shield className="w-4 h-4 text-vault-text-faint" />
-                  )}
+                  <SafeImage
+                    src={firearm.imageUrl}
+                    alt={firearm.name}
+                    fill
+                    sizes="40px"
+                    loading="lazy"
+                    className="w-full h-full object-cover"
+                    fallback={<Shield className="w-4 h-4 text-vault-text-faint" />}
+                  />
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-0.5">

--- a/src/components/shared/SafeImage.tsx
+++ b/src/components/shared/SafeImage.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import Image, { type ImageProps } from "next/image";
+
+type SafeImageSource = ImageProps["src"] | null | undefined;
+
+interface SafeImageProps extends Omit<ImageProps, "src" | "alt"> {
+  src?: SafeImageSource;
+  alt: string;
+  fallback: ReactNode;
+}
+
+function sourceKey(src: SafeImageSource): string | null {
+  if (!src) return null;
+  return typeof src === "string" ? src : src.src;
+}
+
+export function SafeImage({ src, fallback, onError, alt, ...imageProps }: SafeImageProps) {
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  const currentSource = sourceKey(src);
+
+  if (!currentSource || failedSource === currentSource) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <Image
+      {...imageProps}
+      src={src}
+      alt={alt}
+      onError={(event) => {
+        setFailedSource(currentSource);
+        onError?.(event);
+      }}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation
- Prevent unhandled image load failures in high-traffic UI surfaces by centralizing error handling and fallbacks for remote images.
- Preserve existing placeholder design language (shield / type / slot icons and labels) so image failures look intentional and consistent.
- Allow `next/image` props to pass through while making an ergonomic, reusable client component for image fallbacks.

### Description
- Add a client `SafeImage` component at `src/components/shared/SafeImage.tsx` that wraps `next/image`, tracks failed sources, and renders a provided `fallback` when `src` is missing or fails to load.
- Replace direct `imageUrl ? <Image .../> : ...` branches with `SafeImage` in `src/app/vault/page.tsx`, keeping the same firearm-type placeholder markup.
- Replace accessory thumbnail rendering in `src/app/accessories/page.tsx` with `SafeImage`, preserving the `Shield` fallback icon.
- Replace recent firearm and accessory-browser thumbnails in `src/components/dashboard/DashboardClient.tsx` and `src/app/vault/[id]/builds/[buildId]/page.tsx` with `SafeImage`, preserving slot/fallback icons.

### Testing
- Linted affected files with `npx eslint src/components/shared/SafeImage.tsx src/app/vault/page.tsx src/app/accessories/page.tsx src/components/dashboard/DashboardClient.tsx src/app/vault/[id]/builds/[buildId]/page.tsx` with no remaining lint errors after fixes. (succeeded)
- Launched the dev server with `npm run dev -- --port 3000` and exercised the vault view to validate runtime rendering and fallback UI visually. (succeeded)
- Captured an automated screenshot of the vault page via a Playwright script to confirm the integrated placeholder appearance. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b429c384048326bf1f56c2eed31ddb)