### PR TITLE
Add optional executable /api/system-update with session auth and settings UI support

### DIFF
--- a/src/app/api/system-update/route.ts
+++ b/src/app/api/system-update/route.ts
@@ -1,5 +1,14 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
 import { NextRequest, NextResponse } from "next/server";
 import { verifyTokenNode } from "@/lib/session";
+
+const execAsync = promisify(exec);
+
+export const runtime = "nodejs";
+
+const UPDATE_DEFAULT_COMMAND = "git pull --ff-only";
+const UPDATE_TIMEOUT_MS = Number(process.env.SYSTEM_UPDATE_TIMEOUT_MS ?? "120000");
 
 type SystemUpdateMetadata = {
   currentVersion: string | null;
@@ -13,21 +22,19 @@ function isStatusRouteEnabled() {
   return process.env.SYSTEM_UPDATE_STATUS_ENABLED === "true";
 }
 
+function isExecutionEnabled() {
+  return process.env.SYSTEM_UPDATE_EXEC_ENABLED === "true";
+}
+
 function isProductionAllowed() {
   return process.env.NODE_ENV !== "production" || process.env.SYSTEM_UPDATE_ALLOW_PRODUCTION === "true";
 }
 
-function requireElevatedAdmin(request: NextRequest) {
-  const adminToken = process.env.SYSTEM_UPDATE_ADMIN_TOKEN;
+function hasValidSession(request: NextRequest) {
   const sessionSecret = process.env.SESSION_SECRET;
   const sessionCookie = request.cookies.get("vault_session")?.value;
 
-  if (!adminToken || !sessionSecret || !sessionCookie) {
-    return false;
-  }
-
-  const headerToken = request.headers.get("x-system-update-admin-token");
-  if (!headerToken || headerToken !== adminToken) {
+  if (!sessionSecret || !sessionCookie) {
     return false;
   }
 
@@ -47,40 +54,103 @@ function getMetadata(): SystemUpdateMetadata {
   };
 }
 
-function endpointDisabledResponse() {
-  return NextResponse.json(
-    {
-      error: "System update endpoint is disabled.",
-      message:
-        "Application self-update has been deprecated. Move updates to host-level operations (systemd/cron/CI/CD).",
-    },
-    { status: 404 }
-  );
+async function runShellCommand(command: string) {
+  const { stdout, stderr } = await execAsync(command, {
+    cwd: process.cwd(),
+    env: process.env,
+    shell: "/bin/bash",
+    timeout: UPDATE_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024 * 10,
+  });
+
+  return [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
 }
 
 export async function GET(request: NextRequest) {
   if (!isStatusRouteEnabled() || !isProductionAllowed()) {
-    return endpointDisabledResponse();
+    return NextResponse.json(
+      {
+        error: "System update endpoint is disabled.",
+        message: "Enable SYSTEM_UPDATE_STATUS_ENABLED=true to allow update checks.",
+      },
+      { status: 404 }
+    );
   }
 
-  if (!requireElevatedAdmin(request)) {
+  if (!hasValidSession(request)) {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
   return NextResponse.json({
     metadata: getMetadata(),
-    writable: false,
-    message: "Read-only system update metadata endpoint.",
+    writable: isExecutionEnabled(),
+    message: isExecutionEnabled()
+      ? "System update endpoint is enabled."
+      : "Update checks are enabled, but command execution is disabled.",
   });
 }
 
-export async function POST() {
-  return NextResponse.json(
-    {
-      error: "Deprecated endpoint.",
-      message:
-        "POST /api/system-update has been removed. Execute updates via host-level operations (systemd/cron/CI/CD).",
-    },
-    { status: 410 }
-  );
+export async function POST(request: NextRequest) {
+  if (!isStatusRouteEnabled() || !isProductionAllowed()) {
+    return NextResponse.json(
+      {
+        error: "System update endpoint is disabled.",
+        message: "Enable SYSTEM_UPDATE_STATUS_ENABLED=true to permit application update operations.",
+      },
+      { status: 404 }
+    );
+  }
+
+  if (!isExecutionEnabled()) {
+    return NextResponse.json(
+      {
+        error: "System update command execution is disabled.",
+        message: "Set SYSTEM_UPDATE_EXEC_ENABLED=true to allow update command execution.",
+      },
+      { status: 403 }
+    );
+  }
+
+  if (!hasValidSession(request)) {
+    return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+  }
+
+  const requestedCommand = process.env.SYSTEM_UPDATE_COMMAND?.trim() || UPDATE_DEFAULT_COMMAND;
+  const postCommand = process.env.SYSTEM_UPDATE_POST_COMMAND?.trim();
+
+  try {
+    const before = await runShellCommand("git rev-parse --short HEAD");
+    const updateOutput = await runShellCommand(requestedCommand);
+    const after = await runShellCommand("git rev-parse --short HEAD");
+
+    const commandLogs = [
+      `Command: ${requestedCommand}`,
+      `Timeout(ms): ${UPDATE_TIMEOUT_MS}`,
+      `Before: ${before}`,
+      `After: ${after}`,
+      "",
+      updateOutput || "No output from update command.",
+    ];
+
+    if (postCommand) {
+      const postOutput = await runShellCommand(postCommand);
+      commandLogs.push("", `Post-command: ${postCommand}`, "", postOutput || "No output from post-command.");
+    }
+
+    return NextResponse.json({
+      ok: true,
+      changed: before !== after,
+      output: commandLogs.join("\n"),
+      metadata: getMetadata(),
+      message: before === after ? "Update command completed. No version change detected." : "Update completed successfully.",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "Update command failed.",
+        details: error instanceof Error ? error.message : "Unknown update command failure.",
+      },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -464,36 +464,51 @@ export default function SettingsPage() {
     setUpdateOutput(null);
 
     try {
-      const checkRes = await fetch("/api/system-update");
-      const checkJson = await checkRes.json();
+      const statusRes = await fetch("/api/system-update");
+      const statusJson = await statusRes.json();
 
-      if (!checkRes.ok) {
-        // Treat "endpoint disabled" (404) as informational rather than an error
-        if (checkRes.status === 404) {
-          setUpdateOutput(checkJson.message ?? "System updates must be performed at the host level (systemd, cron, or deployment pipeline).");
-          return;
-        }
-        const details = typeof checkJson.details === "string" ? `\n\n${checkJson.details}` : "";
-        setUpdateError(`${checkJson.error ?? "Failed to check for updates."}${details}`);
+      if (!statusRes.ok) {
+        const details = typeof statusJson.details === "string" ? `\n\n${statusJson.details}` : "";
+        setUpdateError(`${statusJson.error ?? "Failed to check update status."}${details}`);
         return;
       }
 
-      const metadata = checkJson.metadata ?? checkJson;
+      if (!statusJson.writable) {
+        setUpdateError(
+          statusJson.message ??
+            "Update command execution is disabled. Set SYSTEM_UPDATE_EXEC_ENABLED=true to enable this button."
+        );
+        return;
+      }
+
+      const updateRes = await fetch("/api/system-update", { method: "POST" });
+      const updateJson = await updateRes.json();
+
+      if (!updateRes.ok) {
+        const details = typeof updateJson.details === "string" ? `\n\n${updateJson.details}` : "";
+        setUpdateError(`${updateJson.error ?? "Failed to update application."}${details}`);
+        return;
+      }
+
+      const metadata = updateJson.metadata ?? {};
       const currentVersion = typeof metadata.currentVersion === "string" ? metadata.currentVersion : "unknown";
       const latestVersion = typeof metadata.latestVersion === "string" ? metadata.latestVersion : null;
       const checkedAt = typeof metadata.checkedAt === "string" ? metadata.checkedAt : null;
       const checkedAtLine = checkedAt ? `Checked: ${new Date(checkedAt).toLocaleString()}` : null;
 
-      if (metadata.updateAvailable && latestVersion) {
-        setUpdateOutput(
-          [`Current: ${currentVersion}`, `Latest: ${latestVersion}`, checkedAtLine, "\nUpdate available. Run the host update workflow to apply it."]
-            .filter(Boolean)
-            .join("\n")
-        );
-        return;
-      }
+      const versionLines = [
+        `Current: ${currentVersion}`,
+        latestVersion ? `Latest: ${latestVersion}` : null,
+        checkedAtLine,
+        updateJson.changed
+          ? "\nUpdate applied. Restart BlackVault if your process manager does not auto-reload."
+          : "\nUpdate command completed. Already on latest commit.",
+      ]
+        .filter(Boolean)
+        .join("\n");
 
-      setUpdateOutput([`Current: ${currentVersion}`, checkedAtLine, "\nSystem is already up to date."].filter(Boolean).join("\n"));
+      const commandOutput = typeof updateJson.output === "string" ? updateJson.output : "No command output available.";
+      setUpdateOutput(`${versionLines}\n\n${commandOutput}`);
     } catch {
       setUpdateError("Network error. Please try again.");
     } finally {
@@ -1031,7 +1046,7 @@ export default function SettingsPage() {
             </legend>
 
             <p className="text-xs text-vault-text-muted leading-relaxed">
-              Check whether a new version is available. Applying updates now happens through your host deployment workflow.
+              Run the configured update command to pull and apply the newest version on this host. This action is disabled unless SYSTEM_UPDATE_EXEC_ENABLED=true.
             </p>
 
             {updateError && (
@@ -1045,7 +1060,7 @@ export default function SettingsPage() {
               <div className="rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2 space-y-2">
                 <div className="flex items-center gap-2">
                   <CheckCircle2 className="h-3.5 w-3.5 text-[#00C853]" />
-                  <p className="text-xs text-[#00C853]">Update check completed.</p>
+                  <p className="text-xs text-[#00C853]">Update command completed.</p>
                 </div>
                 <pre className="text-[11px] text-vault-text-faint whitespace-pre-wrap break-words font-mono">{updateOutput}</pre>
               </div>
@@ -1058,11 +1073,11 @@ export default function SettingsPage() {
               className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 disabled:cursor-not-allowed text-xs transition-colors"
             >
               {updateBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
-              {updateBusy ? "Checking updates..." : "Check for Updates"}
+              {updateBusy ? "Applying update..." : "Update Now"}
             </button>
 
             <p className="text-[11px] text-vault-text-faint">
-              This reads update metadata only. To install updates, use your host-level process (systemd, cron, deployment pipeline, or manual pull/restart).
+              By default this executes <code className="font-mono">git pull --ff-only</code>. Override <code className="font-mono">SYSTEM_UPDATE_COMMAND</code>, optional <code className="font-mono">SYSTEM_UPDATE_POST_COMMAND</code>, and <code className="font-mono">SYSTEM_UPDATE_TIMEOUT_MS</code> for custom deployment behavior.
             </p>
           </fieldset>
 


### PR DESCRIPTION
### Motivation
- Provide a controlled way for the application to run host-level update commands from the settings UI while keeping execution disabled by default for safety.
- Replace the deprecated admin-token header check with session cookie verification for consistency with existing auth flows.
- Surface richer update execution metadata and command output to assist operators when in environments where in-place updates are acceptable.

### Description
- Add `runtime = "nodejs"`, promisified `execAsync`, and `runShellCommand` to execute shell commands with a configurable timeout and buffer limits.
- Introduce environment flags and defaults: `SYSTEM_UPDATE_STATUS_ENABLED`, `SYSTEM_UPDATE_EXEC_ENABLED`, `SYSTEM_UPDATE_COMMAND` (defaults to `git pull --ff-only`), `SYSTEM_UPDATE_POST_COMMAND`, and `SYSTEM_UPDATE_TIMEOUT_MS` to control status checks and execution behavior.
- Replace the old admin token check with `hasValidSession` using `verifyTokenNode` against the `vault_session` cookie and `SESSION_SECRET`, and update GET to return `writable` and contextual messages based on config.
- Implement POST to run pre/post git commit checks and the configured update/post commands while returning `changed`, `output`, and structured metadata with error handling.
- Update the settings UI to call the status endpoint, require `writable` before issuing a POST, update button labels and help text, and display command output and status messages in the UI.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` which completed successfully.
- Performed a production build with `next build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cf866bd483268c33147c506b71fa)