### PR TITLE
Harden external image URL handling with strict allowlist validation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { TRUSTED_IMAGE_HOSTNAMES } from "./src/lib/image-host-allowlist";
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -6,10 +7,10 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    remotePatterns: [
-      { protocol: "https", hostname: "**" },
-      { protocol: "http", hostname: "**" },
-    ],
+    remotePatterns: TRUSTED_IMAGE_HOSTNAMES.map((hostname) => ({
+      protocol: "https",
+      hostname,
+    })),
   },
   serverExternalPackages: ["@prisma/client", "sharp"],
 };

--- a/src/app/api/accessories/[id]/route.ts
+++ b/src/app/api/accessories/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
+import { validateOptionalImageUrl } from "@/lib/image-url-validation";
 
 // GET /api/accessories/[id] - Get a single accessory with roundCountLogs and current buildSlots
 export async function GET(
@@ -106,6 +107,13 @@ export async function PUT(
       );
     }
 
+    if (imageUrl !== undefined) {
+      const imageValidation = validateOptionalImageUrl(imageUrl);
+      if (!imageValidation.valid) {
+        return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+      }
+    }
+
     if (purchasePrice !== undefined && purchasePrice !== null && purchasePrice < 0) {
       return NextResponse.json({ error: "purchasePrice cannot be negative" }, { status: 400 });
     }
@@ -123,7 +131,7 @@ export async function PUT(
           acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : null,
         }),
         ...(notes !== undefined && { notes }),
-        ...(imageUrl !== undefined && { imageUrl }),
+        ...(imageUrl !== undefined && { imageUrl: imageUrl?.trim() || null }),
         ...(imageSource !== undefined && { imageSource }),
         ...(compatibleFirearmTypes !== undefined && { compatibleFirearmTypes }),
         ...(compatibleCalibers !== undefined && { compatibleCalibers }),

--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
+import { validateOptionalImageUrl } from "@/lib/image-url-validation";
 
 const BATTERY_TRACKED_SLOT_TYPES = new Set(["OPTIC", "LIGHT", "LASER"]);
 
@@ -85,6 +86,11 @@ export async function POST(request: NextRequest) {
       batteryIntervalDays,
     } = body;
 
+    const imageValidation = validateOptionalImageUrl(imageUrl);
+    if (!imageValidation.valid) {
+      return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+    }
+
     if (!name || !type) {
       return NextResponse.json(
         { error: "Missing required fields: name, type" },
@@ -106,7 +112,7 @@ export async function POST(request: NextRequest) {
         purchasePrice: purchasePrice ?? null,
         acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : null,
         notes: notes ?? null,
-        imageUrl: imageUrl ?? null,
+        imageUrl: imageValidation.normalized,
         imageSource: imageSource ?? null,
         compatibleFirearmTypes: compatibleFirearmTypes ?? null,
         compatibleCalibers: compatibleCalibers ?? null,

--- a/src/app/api/firearms/[id]/route.ts
+++ b/src/app/api/firearms/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
+import { validateOptionalImageUrl } from "@/lib/image-url-validation";
 
 // GET /api/firearms/[id] - Get a single firearm with active build, slots, and accessories
 export async function GET(
@@ -83,6 +84,13 @@ export async function PUT(
       return NextResponse.json({ error: "Firearm not found" }, { status: 404 });
     }
 
+    if (imageUrl !== undefined) {
+      const imageValidation = validateOptionalImageUrl(imageUrl);
+      if (!imageValidation.valid) {
+        return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+      }
+    }
+
     if (purchasePrice !== undefined && purchasePrice !== null && purchasePrice < 0) {
       return NextResponse.json({ error: "purchasePrice cannot be negative" }, { status: 400 });
     }
@@ -107,7 +115,7 @@ export async function PUT(
         ...(purchasePrice !== undefined && { purchasePrice }),
         ...(currentValue !== undefined && { currentValue }),
         ...(notes !== undefined && { notes: notes ? await encryptField(notes) : null }),
-        ...(imageUrl !== undefined && { imageUrl }),
+        ...(imageUrl !== undefined && { imageUrl: imageUrl?.trim() || null }),
         ...(imageSource !== undefined && { imageSource }),
       },
       include: {

--- a/src/app/api/firearms/route.ts
+++ b/src/app/api/firearms/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
 import { revalidateDashboardCaches } from "@/lib/server/dashboard";
+import { validateOptionalImageUrl } from "@/lib/image-url-validation";
 import { FIREARM_TYPES } from "@/lib/types";
 
 // GET /api/firearms - List all firearms with build count
@@ -71,6 +72,11 @@ export async function POST(request: NextRequest) {
       imageSource,
     } = body;
 
+    const imageValidation = validateOptionalImageUrl(imageUrl);
+    if (!imageValidation.valid) {
+      return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+    }
+
     if (!name) {
       return NextResponse.json(
         { error: "Missing required field: name" },
@@ -97,7 +103,7 @@ export async function POST(request: NextRequest) {
         purchasePrice: purchasePrice ?? null,
         currentValue: currentValue ?? null,
         notes: notes ? await encryptField(notes) : null,
-        imageUrl: imageUrl ?? null,
+        imageUrl: imageValidation.normalized,
         imageSource: imageSource ?? null,
       },
       include: {

--- a/src/app/api/images/search/route.ts
+++ b/src/app/api/images/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { decryptField } from "@/lib/crypto";
+import { isTrustedExternalImageUrl } from "@/lib/image-host-allowlist";
 
 interface GoogleCseItem {
   title: string;
@@ -100,16 +101,21 @@ export async function POST(request: NextRequest) {
     const data = await response.json();
     const items: GoogleCseItem[] = data.items ?? [];
 
-    const results = items.map((item) => ({
-      title: item.title,
-      url: item.link,
-      thumbnailUrl: item.image?.thumbnailLink ?? item.link,
-      width: item.image?.width ?? null,
-      height: item.image?.height ?? null,
-      contextLink: item.image?.contextLink ?? null,
-      displayLink: item.displayLink ?? null,
-      snippet: item.snippet ?? null,
-    }));
+    const results = items
+      .filter((item) => isTrustedExternalImageUrl(item.link))
+      .map((item) => ({
+        title: item.title,
+        url: item.link,
+        thumbnailUrl:
+          item.image?.thumbnailLink && isTrustedExternalImageUrl(item.image.thumbnailLink)
+            ? item.image.thumbnailLink
+            : item.link,
+        width: item.image?.width ?? null,
+        height: item.image?.height ?? null,
+        contextLink: item.image?.contextLink ?? null,
+        displayLink: item.displayLink ?? null,
+        snippet: item.snippet ?? null,
+      }));
 
     return NextResponse.json({ results, query: query.trim() });
   } catch (error) {

--- a/src/components/shared/ImagePicker.tsx
+++ b/src/components/shared/ImagePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { isAllowedImageUrlForStorage, IMAGE_URL_ALLOWLIST_ERROR } from "@/lib/image-url-validation";
 import Image from "next/image";
 import { Camera, Link, Loader2, X, AlertCircle, ChevronDown, ChevronUp } from "lucide-react";
 
@@ -31,6 +32,7 @@ export default function ImagePicker({
   const [error, setError] = useState<string | null>(null);
   const [showUrl, setShowUrl] = useState(false);
   const [urlInput, setUrlInput] = useState("");
+  const previewNeedsSafeMode = preview ? !isAllowedImageUrlForStorage(preview) : false;
 
   async function handleFile(file: File) {
     setError(null);
@@ -90,6 +92,13 @@ export default function ImagePicker({
   function handleUrlApply() {
     const url = urlInput.trim();
     if (!url) return;
+
+    if (!isAllowedImageUrlForStorage(url)) {
+      setError(IMAGE_URL_ALLOWLIST_ERROR);
+      return;
+    }
+
+    setError(null);
     setPreview(url);
     onChange(url, "url");
     setShowUrl(false);
@@ -100,17 +109,29 @@ export default function ImagePicker({
       {/* Preview */}
       {preview ? (
         <div className="relative rounded-md overflow-hidden border border-vault-border bg-vault-bg">
-          <Image
-            src={preview}
-            alt="Preview"
-            width={1200}
-            height={800}
-            loading="lazy"
-            className="w-full max-h-48 h-auto object-contain"
-            onError={() => {
-              setError("Could not load this image URL. Please check the link.");
-            }}
-          />
+          {previewNeedsSafeMode ? (
+            <img
+              src={preview}
+              alt="Preview"
+              loading="lazy"
+              className="w-full max-h-48 h-auto object-contain"
+              onError={() => {
+                setError("Could not load this image URL. Please check the link.");
+              }}
+            />
+          ) : (
+            <Image
+              src={preview}
+              alt="Preview"
+              width={1200}
+              height={800}
+              loading="lazy"
+              className="w-full max-h-48 h-auto object-contain"
+              onError={() => {
+                setError("Could not load this image URL. Please check the link.");
+              }}
+            />
+          )}
           <button
             type="button"
             onClick={handleRemove}

--- a/src/lib/image-host-allowlist.ts
+++ b/src/lib/image-host-allowlist.ts
@@ -1,0 +1,45 @@
+export const TRUSTED_IMAGE_HOSTNAMES = [
+  "images.unsplash.com",
+  "plus.unsplash.com",
+  "images.pexels.com",
+  "cdn.pixabay.com",
+  "i.imgur.com",
+  "lh3.googleusercontent.com",
+  "lh4.googleusercontent.com",
+  "lh5.googleusercontent.com",
+  "lh6.googleusercontent.com",
+  "*.gstatic.com",
+] as const;
+
+const NORMALIZED_TRUSTED_IMAGE_HOSTNAMES = TRUSTED_IMAGE_HOSTNAMES.map((hostname) =>
+  hostname.toLowerCase()
+);
+
+function hostnameMatchesAllowlist(hostname: string, allowlistEntry: string): boolean {
+  if (allowlistEntry.startsWith("*.")) {
+    const suffix = allowlistEntry.slice(2);
+    return hostname === suffix || hostname.endsWith(`.${suffix}`);
+  }
+
+  return hostname === allowlistEntry;
+}
+
+export function isTrustedExternalImageUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+      return false;
+    }
+
+    const hostname = parsedUrl.hostname.toLowerCase();
+    return NORMALIZED_TRUSTED_IMAGE_HOSTNAMES.some((entry) =>
+      hostnameMatchesAllowlist(hostname, entry)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isLocalImagePath(url: string): boolean {
+  return url.startsWith("/");
+}

--- a/src/lib/image-url-validation.ts
+++ b/src/lib/image-url-validation.ts
@@ -1,0 +1,29 @@
+import { isLocalImagePath, isTrustedExternalImageUrl } from "@/lib/image-host-allowlist";
+
+export const IMAGE_URL_ALLOWLIST_ERROR =
+  "Image URL host is not allowed. Use uploads or a trusted image host.";
+
+export function isAllowedImageUrlForStorage(url: string): boolean {
+  return isLocalImagePath(url) || isTrustedExternalImageUrl(url);
+}
+
+export function validateOptionalImageUrl(url: unknown): { valid: true; normalized: string | null } | { valid: false; error: string } {
+  if (url === undefined || url === null) {
+    return { valid: true, normalized: null };
+  }
+
+  if (typeof url !== "string") {
+    return { valid: false, error: "imageUrl must be a string or null" };
+  }
+
+  const trimmed = url.trim();
+  if (trimmed === "") {
+    return { valid: true, normalized: null };
+  }
+
+  if (!isAllowedImageUrlForStorage(trimmed)) {
+    return { valid: false, error: IMAGE_URL_ALLOWLIST_ERROR };
+  }
+
+  return { valid: true, normalized: trimmed };
+}


### PR DESCRIPTION
### Motivation
- Replace permissive Next.js remote image wildcard patterns with an explicit allowlist to reduce risk from arbitrary external hosts.
- Prevent untrusted external image hostnames from being persisted in the database to avoid loading/serving unsafe external content.
- Provide a safe client-side fallback for untrusted image URLs by disabling Next image optimization for those URLs and rendering them more conservatively.

### Description
- Use a centralized allowlist in `src/lib/image-host-allowlist.ts` and wire it into `next.config.ts` so `images.remotePatterns` is built from `TRUSTED_IMAGE_HOSTNAMES` only.
- Add `src/lib/image-url-validation.ts` with `validateOptionalImageUrl` and `isAllowedImageUrlForStorage` helpers and a consistent error message for disallowed hosts.
- Enforce validation in API create/update endpoints so `imageUrl` is validated before persisting in `src/app/api/firearms/route.ts`, `src/app/api/firearms/[id]/route.ts`, `src/app/api/accessories/route.ts`, and `src/app/api/accessories/[id]/route.ts`.
- Update `ImagePicker` (`src/components/shared/ImagePicker.tsx`) to reject unallowlisted manual URL input client-side and use a safe `<img>` preview fallback when Next optimization is not suitable for the URL.
- Filter Google CSE image search results in `src/app/api/images/search/route.ts` so only images from trusted hosts (and trusted thumbnails) are returned to the client.

### Testing
- Ran `npm run lint` which failed in this environment due to the `eslint` package/binary not being present in `node_modules` (no lint pass performed here).
- Ran `npm run build` which failed in this environment because the `next` binary is not installed in `node_modules` (build could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433fae2008326b9d584f2aa5ab52a)