### PR TITLE
Remove Google Custom Search image search and related settings/UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A self-hosted tactical firearms management application built with Next.js 16, Pr
 - **Accessories** - Manage optics, suppressors, handguards, triggers, and all other parts with per-accessory round count tracking
 - **Ammo Inventory** - Track ammunition stocks by caliber, brand, bullet type, and grain weight with low-stock alerts
 - **Round Count Logs** - Log range sessions and maintain a full history of rounds through each part
-- **Image Search** - Optional Google Custom Search integration to automatically fetch firearm and accessory images
 - **All Loadouts View** - Cross-firearm build overview grouped by platform
 - **Dark Tactical UI** - Optimized dark theme built for desktop and mobile
 
@@ -87,8 +86,6 @@ Data is persisted in named Docker volumes:
 | `SESSION_SECRET` | Recommended | — | Signs session cookies to prevent forgery. Generate: `openssl rand -hex 32` |
 | `NODE_ENV` | No | `development` | Set to `production` in deployed environments |
 | `PORT` | No | `3000` | Port exposed by Docker Compose |
-| `GOOGLE_CSE_API_KEY` | No | — | Google Custom Search API key for image lookup |
-| `GOOGLE_CSE_SEARCH_ENGINE_ID` | No | — | Google CSE search engine ID |
 | `APP_PASSWORD` | — | — | Set via the Settings UI — not an environment variable |
 
 ---

--- a/src/app/api/images/search/route.ts
+++ b/src/app/api/images/search/route.ts
@@ -1,122 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { decryptField } from "@/lib/crypto";
+import { NextResponse } from "next/server";
 
-interface GoogleCseItem {
-  title: string;
-  link: string;
-  image?: {
-    contextLink: string;
-    height: number;
-    width: number;
-    byteSize: number;
-    thumbnailLink: string;
-    thumbnailHeight: number;
-    thumbnailWidth: number;
-  };
-  snippet?: string;
-  displayLink?: string;
-}
-
-// POST /api/images/search - Proxy to Google Custom Search API
-// Body: { query: string }
-// Reads googleCseApiKey and googleCseSearchEngineId from AppSettings in DB.
-// Returns array of image results.
-// If no API key, returns 400 with helpful message.
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { query } = body;
-
-    if (!query || typeof query !== "string" || query.trim() === "") {
-      return NextResponse.json(
-        { error: "Missing required field: query" },
-        { status: 400 }
-      );
-    }
-
-    // Fetch settings from DB
-    const settings = await prisma.appSettings.findUnique({
-      where: { id: "singleton" },
-    });
-
-    const googleCseApiKey = await decryptField(settings?.googleCseApiKey ?? null);
-    const googleCseSearchEngineId = settings?.googleCseSearchEngineId ?? null;
-
-    if (!settings || !googleCseApiKey || !googleCseSearchEngineId) {
-      return NextResponse.json(
-        {
-          error:
-            "Google Custom Search is not configured. Please add your Google CSE API key and Search Engine ID in the app settings.",
-          configRequired: true,
-        },
-        { status: 400 }
-      );
-    }
-
-    if (!settings.enableImageSearch) {
-      return NextResponse.json(
-        {
-          error:
-            "Image search is disabled. Please enable it in the app settings.",
-          configRequired: true,
-        },
-        { status: 400 }
-      );
-    }
-
-    const searchUrl = new URL(
-      "https://www.googleapis.com/customsearch/v1"
-    );
-    searchUrl.searchParams.set("key", googleCseApiKey);
-    searchUrl.searchParams.set("cx", googleCseSearchEngineId);
-    searchUrl.searchParams.set("q", query.trim());
-    searchUrl.searchParams.set("searchType", "image");
-    searchUrl.searchParams.set("num", "10");
-    searchUrl.searchParams.set("safe", "active");
-
-    const response = await fetch(searchUrl.toString());
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      console.error("Google CSE API error:", response.status, errorData);
-
-      if (response.status === 403) {
-        return NextResponse.json(
-          {
-            error:
-              "Google CSE API key is invalid or quota exceeded. Please check your API key in settings.",
-          },
-          { status: 502 }
-        );
-      }
-
-      return NextResponse.json(
-        { error: "Failed to fetch images from Google Custom Search" },
-        { status: 502 }
-      );
-    }
-
-    const data = await response.json();
-    const items: GoogleCseItem[] = data.items ?? [];
-
-    const results = items.map((item) => ({
-      title: item.title,
-      url: item.link,
-      thumbnailUrl: item.image?.thumbnailLink ?? item.link,
-      width: item.image?.width ?? null,
-      height: item.image?.height ?? null,
-      contextLink: item.image?.contextLink ?? null,
-      displayLink: item.displayLink ?? null,
-      snippet: item.snippet ?? null,
-    }));
-
-    return NextResponse.json({ results, query: query.trim() });
-  } catch (error) {
-    console.error("POST /api/images/search error:", error);
-    return NextResponse.json(
-      { error: "Failed to perform image search" },
-      { status: 500 }
-    );
-  }
+// Image search has been intentionally removed to keep the app offline-first.
+export async function POST() {
+  return NextResponse.json(
+    {
+      error:
+        "Image search has been removed. Use local uploads or direct image URLs instead.",
+      removed: true,
+    },
+    { status: 410 }
+  );
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { hashPassword } from "@/lib/password";
-import { encryptField, decryptField } from "@/lib/crypto";
 
 // GET /api/settings - Get the singleton AppSettings
 export async function GET() {
@@ -20,13 +19,13 @@ export async function GET() {
       });
     }
 
-    const decryptedKey = await decryptField(settings.googleCseApiKey);
-
-    // Mask the API key; never return password hash or raw key to the client
+    // Never return password hash to the client
     return NextResponse.json({
       ...settings,
-      googleCseApiKey: decryptedKey ? "***configured***" : null,
-      _googleCseApiKeyIsSet: !!decryptedKey,
+      enableImageSearch: false,
+      googleCseApiKey: null,
+      _googleCseApiKeyIsSet: false,
+      googleCseSearchEngineId: null,
       appPassword: settings.appPassword ? "***set***" : null,
       encryptionEnabled: !!process.env.VAULT_ENCRYPTION_KEY,
       encryptionViaEnv: !!process.env.VAULT_ENCRYPTION_KEY,
@@ -46,9 +45,6 @@ export async function PUT(request: NextRequest) {
     const body = await request.json();
 
     const {
-      googleCseApiKey,
-      googleCseSearchEngineId,
-      enableImageSearch,
       defaultCurrency,
       appPassword,
     } = body;
@@ -56,20 +52,10 @@ export async function PUT(request: NextRequest) {
     // Build update data, only including fields that were provided
     const updateData: Record<string, unknown> = {};
 
-    if (googleCseApiKey !== undefined) {
-      // Allow clearing the key by passing null or empty string; encrypt non-empty values
-      updateData.googleCseApiKey =
-        googleCseApiKey === "" ? null : await encryptField(googleCseApiKey);
-    }
-
-    if (googleCseSearchEngineId !== undefined) {
-      updateData.googleCseSearchEngineId =
-        googleCseSearchEngineId === "" ? null : googleCseSearchEngineId;
-    }
-
-    if (enableImageSearch !== undefined) {
-      updateData.enableImageSearch = Boolean(enableImageSearch);
-    }
+    // Image search is retired; force-disable and clear old Google CSE settings.
+    updateData.enableImageSearch = false;
+    updateData.googleCseApiKey = null;
+    updateData.googleCseSearchEngineId = null;
 
     if (defaultCurrency !== undefined) {
       updateData.defaultCurrency = defaultCurrency;
@@ -93,12 +79,12 @@ export async function PUT(request: NextRequest) {
       update: updateData,
     });
 
-    const savedDecryptedKey = await decryptField(settings.googleCseApiKey);
-
     return NextResponse.json({
       ...settings,
-      googleCseApiKey: savedDecryptedKey ? "***configured***" : null,
-      _googleCseApiKeyIsSet: !!savedDecryptedKey,
+      enableImageSearch: false,
+      googleCseApiKey: null,
+      _googleCseApiKeyIsSet: false,
+      googleCseSearchEngineId: null,
       appPassword: settings.appPassword ? "***set***" : null,
       encryptionEnabled: !!process.env.VAULT_ENCRYPTION_KEY,
       encryptionViaEnv: !!process.env.VAULT_ENCRYPTION_KEY,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,11 +6,9 @@ import {
   Loader2,
   AlertCircle,
   CheckCircle2,
-  Search,
   Lock,
   Eye,
   EyeOff,
-  Image as ImageIcon,
   Settings,
   ShieldCheck,
   HardDrive,
@@ -36,10 +34,6 @@ const LABEL_CLASS =
 
 interface AppSettings {
   id: string;
-  enableImageSearch: boolean;
-  googleCseApiKey: string | null;
-  _googleCseApiKeyIsSet?: boolean;
-  googleCseSearchEngineId: string | null;
   appPassword: string | null;
   defaultCurrency: string;
   encryptionEnabled?: boolean;
@@ -60,11 +54,7 @@ export default function SettingsPage() {
   const [dataLoading, setDataLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
 
-  const [enableImageSearch, setEnableImageSearch] = useState(false);
-  const [apiKey, setApiKey] = useState("");
-  const [searchEngineId, setSearchEngineId] = useState("");
   const [appPassword, setAppPassword] = useState("");
-  const [showApiKey, setShowApiKey] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
 
@@ -116,8 +106,6 @@ export default function SettingsPage() {
           setDataError(data.error);
         } else {
           setSettings(data);
-          setEnableImageSearch(data.enableImageSearch ?? false);
-          setSearchEngineId(data.googleCseSearchEngineId ?? "");
         }
         if (!info.error) setSysInfo(info);
         setDataLoading(false);
@@ -155,14 +143,7 @@ export default function SettingsPage() {
     setSaveSuccess(false);
     setSaving(true);
 
-    const payload: Record<string, unknown> = {
-      enableImageSearch,
-      googleCseSearchEngineId: searchEngineId || null,
-    };
-
-    if (apiKey) {
-      payload.googleCseApiKey = apiKey;
-    }
+    const payload: Record<string, unknown> = {};
 
     payload.appPassword = appPassword || null;
 
@@ -179,7 +160,6 @@ export default function SettingsPage() {
         setSaveError(json.error ?? "Failed to save settings");
       } else {
         setSettings(json);
-        setApiKey("");
         setSaveSuccess(true);
         setTimeout(() => setSaveSuccess(false), 3000);
       }
@@ -528,9 +508,6 @@ export default function SettingsPage() {
     );
   }
 
-  const imageSearchConfigured =
-    settings?._googleCseApiKeyIsSet && !!settings?.googleCseSearchEngineId;
-
   const wizardSteps = [
     {
       title: "Secure Access",
@@ -585,66 +562,6 @@ export default function SettingsPage() {
         )}
 
         <form onSubmit={handleSave} className="space-y-6">
-          {/* ── Image Search ────────────────────────────────── */}
-          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-5">
-            <div className="flex items-center justify-between">
-              <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
-                <ImageIcon className="w-3.5 h-3.5" />
-                Image Search
-              </legend>
-              <span className={`text-[10px] font-mono px-2 py-0.5 rounded border uppercase ${imageSearchConfigured ? "text-[#00C853] border-[#00C853]/40" : "text-vault-text-faint border-vault-border"}`}>
-                {imageSearchConfigured ? "Configured" : "Not Configured"}
-              </span>
-            </div>
-
-            <p className="text-xs text-vault-text-muted leading-relaxed">
-              Enable Google Custom Search to automatically find images for firearms and accessories. Requires a Google Cloud CSE API key and a configured search engine.
-            </p>
-
-            <div>
-              <button type="button" onClick={() => setEnableImageSearch((v) => !v)}
-                className={`flex items-center gap-3 w-full text-left px-4 py-3 rounded-md border transition-all ${enableImageSearch ? "border-[#00C2FF]/40 bg-[#00C2FF]/5" : "border-vault-border hover:border-vault-text-muted/20"}`}>
-                <div className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${enableImageSearch ? "bg-[#00C2FF]" : "bg-vault-border"}`}>
-                  <div className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${enableImageSearch ? "left-4" : "left-0.5"}`} />
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-vault-text">Enable Image Search</p>
-                  <p className="text-xs text-vault-text-faint mt-0.5">Adds a &quot;Search Images&quot; button to firearm and accessory forms.</p>
-                </div>
-              </button>
-            </div>
-
-            <div>
-              <label className={LABEL_CLASS}>
-                <Search className="w-3 h-3 inline mr-1" />
-                Google CSE API Key
-                {settings?._googleCseApiKeyIsSet && (
-                  <span className="ml-2 text-[#00C853] text-[10px] normal-case tracking-normal">(currently set)</span>
-                )}
-              </label>
-              <div className="relative">
-                <input type={showApiKey ? "text" : "password"} value={apiKey} onChange={(e) => setApiKey(e.target.value)}
-                  placeholder={settings?._googleCseApiKeyIsSet ? "Leave blank to keep existing key" : "AIza..."}
-                  className={`${INPUT_CLASS} pr-10 font-mono`} />
-                <button type="button" onClick={() => setShowApiKey((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-vault-text-faint hover:text-vault-text-muted">
-                  {showApiKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                </button>
-              </div>
-              <p className="text-xs text-vault-text-faint mt-1">From the Google Cloud Console. Leave blank to keep the existing key.</p>
-            </div>
-
-            <div>
-              <label htmlFor="searchEngineId" className={LABEL_CLASS}>
-                <Search className="w-3 h-3 inline mr-1" />
-                Search Engine ID (cx)
-              </label>
-              <input id="searchEngineId" type="text" value={searchEngineId} onChange={(e) => setSearchEngineId(e.target.value)}
-                placeholder="e.g. 017576662512468239146:omuauf_lfve" className={`${INPUT_CLASS} font-mono`} />
-              <p className="text-xs text-vault-text-faint mt-1">The &quot;cx&quot; parameter from your Programmable Search Engine dashboard.</p>
-            </div>
-          </fieldset>
-
           {/* ── Security ────────────────────────────────────── */}
           <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-5">
             <div className="flex items-center justify-between">
@@ -1281,9 +1198,6 @@ export default function SettingsPage() {
           <div className="bg-vault-bg border border-vault-border rounded-lg p-4">
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-3 font-mono">Current Configuration Status</p>
             <div className="space-y-2">
-              <StatusRow label="Image Search" value={enableImageSearch ? "Enabled" : "Disabled"} ok={enableImageSearch} />
-              <StatusRow label="CSE API Key" value={settings?._googleCseApiKeyIsSet ? "Configured" : "Not set"} ok={!!settings?._googleCseApiKeyIsSet} />
-              <StatusRow label="Search Engine ID" value={settings?.googleCseSearchEngineId ? "Configured" : "Not set"} ok={!!settings?.googleCseSearchEngineId} />
               <StatusRow label="App Password" value={settings?.appPassword ? "Enabled" : "Disabled"} ok={!!settings?.appPassword} neutralIfFalse />
               <StatusRow label="Encryption at Rest" value={settings?.encryptionEnabled ? "Active" : "Not configured"} ok={!!settings?.encryptionEnabled} />
             </div>


### PR DESCRIPTION
### Motivation
- Remove the online Google Custom Search image lookup to make the app offline-first and avoid requiring external API keys or network dependencies.
- Clear and disable legacy Google CSE configuration stored in settings to avoid exposing partially-configured or encrypted key state.
- Clean up the settings UI and README to reflect the removal of the image-search feature.

### Description
- Replace the image search API handler at `src/app/api/images/search/route.ts` with a stub that returns a `410` and a message that image search was removed.
- Update the settings API at `src/app/api/settings/route.ts` to stop reading/writing Google CSE fields, force-disable `enableImageSearch`, clear `googleCseApiKey` and `googleCseSearchEngineId`, and never expose API key indicators to clients.
- Remove image-search-related UI from `src/app/settings/page.tsx`, including state, form fields, status rows, and icons, and update the settings form payload accordingly.
- Update `README.md` to remove the `GOOGLE_CSE_API_KEY` and `GOOGLE_CSE_SEARCH_ENGINE_ID` environment variable references and to remove Image Search from the features list.

### Testing
- Performed a TypeScript build check via `npm run build`, which completed successfully.
- Performed a manual smoke test of the settings page and image-search endpoint to verify the image search UI is gone and the `/api/images/search` endpoint now returns `410` with the removal message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b432d140408326b74be1074562e56c)