### PR TITLE
Deprecate in-app system update execution endpoint

### DIFF
--- a/src/app/api/system-update/route.ts
+++ b/src/app/api/system-update/route.ts
@@ -1,86 +1,86 @@
-import { NextResponse } from "next/server";
-import { promisify } from "node:util";
-import { execFile } from "node:child_process";
+import { NextRequest, NextResponse } from "next/server";
+import { verifyTokenNode } from "@/lib/session";
 
-const execFileAsync = promisify(execFile);
+type SystemUpdateMetadata = {
+  currentVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  source: string;
+  checkedAt: string;
+};
 
-async function runGit(args: string[]) {
-  return execFileAsync("git", args, {
-    cwd: process.cwd(),
-    maxBuffer: 1024 * 1024,
+function isStatusRouteEnabled() {
+  return process.env.SYSTEM_UPDATE_STATUS_ENABLED === "true";
+}
+
+function isProductionAllowed() {
+  return process.env.NODE_ENV !== "production" || process.env.SYSTEM_UPDATE_ALLOW_PRODUCTION === "true";
+}
+
+function requireElevatedAdmin(request: NextRequest) {
+  const adminToken = process.env.SYSTEM_UPDATE_ADMIN_TOKEN;
+  const sessionSecret = process.env.SESSION_SECRET;
+  const sessionCookie = request.cookies.get("vault_session")?.value;
+
+  if (!adminToken || !sessionSecret || !sessionCookie) {
+    return false;
+  }
+
+  const headerToken = request.headers.get("x-system-update-admin-token");
+  if (!headerToken || headerToken !== adminToken) {
+    return false;
+  }
+
+  return verifyTokenNode(sessionCookie, sessionSecret);
+}
+
+function getMetadata(): SystemUpdateMetadata {
+  const currentVersion = process.env.APP_VERSION ?? process.env.npm_package_version ?? null;
+  const latestVersion = process.env.SYSTEM_UPDATE_LATEST_VERSION ?? null;
+
+  return {
+    currentVersion,
+    latestVersion,
+    updateAvailable: !!latestVersion && !!currentVersion && latestVersion !== currentVersion,
+    source: process.env.SYSTEM_UPDATE_STATUS_SOURCE ?? "environment",
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function endpointDisabledResponse() {
+  return NextResponse.json(
+    {
+      error: "System update endpoint is disabled.",
+      message:
+        "Application self-update has been deprecated. Move updates to host-level operations (systemd/cron/CI/CD).",
+    },
+    { status: 404 }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  if (!isStatusRouteEnabled() || !isProductionAllowed()) {
+    return endpointDisabledResponse();
+  }
+
+  if (!requireElevatedAdmin(request)) {
+    return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    metadata: getMetadata(),
+    writable: false,
+    message: "Read-only system update metadata endpoint.",
   });
 }
 
-async function ensureRepoContext() {
-  const insideRepo = await runGit(["rev-parse", "--is-inside-work-tree"]);
-  if (insideRepo.stdout.trim() !== "true") {
-    return { error: "Application is not running from a Git repository." };
-  }
-
-  const branchResult = await runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
-  const branch = branchResult.stdout.trim();
-  const remoteResult = await runGit(["remote", "get-url", "origin"]);
-  const remote = remoteResult.stdout.trim();
-
-  return { branch, remote };
-}
-
-export async function GET() {
-  try {
-    const context = await ensureRepoContext();
-    if ("error" in context) {
-      return NextResponse.json({ error: context.error }, { status: 400 });
-    }
-
-    const { branch, remote } = context;
-    await runGit(["fetch", "origin", branch]);
-    const behindResult = await runGit(["rev-list", "--count", `HEAD..origin/${branch}`]);
-    const behind = Number.parseInt(behindResult.stdout.trim(), 10) || 0;
-
-    return NextResponse.json({
-      branch,
-      remote,
-      updateAvailable: behind > 0,
-      commitsBehind: behind,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to check for updates.";
-    return NextResponse.json(
-      {
-        error: "Failed to check for updates.",
-        details: message,
-      },
-      { status: 500 }
-    );
-  }
-}
-
 export async function POST() {
-  try {
-    const context = await ensureRepoContext();
-    if ("error" in context) {
-      return NextResponse.json({ error: context.error }, { status: 400 });
-    }
-
-    const { branch, remote } = context;
-
-    const pullResult = await runGit(["pull", "--ff-only", "origin", branch]);
-    const output = `${pullResult.stdout}${pullResult.stderr}`.trim();
-
-    return NextResponse.json({
-      branch,
-      remote,
-      output: output || "Already up to date.",
-      message: "Git update completed. Restart the app if dependencies or runtime files changed.",
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to pull updates from GitHub.";
-    return NextResponse.json(
-      {
-        error: "Failed to pull updates from GitHub.",
-        details: message,
-      },
-      { status: 500 }
-    );
-  }
+  return NextResponse.json(
+    {
+      error: "Deprecated endpoint.",
+      message:
+        "POST /api/system-update has been removed. Execute updates via host-level operations (systemd/cron/CI/CD).",
+    },
+    { status: 410 }
+  );
 }


### PR DESCRIPTION
### Motivation
- Prevent the web process from performing privileged Git operations and move update execution to host-level workflows (systemd/cron/CI-CD) where credentials and execution context are isolated.  
- Preserve a safe, read-only status surface for operators while reducing attack surface of the web app.  
- Ensure status checks are explicitly enabled and strongly gated in production to avoid accidental exposure.

### Description
- Replaced `POST /api/system-update` with a deprecation response (`410 Gone`) so the endpoint no longer executes Git commands or updates.  
- Reworked `GET /api/system-update` into a read-only metadata endpoint that sources values from environment variables (`APP_VERSION`, `SYSTEM_UPDATE_LATEST_VERSION`, `SYSTEM_UPDATE_STATUS_SOURCE`) instead of running Git.  
- Added explicit enablement gates using `SYSTEM_UPDATE_STATUS_ENABLED=true` and a production override `SYSTEM_UPDATE_ALLOW_PRODUCTION=true`.  
- Enforced stricter access controls by requiring a signed `vault_session` cookie verified with `SESSION_SECRET` and a matching `x-system-update-admin-token` header against `SYSTEM_UPDATE_ADMIN_TOKEN`, and removed `child_process`/`git` usage from the route.

### Testing
- Ran linter on the modified file with `npm run lint -- src/app/api/system-update/route.ts` and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433fed0dc8326b07ad30d2d0cc69a)