### PR TITLE
Harden uploads: magic-byte validation, disallow SVG, canonical MIME, controlled file serving

### DIFF
--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -2,22 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import { prisma } from "@/lib/prisma";
+import { detectFileSignature } from "@/lib/server/file-signatures";
 
-const ALLOWED_EXTENSIONS = new Set(["pdf", "jpg", "jpeg", "png", "webp"]);
-
-const MIME_TO_EXT: Record<string, string> = {
-  "application/pdf": "pdf",
-  "image/jpeg": "jpg",
-  "image/jpg": "jpg",
-  "image/png": "png",
-  "image/webp": "webp",
-};
+const ALLOWED_EXTENSIONS = new Set(["pdf", "jpg", "png", "webp"]);
 
 const MAX_SIZE = 20 * 1024 * 1024; // 20MB
 
 // POST /api/documents/upload
 // Accepts multipart form data: file, name, type, firearmId?, accessoryId?, notes?
-// Saves to /public/uploads/documents/{cuid}.{ext}
+// Saves to /storage/uploads/documents/{uuid}.{ext}
 // Creates a Document record and returns it.
 export async function POST(request: NextRequest) {
   try {
@@ -37,39 +30,33 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Missing required field: name" }, { status: 400 });
     }
 
-    const originalName = file.name ?? "";
-    const dotIndex = originalName.lastIndexOf(".");
-    let ext = dotIndex !== -1 ? originalName.slice(dotIndex + 1).toLowerCase() : "";
-
-    if (!ext || !ALLOWED_EXTENSIONS.has(ext)) {
-      ext = MIME_TO_EXT[file.type] ?? "";
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json({ error: "File too large. Maximum size is 20MB." }, { status: 400 });
     }
 
-    if (!ext || !ALLOWED_EXTENSIONS.has(ext)) {
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const detected = detectFileSignature(buffer);
+
+    if (!detected || !ALLOWED_EXTENSIONS.has(detected.extension)) {
       return NextResponse.json(
         { error: `Invalid file type. Allowed: ${Array.from(ALLOWED_EXTENSIONS).join(", ")}` },
         { status: 400 }
       );
     }
 
-    if (file.size > MAX_SIZE) {
-      return NextResponse.json({ error: "File too large. Maximum size is 20MB." }, { status: 400 });
-    }
-
     // Generate a unique ID for the file
     const fileId = crypto.randomUUID().replace(/-/g, "");
 
-    const fileName = `${fileId}.${ext}`;
-    const relativeUrl = `/uploads/documents/${fileName}`;
+    const fileName = `${fileId}.${detected.extension}`;
+    const relativeUrl = `/api/files/documents/${fileName}`;
 
     const projectRoot = process.cwd();
-    const uploadDir = path.join(projectRoot, "public", "uploads", "documents");
+    const uploadDir = path.join(projectRoot, "storage", "uploads", "documents");
     const filePath = path.join(uploadDir, fileName);
 
     await fs.mkdir(uploadDir, { recursive: true });
 
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
     await fs.writeFile(filePath, buffer);
 
     const doc = await prisma.document.create({
@@ -78,7 +65,7 @@ export async function POST(request: NextRequest) {
         type,
         fileUrl: relativeUrl,
         fileSize: file.size,
-        mimeType: file.type || null,
+        mimeType: detected.mimeType,
         notes: notes || null,
         firearmId: firearmId || null,
         accessoryId: accessoryId || null,

--- a/src/app/api/files/[...segments]/route.ts
+++ b/src/app/api/files/[...segments]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  avif: "image/avif",
+  pdf: "application/pdf",
+};
+
+const ROOT_UPLOAD_PATH = path.join(process.cwd(), "storage", "uploads");
+
+function isSafeSegment(segment: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(segment) && !segment.includes("..");
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ segments: string[] }> }
+) {
+  try {
+    const { segments } = await params;
+    if (!Array.isArray(segments) || segments.length === 0) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+
+    if (segments.some((segment) => !isSafeSegment(segment))) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+
+    const normalizedRelativePath = path.normalize(path.join(...segments));
+    const resolvedPath = path.resolve(ROOT_UPLOAD_PATH, normalizedRelativePath);
+
+    if (!resolvedPath.startsWith(ROOT_UPLOAD_PATH + path.sep)) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+
+    const ext = path.extname(resolvedPath).slice(1).toLowerCase();
+    const mimeType = MIME_BY_EXTENSION[ext];
+
+    if (!mimeType) {
+      return NextResponse.json({ error: "Unsupported file type" }, { status: 400 });
+    }
+
+    const data = await fs.readFile(resolvedPath);
+    const filename = path.basename(resolvedPath);
+    const download = request.nextUrl.searchParams.get("download") === "1";
+
+    return new NextResponse(data, {
+      status: 200,
+      headers: {
+        "Content-Type": mimeType,
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "private, max-age=31536000, immutable",
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename=\"${filename}\"`,
+      },
+    });
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
+
+    console.error("GET /api/files error:", error);
+    return NextResponse.json({ error: "Failed to retrieve file" }, { status: 500 });
+  }
+}

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { detectFileSignature } from "@/lib/server/file-signatures";
 
-const ALLOWED_EXTENSIONS = new Set([
-  "jpg",
-  "jpeg",
-  "png",
-  "gif",
-  "webp",
-  "avif",
-  "svg",
-]);
+const ALLOWED_EXTENSIONS = new Set(["jpg", "png", "webp", "avif"]);
 
 const ALLOWED_ENTITY_TYPES = new Set([
   "firearm",
@@ -20,7 +13,7 @@ const ALLOWED_ENTITY_TYPES = new Set([
 
 // POST /api/images/upload - Upload an image for an entity
 // Accepts multipart form data: file, entityType, entityId
-// Saves to /public/uploads/{entityType}s/{entityId}.{ext}
+// Saves to /storage/uploads/images/{entityType}s/{entityId}.{ext}
 // Returns the URL path.
 export async function POST(request: NextRequest) {
   try {
@@ -62,34 +55,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Determine the file extension
-    const originalName = file.name ?? "";
-    const dotIndex = originalName.lastIndexOf(".");
-    let ext = dotIndex !== -1 ? originalName.slice(dotIndex + 1).toLowerCase() : "";
-
-    // Also check MIME type as fallback
-    if (!ext || !ALLOWED_EXTENSIONS.has(ext)) {
-      const mimeToExt: Record<string, string> = {
-        "image/jpeg": "jpg",
-        "image/jpg": "jpg",
-        "image/png": "png",
-        "image/gif": "gif",
-        "image/webp": "webp",
-        "image/avif": "avif",
-        "image/svg+xml": "svg",
-      };
-      ext = mimeToExt[file.type] ?? "";
-    }
-
-    if (!ext || !ALLOWED_EXTENSIONS.has(ext)) {
-      return NextResponse.json(
-        {
-          error: `Invalid file type. Allowed types: ${Array.from(ALLOWED_EXTENSIONS).join(", ")}`,
-        },
-        { status: 400 }
-      );
-    }
-
     // Check file size (limit to 10MB)
     const MAX_SIZE = 10 * 1024 * 1024;
     if (file.size > MAX_SIZE) {
@@ -99,23 +64,33 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const detected = detectFileSignature(buffer);
+
+    if (!detected || !ALLOWED_EXTENSIONS.has(detected.extension)) {
+      return NextResponse.json(
+        {
+          error: `Invalid file type. Only raster formats are allowed: ${Array.from(ALLOWED_EXTENSIONS).join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+
     // Build paths
     // entityType = "firearm" -> directory = "firearms"
     const entityTypeDir = `${entityType}s`;
-    const fileName = `${sanitizedEntityId}_${Date.now()}.${ext}`;
-    const relativeUrl = `/uploads/${entityTypeDir}/${fileName}`;
+    const fileName = `${sanitizedEntityId}_${Date.now()}.${detected.extension}`;
+    const relativeUrl = `/api/files/images/${entityTypeDir}/${fileName}`;
 
-    // Resolve the absolute path within the project's public directory
+    // Resolve the absolute path outside the web root
     const projectRoot = process.cwd();
-    const uploadDir = path.join(projectRoot, "public", "uploads", entityTypeDir);
+    const uploadDir = path.join(projectRoot, "storage", "uploads", "images", entityTypeDir);
     const filePath = path.join(uploadDir, fileName);
 
     // Ensure the directory exists
     await fs.mkdir(uploadDir, { recursive: true });
 
-    // Read the file contents and write to disk
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
     await fs.writeFile(filePath, buffer);
 
     return NextResponse.json(
@@ -125,7 +100,7 @@ export async function POST(request: NextRequest) {
         entityId: sanitizedEntityId,
         fileName,
         size: file.size,
-        mimeType: file.type,
+        mimeType: detected.mimeType,
       },
       { status: 201 }
     );

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -3,8 +3,17 @@ import path from "path";
 import { prisma } from "@/lib/prisma";
 
 async function readDocumentFileAsBase64(fileUrl: string): Promise<string | null> {
-  if (!fileUrl.startsWith("/uploads/")) return null;
-  const absolutePath = path.join(process.cwd(), "public", fileUrl.replace(/^\//, ""));
+  let absolutePath: string | null = null;
+
+  if (fileUrl.startsWith("/api/files/documents/")) {
+    const fileName = fileUrl.replace("/api/files/documents/", "").split("?")[0];
+    absolutePath = path.join(process.cwd(), "storage", "uploads", "documents", fileName);
+  } else if (fileUrl.startsWith("/uploads/")) {
+    absolutePath = path.join(process.cwd(), "public", fileUrl.replace(/^\//, ""));
+  }
+
+  if (!absolutePath) return null;
+
   try {
     const buf = await fs.readFile(absolutePath);
     return buf.toString("base64");

--- a/src/lib/server/file-signatures.ts
+++ b/src/lib/server/file-signatures.ts
@@ -1,0 +1,83 @@
+type FileSignature = {
+  extension: string;
+  mimeType: string;
+};
+
+const JPEG_SOI_1 = 0xff;
+const JPEG_SOI_2 = 0xd8;
+const JPEG_SOI_3 = 0xff;
+
+export function detectFileSignature(buffer: Buffer): FileSignature | null {
+  if (buffer.length < 12) {
+    return null;
+  }
+
+  // JPEG: FF D8 FF
+  if (
+    buffer[0] === JPEG_SOI_1 &&
+    buffer[1] === JPEG_SOI_2 &&
+    buffer[2] === JPEG_SOI_3
+  ) {
+    return { extension: "jpg", mimeType: "image/jpeg" };
+  }
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return { extension: "png", mimeType: "image/png" };
+  }
+
+  // WEBP: RIFF....WEBP
+  if (
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return { extension: "webp", mimeType: "image/webp" };
+  }
+
+  // AVIF: ISO BMFF with ftyp and major brand avif/avis/mif1/msf1
+  if (
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70
+  ) {
+    const majorBrand = buffer.subarray(8, 12).toString("ascii");
+    const compatibleBrands = buffer.subarray(8, 64).toString("ascii");
+    if (
+      ["avif", "avis"].includes(majorBrand) ||
+      compatibleBrands.includes("avif") ||
+      compatibleBrands.includes("avis")
+    ) {
+      return { extension: "avif", mimeType: "image/avif" };
+    }
+  }
+
+  // PDF: %PDF-
+  if (
+    buffer[0] === 0x25 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x44 &&
+    buffer[3] === 0x46 &&
+    buffer[4] === 0x2d
+  ) {
+    return { extension: "pdf", mimeType: "application/pdf" };
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
### Motivation
- Prevent client-controlled extension/MIME spoofing by validating file signatures (magic bytes) server-side and restrict images to raster formats for safety.
- Avoid serving uploaded files directly from the web root to reduce accidental exposure and force controlled delivery with safe headers.

### Description
- Added `src/lib/server/file-signatures.ts` with `detectFileSignature` to identify `jpg`, `png`, `webp`, `avif`, and `pdf` by magic bytes and return a canonical extension and MIME.
- Updated `src/app/api/images/upload/route.ts` to reject non-raster images, use detected extension/MIME, enforce size limits, store files under `storage/uploads/images/...`, and return a controlled URL under `/api/files/...`.
- Updated `src/app/api/documents/upload/route.ts` to detect file signatures, canonicalize MIME/extension, store documents under `storage/uploads/documents/...`, and return `/api/files/...` URLs; PDF and raster images are allowed for documents.
- Added a controlled file-serving endpoint `src/app/api/files/[...segments]/route.ts` that validates path segments, resolves files only under `storage/uploads`, and responds with explicit `Content-Type`, `X-Content-Type-Options: nosniff`, `Cache-Control`, and `Content-Disposition` headers, and updated `src/lib/backup.ts` to read files from the new layout while still supporting legacy `/uploads/` paths.

### Testing
- Ran `npm run lint`, which completed successfully.
- Ran `npm test`, all test files passed (`7 files, 68 tests` passed).
- Ran `npm run build`, which failed in this environment due to Next.js being unable to fetch Google Fonts from `fonts.googleapis.com` during the build (network font fetch, unrelated to the upload changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433fd22f8832682f36ad5ee5a93cd)