### PR TITLE
Validate date parsing for range session updates

### DIFF
--- a/src/app/api/range-sessions/[id]/route.test.ts
+++ b/src/app/api/range-sessions/[id]/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    rangeSession: {
+      update: vi.fn(),
+    },
+    sessionFirearm: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    sessionAmmoLink: {
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+    },
+  };
+
+  const prisma = {
+    $transaction: vi.fn(),
+    rangeSession: {
+      findUnique: vi.fn(),
+    },
+  };
+
+  return { tx, prisma, revalidateDashboardCaches: vi.fn() };
+});
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock("@/lib/server/dashboard", () => ({
+  revalidateDashboardCaches: mocks.revalidateDashboardCaches,
+}));
+
+import { PUT } from "./route";
+
+describe("PUT /api/range-sessions/[id] date parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.tx.rangeSession.update.mockResolvedValue({ id: "session-1" });
+    mocks.tx.sessionFirearm.deleteMany.mockResolvedValue({ count: 0 });
+    mocks.tx.sessionFirearm.createMany.mockResolvedValue({ count: 0 });
+    mocks.tx.sessionAmmoLink.deleteMany.mockResolvedValue({ count: 0 });
+    mocks.tx.sessionAmmoLink.create.mockResolvedValue({});
+
+    mocks.prisma.$transaction.mockImplementation(async (cb: (tx: typeof mocks.tx) => unknown) => cb(mocks.tx));
+    mocks.prisma.rangeSession.findUnique.mockResolvedValue({ id: "session-1", date: "2026-01-01T00:00:00.000Z" });
+  });
+
+  it("accepts a valid date string and stores a Date", async () => {
+    const request = new NextRequest("http://localhost/api/range-sessions/session-1", {
+      method: "PUT",
+      body: JSON.stringify({ date: "2026-01-01" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "session-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(mocks.tx.rangeSession.update).toHaveBeenCalledTimes(1);
+    const updateArg = mocks.tx.rangeSession.update.mock.calls[0][0];
+    expect(updateArg.data.date).toBeInstanceOf(Date);
+    expect(updateArg.data.date.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("does not mutate date when date field is omitted", async () => {
+    const request = new NextRequest("http://localhost/api/range-sessions/session-1", {
+      method: "PUT",
+      body: JSON.stringify({ notes: "updated" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "session-1" }) });
+
+    expect(response.status).toBe(200);
+    const updateArg = mocks.tx.rangeSession.update.mock.calls[0][0];
+    expect(updateArg.data.date).toBeUndefined();
+  });
+
+  it("returns 400 for an invalid date string", async () => {
+    const request = new NextRequest("http://localhost/api/range-sessions/session-1", {
+      method: "PUT",
+      body: JSON.stringify({ date: "not-a-date" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "session-1" }) });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid date value" });
+    expect(mocks.prisma.$transaction).not.toHaveBeenCalled();
+    expect(mocks.tx.rangeSession.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/range-sessions/[id]/route.ts
+++ b/src/app/api/range-sessions/[id]/route.ts
@@ -94,6 +94,13 @@ export async function PUT(
       const n = parseInt(String(v), 10);
       return Number.isFinite(n) ? n : undefined;
     };
+    const parseDate_ = (v: unknown): { value: Date | null | undefined; invalid: boolean } => {
+      if (v === undefined) return { value: undefined, invalid: false };
+      if (v === null || v === "") return { value: null, invalid: false };
+      const parsed = new Date(String(v));
+      if (Number.isNaN(parsed.getTime())) return { value: undefined, invalid: true };
+      return { value: parsed, invalid: false };
+    };
     const parseOptionalString = (v: unknown, maxLength?: number) => {
       if (v === undefined) return undefined;
       if (v === null || v === "") return null;
@@ -103,6 +110,12 @@ export async function PUT(
     };
 
     let parsedFirearms: { firearmId: string; buildId: string | null; roundsFired: number }[] | null = null;
+    const parsedDate = parseDate_(date);
+
+    if (parsedDate.invalid) {
+      return NextResponse.json({ error: "Invalid date value" }, { status: 400 });
+    }
+
     if (firearms !== undefined) {
       if (!Array.isArray(firearms) || firearms.length === 0) {
         return NextResponse.json({ error: "At least one firearm entry is required" }, { status: 400 });
@@ -132,7 +145,7 @@ export async function PUT(
           rangeName: parseOptionalString(rangeName, 200),
           rangeLocation: parseOptionalString(rangeLocation, 200),
           notes: parseOptionalString(notes, 5000),
-          date: date ? new Date(date) : undefined,
+          date: parsedDate.value,
           environment: parseOptionalString(environment),
           temperatureF: parseFloat_(temperatureF),
           windSpeedMph: parseFloat_(windSpeedMph),


### PR DESCRIPTION
### Motivation
- Make date handling explicit and safe in the `PUT /api/range-sessions/[id]` route so unparseable input is rejected, explicit clears are preserved, and omitted fields do not mutate stored values.

### Description
- Added a `parseDate_` helper next to `parseFloat_`/`parseInt_` that returns `undefined` for omitted fields, `null` for explicit clears (`null`/`""`), a `Date` for parseable values, and an `invalid` flag for unparsable input.
- Added an early validation guard that returns `NextResponse.json({ error: "Invalid date value" }, { status: 400 })` when `parseDate_` flags the input invalid.
- Replaced the previous `date: date ? new Date(date) : undefined` with `date: parsedDate.value` to preserve explicit semantics.
- Added focused route tests in `src/app/api/range-sessions/[id]/route.test.ts` for valid date input, omitted date behavior, and invalid date rejection.

### Testing
- Ran `npm test -- src/app/api/range-sessions/[id]/route.test.ts` using `vitest` and the three new tests passed (3 tests, 3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b462cc71fc83269da56b0f05698fd1)