### PR TITLE
Harden production session handling and secure auth cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Required — SQLite database path
 DATABASE_URL="file:./prisma/dev.db"
 
-# Recommended — signs session cookies to prevent cookie forgery attacks
+# Required in production — signs session cookies to prevent cookie forgery attacks
 # Generate with: openssl rand -hex 32
 SESSION_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ Data is persisted in named Docker volumes:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | `file:./prisma/dev.db` | SQLite connection string |
-| `SESSION_SECRET` | Recommended | — | Signs session cookies to prevent forgery. Generate: `openssl rand -hex 32` |
+| `SESSION_SECRET` | Yes (Production) | — | Required in production. Signs session cookies to prevent forgery. Generate: `openssl rand -hex 32` |
 | `NODE_ENV` | No | `development` | Set to `production` in deployed environments |
 | `PORT` | No | `3000` | Port exposed by Docker Compose |
 | `GOOGLE_CSE_API_KEY` | No | — | Google Custom Search API key for image lookup |
 | `GOOGLE_CSE_SEARCH_ENGINE_ID` | No | — | Google CSE search engine ID |
 | `APP_PASSWORD` | — | — | Set via the Settings UI — not an environment variable |
+
+> ⚠️ In production, startup will fail when `SESSION_SECRET` is missing to prevent unsigned sessions.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - DATABASE_URL=file:/app/data/vault.db
       - VAULT_ENCRYPTION_KEY=${VAULT_ENCRYPTION_KEY:-}
-      - SESSION_SECRET=${SESSION_SECRET:-}
+      - SESSION_SECRET=${SESSION_SECRET:?SESSION_SECRET is required in production}
     volumes:
       - ${DATA_DIR:-./data}/db:/app/data
       - ${DATA_DIR:-./data}/uploads:/app/uploads

--- a/docs/secure-backup-system.md
+++ b/docs/secure-backup-system.md
@@ -56,7 +56,7 @@ Optional toggle:
 - Manual backup files are encrypted before being saved locally.
 - Automatic backup files are encrypted server-side before being written to `./backups`.
 - Keep backup passphrases separate from backup files.
-- Set a strong `SESSION_SECRET` in production.
+- `SESSION_SECRET` is required in production (the app fails fast without it).
 
 ## Endpoints
 - `POST /api/backup/export`

--- a/src/app/api/auth/check/route.ts
+++ b/src/app/api/auth/check/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { cookies } from "next/headers";
 import { verifyTokenNode } from "@/lib/session";
+import { getSessionSecret } from "@/lib/session-config";
 
 export async function GET() {
   try {
@@ -16,7 +17,7 @@ export async function GET() {
     const cookieStore = await cookies();
     const session = cookieStore.get("vault_session");
     const passwordRequired = !!settings.appPassword;
-    const secret = process.env.SESSION_SECRET;
+    const secret = getSessionSecret();
     const authenticated = session?.value
       ? (secret ? verifyTokenNode(session.value, secret) : true)
       : false;
@@ -24,6 +25,6 @@ export async function GET() {
     return NextResponse.json({ passwordRequired, authenticated });
   } catch (error) {
     console.error("GET /api/auth/check error:", error);
-    return NextResponse.json({ passwordRequired: false, authenticated: true });
+    return NextResponse.json({ passwordRequired: false, authenticated: false });
   }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import crypto from "crypto";
 import { verifyPassword } from "@/lib/password";
 import { signToken } from "@/lib/session";
+import { getSessionCookieOptions, getSessionSecret } from "@/lib/session-config";
 
 // Simple in-memory rate limiter: max 10 attempts per IP per minute
 const attempts = new Map<string, { count: number; resetAt: number }>();
@@ -52,15 +53,10 @@ export async function POST(request: NextRequest) {
     // If no password is set, always allow access
     if (!settings.appPassword) {
       const token = crypto.randomBytes(32).toString("hex");
-      const secret = process.env.SESSION_SECRET;
+      const secret = getSessionSecret();
       const cookieValue = secret ? signToken(token, secret) : token;
       const cookieStore = await cookies();
-      cookieStore.set("vault_session", cookieValue, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-      });
+      cookieStore.set("vault_session", cookieValue, getSessionCookieOptions());
       return NextResponse.json({ success: true });
     }
 
@@ -70,15 +66,10 @@ export async function POST(request: NextRequest) {
     }
 
     const token = crypto.randomBytes(32).toString("hex");
-    const secret = process.env.SESSION_SECRET;
+    const secret = getSessionSecret();
     const cookieValue = secret ? signToken(token, secret) : token;
     const cookieStore = await cookies();
-    cookieStore.set("vault_session", cookieValue, {
-      httpOnly: true,
-      sameSite: "lax",
-      path: "/",
-      maxAge: 60 * 60 * 24 * 30,
-    });
+    cookieStore.set("vault_session", cookieValue, getSessionCookieOptions());
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getSessionCookieOptions } from "@/lib/session-config";
 
 export async function POST() {
   const cookieStore = await cookies();
-  cookieStore.delete("vault_session");
+  cookieStore.set("vault_session", "", {
+    ...getSessionCookieOptions(),
+    maxAge: 0,
+  });
   return NextResponse.json({ success: true });
 }

--- a/src/lib/session-config.ts
+++ b/src/lib/session-config.ts
@@ -1,0 +1,21 @@
+const isProduction = process.env.NODE_ENV === "production";
+
+export function getSessionSecret(): string | undefined {
+  const secret = process.env.SESSION_SECRET;
+
+  if (isProduction && !secret) {
+    throw new Error("[blackvault] SESSION_SECRET must be set in production.");
+  }
+
+  return secret;
+}
+
+export function getSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+    secure: isProduction,
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getSessionSecret } from "@/lib/session-config";
+
+const sessionSecret = getSessionSecret();
 
 async function verifyWithWebCrypto(signed: string, secret: string): Promise<boolean> {
   const lastDot = signed.lastIndexOf(".");
@@ -46,18 +49,12 @@ export async function proxy(request: NextRequest) {
   }
 
   // Validate the session signature if SESSION_SECRET is configured
-  const secret = process.env.SESSION_SECRET;
-  if (secret) {
-    const valid = await verifyWithWebCrypto(session.value, secret);
+  if (sessionSecret) {
+    const valid = await verifyWithWebCrypto(session.value, sessionSecret);
     if (!valid) {
       const loginUrl = new URL("/login", request.url);
       return NextResponse.redirect(loginUrl);
     }
-  } else {
-    console.warn(
-      "[blackvault] SESSION_SECRET is not set — session cookies are not cryptographically validated. " +
-      "Set SESSION_SECRET in your environment to prevent cookie forgery."
-    );
   }
 
   return NextResponse.next();


### PR DESCRIPTION
### Motivation
- Prevent unsigned session cookies and accidental insecure deployments by enforcing a production guard for `SESSION_SECRET` and making auth cookies secure in production.
- Centralize cookie defaults so all auth handlers consistently preserve `httpOnly`, `sameSite`, `path`, and `maxAge` while applying `secure` when running in production.

### Description
- Add `src/lib/session-config.ts` with `getSessionSecret()` that throws when `NODE_ENV === "production"` and `SESSION_SECRET` is missing, and `getSessionCookieOptions()` which sets `httpOnly`, `sameSite: "lax"`, `path: "/"`, `maxAge`, and `secure: process.env.NODE_ENV === "production"`.
- Update `src/app/api/auth/login/route.ts` to use `getSessionSecret()` and `getSessionCookieOptions()` when setting the `vault_session` cookie so cookies gain the `secure` flag in production and keep existing properties.
- Update `src/app/api/auth/logout/route.ts` to clear the cookie using the same options (setting `maxAge: 0`) for consistent deletion semantics.
- Update `src/app/api/auth/check/route.ts` and `src/proxy.ts` to use the guarded `getSessionSecret()` so unsigned sessions are not allowed in production, and change the auth error path to return `authenticated: false` on error.
- Update docs and deployment configs: mark `SESSION_SECRET` as required in production in `README.md`, `docs/secure-backup-system.md`, and `.env.example`, and make `docker-compose.yml` require `SESSION_SECRET` at runtime in production.

### Testing
- Ran unit tests with `npm test` (Vitest), all tests passed: 7 test files, 68 tests succeeded.
- Ran linting with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433fb42a48326ab0c35d1ac2fdae1)