### PR TITLE
Fix Next.js 16 deprecations in config and edge auth hook

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,9 +5,6 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "**" },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -27,7 +27,7 @@ async function verifyWithWebCrypto(signed: string, secret: string): Promise<bool
   return diff === 0;
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const session = request.cookies.get("vault_session");
   const { pathname } = request.nextUrl;
 


### PR DESCRIPTION
### Motivation
- Remove deprecated Next.js config options that cause build-time warnings and invalid-config errors with Next.js 16.
- Align the edge auth entrypoint with Next.js' newer runtime convention to avoid using the deprecated `middleware` filename and exported handler name.

### Description
- Removed the deprecated `eslint` option from `next.config.ts` to stop Next.js from flagging the config as invalid.
- Renamed the server-side auth file from `src/middleware.ts` to `src/proxy.ts` and updated the exported handler from `middleware` to `proxy`, preserving the original auth logic.
- Left `serverExternalPackages` and other runtime settings intact while adjusting the config to be compatible with Next.js 16.

### Testing
- Ran `npm run lint` and it completed successfully with no new errors.
- Ran `npm test` (Vitest) and all test files passed (68 tests total).
- Ran `npm run build` which failed in this environment due to a blocked network fetch for Google Fonts (the `Inter` fetch from `next/font/google` used in `src/app/layout.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b431959e0c8326b8695c47953ecf44)