### PR TITLE
Add shared API request validation and DB-backed rate limiting for sensitive routes

### DIFF
--- a/prisma/migrations/20260313120000_add_api_rate_limit/migration.sql
+++ b/prisma/migrations/20260313120000_add_api_rate_limit/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "ApiRateLimit" (
+    "bucketId" TEXT NOT NULL PRIMARY KEY,
+    "key" TEXT NOT NULL,
+    "windowStart" DATETIME NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0
+);
+
+-- CreateIndex
+CREATE INDEX "ApiRateLimit_key_windowStart_idx" ON "ApiRateLimit"("key", "windowStart");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -430,3 +430,12 @@ model AppSettings {
   createdAt               DateTime @default(now())
   updatedAt               DateTime @updatedAt
 }
+
+model ApiRateLimit {
+  bucketId    String   @id
+  key         String
+  windowStart DateTime
+  count       Int      @default(0)
+
+  @@index([key, windowStart])
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,37 +4,26 @@ import { cookies } from "next/headers";
 import crypto from "crypto";
 import { verifyPassword } from "@/lib/password";
 import { signToken } from "@/lib/session";
+import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
+import { authSchemas } from "@/lib/validation/schemas/api";
+import { enforceRateLimit } from "@/lib/rate-limit";
 
-// Simple in-memory rate limiter: max 10 attempts per IP per minute
-const attempts = new Map<string, { count: number; resetAt: number }>();
 const MAX_ATTEMPTS = 10;
 const WINDOW_MS = 60 * 1000;
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const rec = attempts.get(ip);
-  if (!rec || now > rec.resetAt) {
-    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-    return true;
-  }
-  if (rec.count >= MAX_ATTEMPTS) return false;
-  rec.count++;
-  return true;
-}
 
 export async function POST(request: NextRequest) {
   try {
     // Rate limiting
     const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
-    if (!checkRateLimit(ip)) {
+    const rate = await enforceRateLimit({ key: `auth:login:${ip}`, windowMs: WINDOW_MS, maxAttempts: MAX_ATTEMPTS });
+    if (!rate.allowed) {
       return NextResponse.json(
         { error: "Too many login attempts. Please wait a minute." },
         { status: 429 }
       );
     }
 
-    const body = await request.json();
-    const { password } = body;
+    const { password } = await parseJsonBody(request, authSchemas.login, { maxBytes: 8 * 1024 });
 
     // Guard against DoS via enormous password strings sent to scrypt
     if (typeof password === "string" && password.length > 1024) {
@@ -82,6 +71,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
+    if (error instanceof Error && (error as { status?: number }).status) {
+      return validationErrorResponse(error, "Invalid login payload");
+    }
     console.error("POST /api/auth/login error:", error);
     return NextResponse.json({ error: "Authentication failed" }, { status: 500 });
   }

--- a/src/app/api/backup/auto/route.ts
+++ b/src/app/api/backup/auto/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
+import { backupSchemas } from "@/lib/validation/schemas/api";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { promises as fs } from "fs";
 import path from "path";
 import crypto from "crypto";
@@ -42,6 +45,9 @@ function encryptForServerBackup(payload: unknown, passphrase: string) {
 
 export async function POST(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `backup:auto:${ip}`, windowMs: 60_000, maxAttempts: 10 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
     const autoPassphrase = process.env.AUTO_BACKUP_PASSPHRASE;
     if (!autoPassphrase) {
       return NextResponse.json(
@@ -50,7 +56,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json().catch(() => ({}));
+    const body = await parseJsonBody(request, backupSchemas.auto, { maxBytes: 32 * 1024 });
     const includeDocumentFiles = body?.includeDocumentFiles !== false;
     const force = body?.force === true;
 
@@ -114,6 +120,7 @@ export async function POST(request: NextRequest) {
       token,
     });
   } catch (error) {
+    if (error instanceof Error && (error as { status?: number }).status) return validationErrorResponse(error);
     console.error("POST /api/backup/auto error:", error);
     return NextResponse.json({ error: "Failed to run automatic backup" }, { status: 500 });
   }

--- a/src/app/api/backup/export/route.ts
+++ b/src/app/api/backup/export/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
+import { backupSchemas } from "@/lib/validation/schemas/api";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { collectBackupData } from "@/lib/backup";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json().catch(() => ({}));
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `backup:export:${ip}`, windowMs: 60_000, maxAttempts: 10 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    const body = await parseJsonBody(request, backupSchemas.export, { maxBytes: 32 * 1024 });
     const includeDocumentFiles = body?.includeDocumentFiles !== false;
 
     const data = await collectBackupData(includeDocumentFiles);
@@ -20,6 +26,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(backup);
   } catch (error) {
+    if (error instanceof Error && (error as { status?: number }).status) return validationErrorResponse(error);
     console.error("POST /api/backup/export error:", error);
     return NextResponse.json({ error: "Failed to generate backup" }, { status: 500 });
   }

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { promises as fs } from "fs";
 import path from "path";
 import { prisma } from "@/lib/prisma";
@@ -21,6 +22,14 @@ const MAX_SIZE = 20 * 1024 * 1024; // 20MB
 // Creates a Document record and returns it.
 export async function POST(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `documents:upload:${ip}`, windowMs: 60_000, maxAttempts: 10 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength) && contentLength > 23068672) {
+      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+    }
     const formData = await request.formData();
 
     const file = formData.get("file") as File | null;

--- a/src/app/api/encryption/route.ts
+++ b/src/app/api/encryption/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
+import { encryptionSchemas } from "@/lib/validation/schemas/api";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { clearKeyCache } from "@/lib/crypto";
 import crypto from "crypto";
 
@@ -26,8 +29,12 @@ export async function GET() {
 }
 
 // POST /api/encryption — generate a new random key and save it
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `encryption:generate:${ip}`, windowMs: 60_000, maxAttempts: 5 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
     if (process.env.VAULT_ENCRYPTION_KEY) {
       return NextResponse.json(
         { error: "Encryption is already active via environment variable. Remove VAULT_ENCRYPTION_KEY to use the UI setup instead." },
@@ -63,6 +70,10 @@ export async function POST() {
 // PUT /api/encryption — save a user-supplied key
 export async function PUT(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `encryption:import:${ip}`, windowMs: 60_000, maxAttempts: 5 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
     if (process.env.VAULT_ENCRYPTION_KEY) {
       return NextResponse.json(
         { error: "Encryption is managed via environment variable" },
@@ -70,8 +81,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { key } = body;
+    const { key } = await parseJsonBody(request, encryptionSchemas.importKey, { maxBytes: 16 * 1024 });
 
     if (typeof key !== "string" || !HEX_KEY_RE.test(key)) {
       return NextResponse.json(
@@ -90,14 +100,21 @@ export async function PUT(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
+    if (error instanceof Error && (error as { status?: number }).status) {
+      return validationErrorResponse(error, "Invalid encryption payload");
+    }
     console.error("PUT /api/encryption error:", error);
     return NextResponse.json({ error: "Failed to save key" }, { status: 500 });
   }
 }
 
 // DELETE /api/encryption — remove the DB-stored key (disables encryption)
-export async function DELETE() {
+export async function DELETE(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `encryption:delete:${ip}`, windowMs: 60_000, maxAttempts: 5 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
     if (process.env.VAULT_ENCRYPTION_KEY) {
       return NextResponse.json(
         { error: "Encryption is managed via environment variable. Remove VAULT_ENCRYPTION_KEY from your environment to disable it." },

--- a/src/app/api/images/search/route.ts
+++ b/src/app/api/images/search/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
+import { imagesSchemas } from "@/lib/validation/schemas/api";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { prisma } from "@/lib/prisma";
 import { decryptField } from "@/lib/crypto";
 
@@ -25,8 +28,10 @@ interface GoogleCseItem {
 // If no API key, returns 400 with helpful message.
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { query } = body;
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `images:search:${ip}`, windowMs: 60_000, maxAttempts: 10 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    const { query } = await parseJsonBody(request, imagesSchemas.search, { maxBytes: 16 * 1024 });
 
     if (!query || typeof query !== "string" || query.trim() === "") {
       return NextResponse.json(
@@ -113,6 +118,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ results, query: query.trim() });
   } catch (error) {
+    if (error instanceof Error && (error as { status?: number }).status) return validationErrorResponse(error);
     console.error("POST /api/images/search error:", error);
     return NextResponse.json(
       { error: "Failed to perform image search" },

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import { promises as fs } from "fs";
 import path from "path";
 
@@ -24,6 +25,14 @@ const ALLOWED_ENTITY_TYPES = new Set([
 // Returns the URL path.
 export async function POST(request: NextRequest) {
   try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const rate = await enforceRateLimit({ key: `images:upload:${ip}`, windowMs: 60_000, maxAttempts: 10 });
+    if (!rate.allowed) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength) && contentLength > 12582912) {
+      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+    }
     const formData = await request.formData();
 
     const file = formData.get("file") as File | null;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prisma";
+
+export async function enforceRateLimit(options: {
+  key: string;
+  windowMs: number;
+  maxAttempts: number;
+}): Promise<{ allowed: boolean; retryAfterSec: number }> {
+  const now = Date.now();
+  const windowStart = new Date(now - options.windowMs);
+  const bucketId = `${options.key}:${Math.floor(now / options.windowMs)}`;
+
+  await prisma.apiRateLimit.deleteMany({ where: { key: options.key, windowStart: { lt: windowStart } } });
+
+  const existing = await prisma.apiRateLimit.findUnique({ where: { bucketId } });
+  if (!existing) {
+    await prisma.apiRateLimit.create({
+      data: {
+        bucketId,
+        key: options.key,
+        windowStart: new Date(Math.floor(now / options.windowMs) * options.windowMs),
+        count: 1,
+      },
+    });
+    return { allowed: true, retryAfterSec: Math.ceil(options.windowMs / 1000) };
+  }
+
+  if (existing.count >= options.maxAttempts) {
+    const retryAfterSec = Math.max(1, Math.ceil((existing.windowStart.getTime() + options.windowMs - now) / 1000));
+    return { allowed: false, retryAfterSec };
+  }
+
+  await prisma.apiRateLimit.update({ where: { bucketId }, data: { count: { increment: 1 } } });
+  return { allowed: true, retryAfterSec: Math.ceil(options.windowMs / 1000) };
+}

--- a/src/lib/validation/request.ts
+++ b/src/lib/validation/request.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export class RequestValidationError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function getContentLength(request: NextRequest): number | null {
+  const value = request.headers.get("content-length");
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function parseJsonBody<T>(
+  request: NextRequest,
+  schema: z.ZodType<T>,
+  options?: { maxBytes?: number }
+): Promise<T> {
+  const maxBytes = options?.maxBytes ?? 1024 * 1024;
+  const headerLength = getContentLength(request);
+  if (headerLength !== null && headerLength > maxBytes) {
+    throw new RequestValidationError(`Request body too large (max ${maxBytes} bytes)`, 413);
+  }
+
+  const raw = await request.text();
+  if (Buffer.byteLength(raw, "utf8") > maxBytes) {
+    throw new RequestValidationError(`Request body too large (max ${maxBytes} bytes)`, 413);
+  }
+
+  let parsedJson: unknown = {};
+  if (raw.trim().length > 0) {
+    try {
+      parsedJson = JSON.parse(raw);
+    } catch {
+      throw new RequestValidationError("Invalid JSON payload", 400);
+    }
+  }
+
+  const result = schema.safeParse(parsedJson);
+  if (!result.success) {
+    throw new RequestValidationError(z.prettifyError(result.error), 400);
+  }
+
+  return result.data;
+}
+
+export function validationErrorResponse(error: unknown, defaultMessage = "Invalid request") {
+  if (error instanceof RequestValidationError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  return NextResponse.json({ error: defaultMessage }, { status: 400 });
+}

--- a/src/lib/validation/schemas/api.ts
+++ b/src/lib/validation/schemas/api.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+const optionalString = z.string().trim().optional();
+const nullableString = z.string().trim().nullable().optional();
+const optionalNumber = z.coerce.number().optional();
+const optionalInt = z.coerce.number().int().optional();
+
+export const authSchemas = {
+  login: z.object({ password: z.string().max(1024) }).strict(),
+};
+
+export const encryptionSchemas = {
+  importKey: z.object({ key: z.string().min(1).max(1024) }).strict(),
+};
+
+export const backupSchemas = {
+  export: z.object({ includeDocumentFiles: z.coerce.boolean().optional() }).strict(),
+  auto: z.object({ includeDocumentFiles: z.coerce.boolean().optional(), force: z.coerce.boolean().optional() }).strict(),
+};
+
+export const imagesSchemas = {
+  search: z.object({ query: z.string().trim().min(1).max(200) }).strict(),
+};
+
+export const buildsSchemas = {
+  create: z.object({ name: z.string().min(1), description: nullableString, firearmId: z.string().min(1), isActive: z.coerce.boolean().optional() }).strict(),
+  update: z.object({ name: z.string().min(1).optional(), description: nullableString, isActive: z.coerce.boolean().optional() }).strict(),
+  reorder: z.object({ sortOrder: z.coerce.number().int() }).strict(),
+  slot: z.object({ slotType: z.string().min(1), accessoryId: z.string().nullable().optional() }).strict(),
+};
+
+export const maintenanceSchemas = {
+  noteCreate: z.object({ firearmId: z.string().min(1), description: z.string().min(1), type: optionalString, date: optionalString, mileage: optionalNumber }).strict(),
+  scheduleCreate: z.object({ firearmId: z.string().min(1), taskName: z.string().min(1), intervalType: z.string().min(1), intervalValue: z.coerce.number().int().positive(), notes: optionalString }).strict(),
+  scheduleUpdate: z.object({ taskName: z.string().min(1), intervalType: z.string().min(1), intervalValue: z.coerce.number().int().positive(), notes: optionalString }).strict(),
+  scheduleComplete: z.object({ notes: optionalString }).strict(),
+};
+
+export const accessoriesSchemas = {
+  create: z.object({ name: z.string().min(1), manufacturer: optionalString, model: optionalString, type: z.string().min(1), caliber: optionalString, purchasePrice: optionalNumber, acquisitionDate: optionalString, notes: optionalString, imageUrl: optionalString, imageSource: optionalString, hasBattery: z.coerce.boolean().optional(), batteryType: optionalString, batteryChangedAt: optionalString, batteryIntervalDays: optionalInt, compatibleFirearmTypes: optionalString, compatibleCalibers: optionalString }).strict(),
+  update: z.object({ name: z.string().min(1).optional(), manufacturer: optionalString, model: optionalString, type: z.string().min(1).optional(), caliber: optionalString, purchasePrice: optionalNumber, acquisitionDate: optionalString, notes: optionalString, imageUrl: optionalString, imageSource: optionalString, hasBattery: z.coerce.boolean().optional(), batteryType: optionalString, batteryChangedAt: optionalString, batteryIntervalDays: optionalInt, compatibleFirearmTypes: optionalString, compatibleCalibers: optionalString }).strict(),
+  rounds: z.object({ rounds: z.coerce.number().int().positive(), note: optionalString }).strict(),
+  battery: z.object({ changedAt: optionalString, intervalDays: optionalInt }).strict(),
+};
+
+export const firearmsSchemas = {
+  create: z.object({ name: z.string().min(1), manufacturer: optionalString, model: optionalString, caliber: optionalString, serialNumber: optionalString, type: optionalString, acquisitionDate: optionalString, purchasePrice: optionalNumber, currentValue: optionalNumber, notes: optionalString, imageUrl: optionalString, imageSource: optionalString }).strict(),
+  update: z.object({ name: z.string().min(1).optional(), manufacturer: optionalString, model: optionalString, caliber: optionalString, serialNumber: optionalString, type: optionalString, acquisitionDate: optionalString, purchasePrice: optionalNumber, currentValue: optionalNumber, notes: optionalString, imageUrl: optionalString, imageSource: optionalString }).strict(),
+};
+
+export const ammoSchemas = {
+  create: z.object({ caliber: z.string().min(1), brand: optionalString, model: optionalString, grain: optionalInt, quantity: z.coerce.number().int().nonnegative(), costPerRound: optionalNumber, notes: optionalString }).strict(),
+  update: z.object({ caliber: z.string().min(1).optional(), brand: optionalString, model: optionalString, grain: optionalInt, quantity: optionalInt, costPerRound: optionalNumber, notes: optionalString }).strict(),
+  transaction: z.object({ type: z.enum(["ADD", "SUBTRACT"]), quantity: z.coerce.number().int().positive(), note: optionalString }).strict(),
+};
+
+export const documentsSchemas = {
+  create: z.object({ name: z.string().min(1), type: optionalString, fileUrl: z.string().min(1), fileSize: optionalInt, mimeType: optionalString, notes: optionalString, firearmId: z.string().nullable().optional(), accessoryId: z.string().nullable().optional() }).strict(),
+  update: z.object({ name: optionalString, type: optionalString, notes: optionalString, firearmId: z.string().nullable().optional(), accessoryId: z.string().nullable().optional() }).strict(),
+};
+
+export const drillSchemas = {
+  template: z.object({ name: z.string().min(1), description: optionalString, category: optionalString, scoringType: optionalString, parTime: optionalNumber, maxScore: optionalInt }).strict(),
+  log: z.object({ templateId: z.string().nullable().optional(), drillName: z.string().min(1), performedAt: optionalString, timeSeconds: optionalNumber, hits: optionalInt, totalShots: optionalInt, accuracy: optionalNumber, score: optionalNumber, notes: optionalString }).strict(),
+};
+
+export const rangeSchemas = {
+  session: z.object({ firearmId: z.string().min(1), buildId: z.string().nullable().optional(), date: optionalString, roundsFired: z.coerce.number().int().nonnegative(), rangeName: optionalString, rangeLocation: optionalString, notes: optionalString, environment: optionalString, temperatureF: optionalNumber, windSpeedMph: optionalNumber, windDirection: optionalString, humidity: optionalNumber, lightCondition: optionalString, weatherNotes: optionalString, targetDistanceYd: optionalNumber, groupSizeIn: optionalNumber, groupSizeMoa: optionalNumber, numberOfGroups: optionalInt, groupNotes: optionalString }).strict(),
+  sessionUpdate: z.object({ firearmId: z.string().min(1).optional(), buildId: z.string().nullable().optional(), date: optionalString, roundsFired: optionalInt, rangeName: optionalString, rangeLocation: optionalString, notes: optionalString, environment: optionalString, temperatureF: optionalNumber, windSpeedMph: optionalNumber, windDirection: optionalString, humidity: optionalNumber, lightCondition: optionalString, weatherNotes: optionalString, targetDistanceYd: optionalNumber, groupSizeIn: optionalNumber, groupSizeMoa: optionalNumber, numberOfGroups: optionalInt, groupNotes: optionalString }).strict(),
+  drillCreate: z.object({ templateId: z.string().nullable().optional(), drillName: z.string().min(1), timeSeconds: optionalNumber, hits: optionalInt, totalShots: optionalInt, accuracy: optionalNumber, score: optionalNumber, notes: optionalString, sortOrder: optionalInt }).strict(),
+  drillUpdate: z.object({ templateId: z.string().nullable().optional(), drillName: z.string().min(1).optional(), timeSeconds: optionalNumber, hits: optionalInt, totalShots: optionalInt, accuracy: optionalNumber, score: optionalNumber, notes: optionalString, sortOrder: optionalInt }).strict(),
+};
+
+export const dopeSchemas = {
+  card: z.object({ firearmId: z.string().min(1), name: z.string().min(1), notes: optionalString, zeroRangeYd: z.coerce.number().positive(), profile: z.record(z.string(), z.unknown()), confirmedAt: optionalString }).strict(),
+  cardUpdate: z.object({ firearmId: z.string().min(1).optional(), name: z.string().min(1).optional(), notes: optionalString, zeroRangeYd: z.coerce.number().positive().optional(), profile: z.record(z.string(), z.unknown()).optional(), confirmedAt: optionalString }).strict(),
+};
+
+export const settingsSchemas = {
+  update: z.object({ appPassword: z.string().max(1024).optional(), encryptionEnabled: z.coerce.boolean().optional(), backupEnabled: z.coerce.boolean().optional(), backupPassphrase: z.string().optional() }).strict(),
+};


### PR DESCRIPTION
### Motivation
- Centralize and standardize request validation (size limits, strict parsing, coercion, reject unknown fields) for mutating API routes.
- Replace fragile in-memory rate limiting for sensitive endpoints with a durable, shared limiter backed by the database.
- Apply consistent protections to high-risk endpoints (auth, encryption, uploads, backup, image search) to reduce abuse and parsing errors.

### Description
- Added a shared JSON request parser and error helper in `src/lib/validation/request.ts` offering `parseJsonBody` with `content-length` + actual byte checks and `validationErrorResponse` for normalized validation failures.
- Introduced strict route-family Zod schemas at `src/lib/validation/schemas/api.ts` that use coercion and `.strict()` to normalize types and reject unknown fields across API families.
- Implemented a durable rate limiter helper `enforceRateLimit` in `src/lib/rate-limit.ts` and added an `ApiRateLimit` model plus migration SQL at `prisma/migrations/20260313120000_add_api_rate_limit/migration.sql` / `prisma/schema.prisma` to persist buckets.
- Applied validation and durable rate limiting to sensitive endpoints by updating handlers to use `parseJsonBody` and `enforceRateLimit` (notably `src/app/api/auth/login/route.ts`, `src/app/api/encryption/route.ts`, `src/app/api/backup/export/route.ts`, `src/app/api/backup/auto/route.ts`, `src/app/api/images/search/route.ts`, `src/app/api/images/upload/route.ts`, and `src/app/api/documents/upload/route.ts`) and added content-length guards for multipart upload routes.

### Testing
- Ran the linter with `npm run lint` and it completed successfully.
- Ran the test suite with `npm test` and all tests passed (`vitest` reports all existing tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433ffe8ec8326978cfdd1b4e31ec9)