### PR TITLE
Disable full encryption key retrieval; return masked fingerprint on create/set

### DIFF
--- a/src/app/api/encryption/route.ts
+++ b/src/app/api/encryption/route.ts
@@ -5,24 +5,19 @@ import crypto from "crypto";
 
 const HEX_KEY_RE = /^[0-9a-fA-F]{64}$/;
 
-// GET /api/encryption — export the DB-stored key (not shown if set via env var)
+function getMaskedKeyFingerprint(key: string) {
+  return {
+    masked: `${key.slice(0, 4)}…${key.slice(-4)}`,
+    digest: crypto.createHash("sha256").update(key, "utf8").digest("hex"),
+  };
+}
+
+// GET /api/encryption — intentionally disabled to avoid exposing key material after creation
 export async function GET() {
-  try {
-    // Never expose a key that was set via env var — it's managed outside the app
-    if (process.env.VAULT_ENCRYPTION_KEY) {
-      return NextResponse.json({ error: "Key is managed via environment variable" }, { status: 403 });
-    }
-
-    const settings = await prisma.appSettings.findUnique({ where: { id: "singleton" } });
-    if (!settings?.encryptionKey) {
-      return NextResponse.json({ error: "No encryption key configured" }, { status: 404 });
-    }
-
-    return NextResponse.json({ key: settings.encryptionKey });
-  } catch (error) {
-    console.error("GET /api/encryption error:", error);
-    return NextResponse.json({ error: "Failed to retrieve key" }, { status: 500 });
-  }
+  return NextResponse.json(
+    { error: "Retrieving full encryption keys is disabled for security." },
+    { status: 405 }
+  );
 }
 
 // POST /api/encryption — generate a new random key and save it
@@ -53,7 +48,7 @@ export async function POST() {
 
     clearKeyCache();
 
-    return NextResponse.json({ key }, { status: 201 });
+    return NextResponse.json({ key, fingerprint: getMaskedKeyFingerprint(key) }, { status: 201 });
   } catch (error) {
     console.error("POST /api/encryption error:", error);
     return NextResponse.json({ error: "Failed to generate key" }, { status: 500 });
@@ -88,7 +83,7 @@ export async function PUT(request: NextRequest) {
 
     clearKeyCache();
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, fingerprint: getMaskedKeyFingerprint(key) });
   } catch (error) {
     console.error("PUT /api/encryption error:", error);
     return NextResponse.json({ error: "Failed to save key" }, { status: 500 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -103,7 +103,6 @@ export default function SettingsPage() {
   const [ownKeyError, setOwnKeyError] = useState<string | null>(null);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
   const [disableInput, setDisableInput] = useState("");
-  const [exportedKey, setExportedKey] = useState<string | null>(null);
   const [keyCopied, setKeyCopied] = useState(false);
 
   useEffect(() => {
@@ -241,21 +240,6 @@ export default function SettingsPage() {
     }
   }
 
-  async function handleExportKey() {
-    setEncError(null);
-    try {
-      const res = await fetch("/api/encryption");
-      const json = await res.json();
-      if (!res.ok) {
-        setEncError(json.error ?? "Could not retrieve key.");
-        return;
-      }
-      setExportedKey(json.key);
-    } catch {
-      setEncError("Network error. Please try again.");
-    }
-  }
-
   async function handleDisableEncryption() {
     if (disableInput !== "DISABLE") return;
     setEncBusy(true);
@@ -269,7 +253,6 @@ export default function SettingsPage() {
       setSettings((s) => s ? { ...s, encryptionEnabled: false } : s);
       setShowDisableConfirm(false);
       setDisableInput("");
-      setExportedKey(null);
       setGeneratedKey(null);
     } catch {
       setEncError("Network error. Please try again.");
@@ -809,37 +792,11 @@ export default function SettingsPage() {
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    {/* Export key panel */}
-                    {exportedKey ? (
-                      <div className="space-y-3 bg-vault-bg border border-vault-border rounded-md p-4">
-                        <p className="text-xs font-semibold text-vault-text">Your Encryption Key</p>
-                        <div className="flex items-center gap-2 bg-vault-surface border border-vault-border rounded-md px-3 py-2">
-                          <code className="text-xs font-mono text-vault-text flex-1 break-all select-all">{exportedKey}</code>
-                        </div>
-                        <div className="flex gap-2 flex-wrap">
-                          <button type="button" onClick={() => copyKey(exportedKey)}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-vault-surface border border-vault-border text-vault-text-muted hover:text-vault-text rounded-md text-xs transition-colors">
-                            {keyCopied ? <CheckCircle2 className="w-3.5 h-3.5 text-[#00C853]" /> : <Copy className="w-3.5 h-3.5" />}
-                            {keyCopied ? "Copied!" : "Copy Key"}
-                          </button>
-                          <button type="button" onClick={() => downloadKey(exportedKey)}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-vault-surface border border-vault-border text-vault-text-muted hover:text-vault-text rounded-md text-xs transition-colors">
-                            <Download className="w-3.5 h-3.5" />
-                            Download Key File
-                          </button>
-                          <button type="button" onClick={() => setExportedKey(null)}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-vault-surface border border-vault-border text-vault-text-faint hover:text-vault-text rounded-md text-xs transition-colors">
-                            Hide
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button type="button" onClick={handleExportKey}
-                        className="flex items-center gap-1.5 text-xs text-vault-text-muted hover:text-[#00C2FF] transition-colors">
-                        <Download className="w-3.5 h-3.5" />
-                        Back Up Your Key
-                      </button>
-                    )}
+                    <div className="bg-vault-bg border border-vault-border rounded-md px-4 py-3">
+                      <p className="text-xs text-vault-text-muted leading-relaxed">
+                        For security, full encryption key retrieval is disabled after setup. Keep your key backup from initial creation or your own secure records.
+                      </p>
+                    </div>
 
                     {/* Disable encryption */}
                     {showDisableConfirm ? (


### PR DESCRIPTION
### Motivation
- Prevent accidental or malicious exposure of full encryption key material by removing the ability to retrieve stored keys after initial creation.
- Keep UX confirmation flows working by providing a non-secret fingerprint so users can verify which key is in use without exposing the key itself.

### Description
- Disabled the `GET /api/encryption` handler so it returns a 405 and no longer exposes stored key material. 
- Added `getMaskedKeyFingerprint()` which returns a masked preview (`first4…last4`) and a SHA-256 digest, and included this `fingerprint` in `POST` and `PUT` responses. 
- Kept `POST`, `PUT`, and `DELETE` operations intact; `POST` still returns the full key once (for immediate backup) plus the fingerprint, while `PUT` returns success with the fingerprint. 
- Updated the Settings UI to remove the client-side export/retrieve flow and replaced it with a guidance message that full key retrieval is intentionally disabled after setup.

### Testing
- Ran `npm run lint -- src/app/api/encryption/route.ts src/app/settings/page.tsx` and the lint step completed successfully. 
- Verified there are no remaining UI consumers calling `fetch("/api/encryption")` for retrieval using a grep-based check which reported no bare GET consumers. 
- Launched the dev server and captured a UI screenshot to validate the settings UI change, but runtime DB-dependent API calls failed in this environment due to a missing `DATABASE_URL` (app still started and screenshot was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433fc7d448326887b32b1d8419f29)