### PR TITLE
Require HTTPS for trusted external image URLs

### DIFF
--- a/src/lib/__tests__/image-host-allowlist.test.ts
+++ b/src/lib/__tests__/image-host-allowlist.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { isTrustedExternalImageUrl } from "../image-host-allowlist";
+
+describe("isTrustedExternalImageUrl", () => {
+  it("allows HTTPS URLs from trusted hosts", () => {
+    expect(isTrustedExternalImageUrl("https://images.unsplash.com/photo-123")).toBe(true);
+  });
+
+  it("rejects HTTP URLs even when host is trusted", () => {
+    expect(isTrustedExternalImageUrl("http://images.unsplash.com/photo-123")).toBe(false);
+  });
+
+  it("rejects non-allowlisted hosts", () => {
+    expect(isTrustedExternalImageUrl("https://example.com/photo-123")).toBe(false);
+  });
+});

--- a/src/lib/__tests__/image-url-validation.test.ts
+++ b/src/lib/__tests__/image-url-validation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { IMAGE_URL_ALLOWLIST_ERROR, validateOptionalImageUrl } from "../image-url-validation";
+
+describe("validateOptionalImageUrl", () => {
+  it("returns allowlist error for non-HTTPS trusted host URL", () => {
+    expect(validateOptionalImageUrl("http://images.unsplash.com/photo-123")).toEqual({
+      valid: false,
+      error: IMAGE_URL_ALLOWLIST_ERROR,
+    });
+  });
+});

--- a/src/lib/image-host-allowlist.ts
+++ b/src/lib/image-host-allowlist.ts
@@ -27,7 +27,7 @@ function hostnameMatchesAllowlist(hostname: string, allowlistEntry: string): boo
 export function isTrustedExternalImageUrl(url: string): boolean {
   try {
     const parsedUrl = new URL(url);
-    if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    if (parsedUrl.protocol !== "https:") {
       return false;
     }
 


### PR DESCRIPTION
### Motivation

- Tighten image URL validation to require secure transport by accepting only `https:` for trusted external images to reduce mixed-content and man-in-the-middle risk.
- Preserve existing hostname allowlist matching so previously trusted hosts remain the same except for protocol enforcement.
- Ensure user-facing validation behavior and error messaging remain unchanged when a URL is disallowed.

### Description

- Update `isTrustedExternalImageUrl` to reject any URL whose `protocol` is not `https:` (previously allowed `http:` as well).  
- Keep the existing hostname allowlist and the `hostnameMatchesAllowlist` logic unchanged.  
- Add unit tests in `src/lib/__tests__/image-host-allowlist.test.ts` covering an allowed HTTPS trusted host, a rejected HTTP trusted host, and a rejected non-allowlisted host.  
- Add a validation test in `src/lib/__tests__/image-url-validation.test.ts` asserting `validateOptionalImageUrl` returns the existing `IMAGE_URL_ALLOWLIST_ERROR` for a disallowed (HTTP) URL.

### Testing

- Ran `npm test -- src/lib/__tests__/image-host-allowlist.test.ts src/lib/__tests__/image-url-validation.test.ts` and all test files passed (2 test files, 4 tests passed).  
- No changes were made to user-facing error strings; the `IMAGE_URL_ALLOWLIST_ERROR` message remains the same and is asserted in the new validation test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b462cd26c88326a183c526656b7648)