### PR TITLE
Add ammo total-price input with derived per-round cost and caliber average display

### DIFF
--- a/src/app/ammo/new/page.tsx
+++ b/src/app/ammo/new/page.tsx
@@ -36,6 +36,7 @@ export default function NewAmmoStockPage() {
       bulletType: (data.get("bulletType") as string) || null,
       quantity: Number(data.get("quantity")) || 0,
       purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
+      purchasePriceTotal: data.get("purchasePriceTotal") ? Number(data.get("purchasePriceTotal")) : null,
       purchaseDate: (data.get("purchaseDate") as string) || null,
       storageLocation: (data.get("storageLocation") as string) || null,
       lowStockAlert: data.get("lowStockAlert") ? Number(data.get("lowStockAlert")) : null,
@@ -215,7 +216,7 @@ export default function NewAmmoStockPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="purchasePrice" className={LABEL_CLASS}>
-                  Purchase Price (total)
+                  Price per Round
                 </label>
                 <div className="relative">
                   <span className="absolute left-3 top-1/2 -translate-y-1/2 text-vault-text-faint text-sm">$</span>
@@ -225,10 +226,29 @@ export default function NewAmmoStockPage() {
                     type="number"
                     min="0"
                     step="0.01"
-                    placeholder="0.00"
+                    placeholder="e.g. 0.28"
                     className={`${INPUT_CLASS} pl-7`}
                   />
                 </div>
+                <p className="text-xs text-vault-text-faint mt-1">Optional if total price is provided.</p>
+              </div>
+              <div>
+                <label htmlFor="purchasePriceTotal" className={LABEL_CLASS}>
+                  Purchase Price (total)
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-vault-text-faint text-sm">$</span>
+                  <input
+                    id="purchasePriceTotal"
+                    name="purchasePriceTotal"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="e.g. 140.00"
+                    className={`${INPUT_CLASS} pl-7`}
+                  />
+                </div>
+                <p className="text-xs text-vault-text-faint mt-1">If entered alone, cost per round will be calculated from quantity.</p>
               </div>
               <div>
                 <label htmlFor="purchaseDate" className={LABEL_CLASS}>

--- a/src/app/ammo/page.tsx
+++ b/src/app/ammo/page.tsx
@@ -52,6 +52,21 @@ const STATUS_STYLES: Record<string, { dot: string; text: string; bg: string; bor
   empty:    { dot: "bg-[#E53935]", text: "text-[#E53935]", bg: "bg-[#E53935]/10", border: "border-[#E53935]/30" },
 };
 
+function avgPricePerRound(stocks: AmmoStock[]): number | null {
+  let pricedRounds = 0;
+  let pricedValue = 0;
+
+  for (const stock of stocks) {
+    if (stock.purchasePrice !== null && stock.purchasePrice !== undefined && stock.purchasePrice > 0) {
+      pricedRounds += stock.quantity;
+      pricedValue += stock.quantity * stock.purchasePrice;
+    }
+  }
+
+  if (pricedRounds === 0) return null;
+  return pricedValue / pricedRounds;
+}
+
 const CALIBER_TEXT_COLORS: Record<string, string> = {
   ok:       "text-[#00C853]",
   low:      "text-[#F5A623]",
@@ -537,6 +552,7 @@ export default function AmmoPage() {
               const isExpanded = expandedCalibers.has(group.caliber);
               const styles = STATUS_STYLES[worstStatus];
               const totalColor = CALIBER_TEXT_COLORS[worstStatus];
+              const groupAvgPrice = avgPricePerRound(group.stocks);
 
               return (
                 <div
@@ -558,9 +574,16 @@ export default function AmmoPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-3">
-                      <p className={`text-2xl font-bold font-mono tabular-nums ${totalColor}`}>
-                        {formatNumber(group.totalQuantity)}
-                      </p>
+                      <div className="text-right">
+                        <p className={`text-2xl font-bold font-mono tabular-nums ${totalColor}`}>
+                          {formatNumber(group.totalQuantity)}
+                        </p>
+                        {groupAvgPrice !== null && (
+                          <p className="text-[10px] text-vault-text-faint font-mono">
+                            avg {formatCurrency(groupAvgPrice ?? 0)}/rd
+                          </p>
+                        )}
+                      </div>
                       {isExpanded ? (
                         <ChevronUp className="w-4 h-4 text-vault-text-faint shrink-0" />
                       ) : (

--- a/src/app/api/ammo/route.ts
+++ b/src/app/api/ammo/route.ts
@@ -70,6 +70,7 @@ export async function POST(request: NextRequest) {
       bulletType,
       quantity,
       purchasePrice,
+      purchasePriceTotal,
       purchaseDate,
       storageLocation,
       lowStockAlert,
@@ -83,14 +84,38 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (purchasePrice !== undefined && purchasePrice !== null && Number(purchasePrice) < 0) {
+      return NextResponse.json({ error: "purchasePrice cannot be negative" }, { status: 400 });
+    }
+    if (
+      purchasePriceTotal !== undefined &&
+      purchasePriceTotal !== null &&
+      Number(purchasePriceTotal) < 0
+    ) {
+      return NextResponse.json({ error: "purchasePriceTotal cannot be negative" }, { status: 400 });
+    }
+
+    const quantityValue = Number(quantity ?? 0);
+    const normalizedPerRoundPrice =
+      purchasePrice !== undefined && purchasePrice !== null
+        ? Number(purchasePrice)
+        : purchasePriceTotal !== undefined &&
+            purchasePriceTotal !== null &&
+            quantityValue > 0
+          ? Number(purchasePriceTotal) / quantityValue
+          : null;
+
     const stock = await prisma.ammoStock.create({
       data: {
         caliber,
         brand,
         grainWeight: grainWeight ?? null,
         bulletType: bulletType ?? null,
-        quantity: quantity ?? 0,
-        purchasePrice: purchasePrice ?? null,
+        quantity: quantityValue,
+        purchasePrice:
+          normalizedPerRoundPrice !== null && Number.isFinite(normalizedPerRoundPrice)
+            ? normalizedPerRoundPrice
+            : null,
         purchaseDate: purchaseDate ? new Date(purchaseDate) : null,
         storageLocation: storageLocation ?? null,
         lowStockAlert: lowStockAlert ?? null,


### PR DESCRIPTION
## Summary
- update the new ammo stock form to accept either **price per round** or **total purchase price**
- pass `purchasePriceTotal` from the client when provided
- in `POST /api/ammo`, normalize incoming price data to a stored per-round `purchasePrice`
  - keep explicit per-round price when supplied
  - otherwise derive per-round from total price and quantity
  - add validation for negative values
- show each caliber group's weighted average price/round in the ammo depot list under the caliber round total

## Files changed
- `src/app/ammo/new/page.tsx`
- `src/app/api/ammo/route.ts`
- `src/app/ammo/page.tsx`

## Notes
- No schema changes were required because `purchasePrice` already represents per-round pricing for downstream inventory value calculations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42cbe13348326bdd6ed23974fedc7)