### PR TITLE
Add update confirmation flow and refresh notice

### DIFF
--- a/src/app/api/system-update/route.ts
+++ b/src/app/api/system-update/route.ts
@@ -11,18 +11,58 @@ async function runGit(args: string[]) {
   });
 }
 
-export async function POST() {
+async function ensureRepoContext() {
+  const insideRepo = await runGit(["rev-parse", "--is-inside-work-tree"]);
+  if (insideRepo.stdout.trim() !== "true") {
+    return { error: "Application is not running from a Git repository." };
+  }
+
+  const branchResult = await runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const branch = branchResult.stdout.trim();
+  const remoteResult = await runGit(["remote", "get-url", "origin"]);
+  const remote = remoteResult.stdout.trim();
+
+  return { branch, remote };
+}
+
+export async function GET() {
   try {
-    const insideRepo = await runGit(["rev-parse", "--is-inside-work-tree"]);
-    if (insideRepo.stdout.trim() !== "true") {
-      return NextResponse.json({ error: "Application is not running from a Git repository." }, { status: 400 });
+    const context = await ensureRepoContext();
+    if ("error" in context) {
+      return NextResponse.json({ error: context.error }, { status: 400 });
     }
 
-    const branchResult = await runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
-    const branch = branchResult.stdout.trim();
+    const { branch, remote } = context;
+    await runGit(["fetch", "origin", branch]);
+    const behindResult = await runGit(["rev-list", "--count", `HEAD..origin/${branch}`]);
+    const behind = Number.parseInt(behindResult.stdout.trim(), 10) || 0;
 
-    const remoteResult = await runGit(["remote", "get-url", "origin"]);
-    const remote = remoteResult.stdout.trim();
+    return NextResponse.json({
+      branch,
+      remote,
+      updateAvailable: behind > 0,
+      commitsBehind: behind,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to check for updates.";
+    return NextResponse.json(
+      {
+        error: "Failed to check for updates.",
+        details: message,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST() {
+  try {
+    const context = await ensureRepoContext();
+    if ("error" in context) {
+      return NextResponse.json({ error: context.error }, { status: 400 });
+    }
+
+    const { branch, remote } = context;
 
     const pullResult = await runGit(["pull", "--ff-only", "origin", branch]);
     const output = `${pullResult.stdout}${pullResult.stderr}`.trim();

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -453,6 +453,24 @@ export default function SettingsPage() {
     setUpdateOutput(null);
 
     try {
+      const checkRes = await fetch("/api/system-update");
+      const checkJson = await checkRes.json();
+
+      if (!checkRes.ok) {
+        const details = typeof checkJson.details === "string" ? `\n\n${checkJson.details}` : "";
+        setUpdateError(`${checkJson.error ?? "Failed to check for updates."}${details}`);
+        return;
+      }
+
+      if (checkJson.updateAvailable) {
+        const commitLabel = checkJson.commitsBehind === 1 ? "1 new commit" : `${checkJson.commitsBehind} new commits`;
+        const confirmed = window.confirm(`A new version is available (${commitLabel}). Pull updates now?`);
+        if (!confirmed) {
+          setUpdateOutput("Update canceled.");
+          return;
+        }
+      }
+
       const res = await fetch("/api/system-update", { method: "POST" });
       const json = await res.json();
 
@@ -465,8 +483,9 @@ export default function SettingsPage() {
       const remoteLine = json.remote ? `Remote: ${json.remote}` : null;
       const branchLine = json.branch ? `Branch: ${json.branch}` : null;
       const outputLine = json.output ? `\n\n${json.output}` : "";
+      const refreshNote = "\n\n✅ Update successful. Please refresh the app to load the latest version.";
       const header = [remoteLine, branchLine].filter(Boolean).join("\n");
-      setUpdateOutput(`${header}${outputLine}`.trim());
+      setUpdateOutput(`${header}${outputLine}${refreshNote}`.trim());
     } catch {
       setUpdateError("Network error. Please try again.");
     } finally {


### PR DESCRIPTION
### Motivation
- Prevent surprising fast-forward pulls by checking for available updates before running a `git pull` and give the user a chance to confirm. 
- Surface a clear post-update instruction so users know to refresh the UI after new code is applied. 

### Description
- Add a shared `ensureRepoContext()` helper to validate repository context and resolve `branch` and `remote`. 
- Add `GET /api/system-update` which fetches `origin/<branch>` and returns `updateAvailable` and `commitsBehind` so the UI can check for updates without pulling. 
- Refactor `POST /api/system-update` to reuse the new repository-context helper. 
- Update the Settings UI (`handlePullUpdates` in `src/app/settings/page.tsx`) to call the new `GET` endpoint first, prompt the user with `window.confirm` when commits are available, and append a refresh note (`✅ Update successful. Please refresh the app to load the latest version.`) on success. 

### Testing
- Ran `npx eslint src/app/settings/page.tsx src/app/api/system-update/route.ts` which passed after a small string-literal fix. 
- Started the dev server with `npm run dev`; the server started and the UI was reachable, but runtime warnings appeared (font download fallbacks) and Prisma failed to initialize due to a missing `DATABASE_URL` environment variable in this container. 
- Executed a headless UI check with Playwright which produced a screenshot artifact of the updated Settings page flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42a9c0200832685c77866d2eb5b0d)