### PR TITLE
Use shared session cookie options in auth login route

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -7,6 +7,7 @@ import { signToken } from "@/lib/session";
 import { parseJsonBody, validationErrorResponse } from "@/lib/validation/request";
 import { authSchemas } from "@/lib/validation/schemas/api";
 import { enforceRateLimit } from "@/lib/rate-limit";
+import { getSessionCookieOptions } from "@/lib/session-config";
 
 const MAX_ATTEMPTS = 10;
 const WINDOW_MS = 60 * 1000;
@@ -44,12 +45,7 @@ export async function POST(request: NextRequest) {
       const secret = process.env.SESSION_SECRET;
       const cookieValue = secret ? signToken(token, secret) : token;
       const cookieStore = await cookies();
-      cookieStore.set("vault_session", cookieValue, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-      });
+      cookieStore.set("vault_session", cookieValue, getSessionCookieOptions());
       return NextResponse.json({ success: true });
     }
 
@@ -62,12 +58,7 @@ export async function POST(request: NextRequest) {
     const secret = process.env.SESSION_SECRET;
     const cookieValue = secret ? signToken(token, secret) : token;
     const cookieStore = await cookies();
-    cookieStore.set("vault_session", cookieValue, {
-      httpOnly: true,
-      sameSite: "lax",
-      path: "/",
-      maxAge: 60 * 60 * 24 * 30,
-    });
+    cookieStore.set("vault_session", cookieValue, getSessionCookieOptions());
 
     return NextResponse.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
### Motivation

- Consolidate cookie configuration so all auth routes use the same canonical session policy instead of duplicating inline options.
- Ensure production enforces `secure: true` and unify `sameSite` and `maxAge` across login and logout.

### Description

- Import `getSessionCookieOptions()` from `src/lib/session-config.ts` into `src/app/api/auth/login/route.ts` and use it for all `vault_session` writes instead of inline cookie attributes.
- Removed duplicated inline cookie settings in both login success branches so login and logout share the canonical options (`sameSite: "strict"`, `maxAge: 7 days`, `secure` enabled in production).
- Left `src/lib/session-config.ts` and `src/app/api/auth/logout/route.ts` unchanged except for keeping the shared options usage.

### Testing

- Ran a repository search for `cookieStore.set("vault_session"` and verified only login and logout write the session cookie and login no longer hardcodes divergent attributes (success).
- Committed the changes and inspected the diff with `git show --stat` to confirm the intended file modifications (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b462cabac483269854758bd826d8fd)