### PR TITLE
Reuse battery settings UI for all accessory battery workflows

### DIFF
--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import ImagePicker from "@/components/shared/ImagePicker";
 import { DocumentUploader, type UploadedDocument } from "@/components/shared/DocumentUploader";
+import BatterySettingsFields from "@/components/shared/BatterySettingsFields";
 
 
 interface RoundCountLog {
@@ -648,22 +649,14 @@ export default function AccessoryDetailPage() {
 
           {showBatterySettings && (
             <form onSubmit={handleSaveBatterySettings} className="p-4 border-b border-vault-border space-y-3">
-              <div className="flex items-center gap-2">
-                <input type="checkbox" id="hasBattery" checked={batteryForm.hasBattery} onChange={(e) => setBatteryForm((p) => ({ ...p, hasBattery: e.target.checked }))} className="w-4 h-4 accent-[#00C2FF]" />
-                <label htmlFor="hasBattery" className="text-sm text-vault-text">This accessory uses a battery</label>
-              </div>
-              {batteryForm.hasBattery && (
-                <>
-                  <div>
-                    <label className="text-[10px] uppercase text-vault-text-faint block mb-1">Battery Type</label>
-                    <input type="text" value={batteryForm.batteryType} onChange={(e) => setBatteryForm((p) => ({ ...p, batteryType: e.target.value }))} placeholder="e.g. CR2032, AA" className="w-full bg-vault-bg border border-vault-border rounded px-2 py-1.5 text-sm text-vault-text placeholder:text-vault-text-faint" />
-                  </div>
-                  <div>
-                    <label className="text-[10px] uppercase text-vault-text-faint block mb-1">Replace Every (days)</label>
-                    <input type="number" min="1" value={batteryForm.batteryIntervalDays} onChange={(e) => setBatteryForm((p) => ({ ...p, batteryIntervalDays: e.target.value }))} placeholder="e.g. 365" className="w-full bg-vault-bg border border-vault-border rounded px-2 py-1.5 text-sm text-vault-text placeholder:text-vault-text-faint" />
-                  </div>
-                </>
-              )}
+              <BatterySettingsFields
+                hasBattery={batteryForm.hasBattery}
+                batteryType={batteryForm.batteryType}
+                batteryIntervalDays={batteryForm.batteryIntervalDays}
+                onHasBatteryChange={(value) => setBatteryForm((p) => ({ ...p, hasBattery: value }))}
+                onBatteryTypeChange={(value) => setBatteryForm((p) => ({ ...p, batteryType: value }))}
+                onBatteryIntervalDaysChange={(value) => setBatteryForm((p) => ({ ...p, batteryIntervalDays: value }))}
+              />
               <button type="submit" disabled={savingBattery} className="w-full flex items-center justify-center gap-1.5 text-xs bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-3 py-1.5 rounded transition-colors disabled:opacity-50">
                 {savingBattery ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
                 Save Settings

--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -7,6 +7,7 @@ import { SLOT_TYPES, SLOT_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
 import { ArrowLeft, Plus, Loader2, AlertCircle } from "lucide-react";
 import ImagePicker from "@/components/shared/ImagePicker";
 import ReceiptUploader from "@/components/shared/ReceiptUploader";
+import BatterySettingsFields from "@/components/shared/BatterySettingsFields";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
@@ -22,6 +23,9 @@ export default function NewAccessoryPage() {
   const [imageSource, setImageSource] = useState<string | null>(null);
   const [receiptFile, setReceiptFile] = useState<File | null>(null);
   const [receiptError, setReceiptError] = useState<string | null>(null);
+  const [hasBattery, setHasBattery] = useState(false);
+  const [batteryType, setBatteryType] = useState("");
+  const [batteryIntervalDays, setBatteryIntervalDays] = useState("");
 
   const filteredCalibers = COMMON_CALIBERS.filter((c) =>
     c.toLowerCase().includes(caliberInput.toLowerCase())
@@ -36,8 +40,6 @@ export default function NewAccessoryPage() {
     const data = new FormData(form);
 
     const type = data.get("type") as string;
-    const shouldEnableBattery = ["OPTIC", "LIGHT", "LASER"].includes(type);
-
     const payload = {
       name: data.get("name") as string,
       manufacturer: data.get("manufacturer") as string,
@@ -49,7 +51,9 @@ export default function NewAccessoryPage() {
       notes: (data.get("notes") as string) || null,
       imageUrl,
       imageSource,
-      hasBattery: shouldEnableBattery,
+      hasBattery,
+      batteryType: hasBattery ? batteryType || null : null,
+      batteryIntervalDays: hasBattery ? batteryIntervalDays || null : null,
     };
 
     try {
@@ -175,6 +179,21 @@ export default function NewAccessoryPage() {
                 </div>
               </div>
             </div>
+          </fieldset>
+
+          {/* Battery */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Battery Tracking</legend>
+            <BatterySettingsFields
+              hasBattery={hasBattery}
+              batteryType={batteryType}
+              batteryIntervalDays={batteryIntervalDays}
+              onHasBatteryChange={setHasBattery}
+              onBatteryTypeChange={setBatteryType}
+              onBatteryIntervalDaysChange={setBatteryIntervalDays}
+              labelClassName={LABEL_CLASS}
+              inputClassName={INPUT_CLASS}
+            />
           </fieldset>
 
           {/* Acquisition */}

--- a/src/components/shared/BatterySettingsFields.tsx
+++ b/src/components/shared/BatterySettingsFields.tsx
@@ -1,0 +1,68 @@
+interface BatterySettingsFieldsProps {
+  hasBattery: boolean;
+  batteryType: string;
+  batteryIntervalDays: string;
+  onHasBatteryChange: (hasBattery: boolean) => void;
+  onBatteryTypeChange: (batteryType: string) => void;
+  onBatteryIntervalDaysChange: (batteryIntervalDays: string) => void;
+  labelClassName?: string;
+  inputClassName?: string;
+}
+
+const DEFAULT_LABEL_CLASS = "text-[10px] uppercase text-vault-text-faint block mb-1";
+const DEFAULT_INPUT_CLASS =
+  "w-full bg-vault-bg border border-vault-border rounded px-2 py-1.5 text-sm text-vault-text placeholder:text-vault-text-faint";
+
+export default function BatterySettingsFields({
+  hasBattery,
+  batteryType,
+  batteryIntervalDays,
+  onHasBatteryChange,
+  onBatteryTypeChange,
+  onBatteryIntervalDaysChange,
+  labelClassName = DEFAULT_LABEL_CLASS,
+  inputClassName = DEFAULT_INPUT_CLASS,
+}: BatterySettingsFieldsProps) {
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="hasBattery"
+          checked={hasBattery}
+          onChange={(e) => onHasBatteryChange(e.target.checked)}
+          className="w-4 h-4 accent-[#00C2FF]"
+        />
+        <label htmlFor="hasBattery" className="text-sm text-vault-text">
+          This accessory uses a battery
+        </label>
+      </div>
+
+      {hasBattery && (
+        <>
+          <div>
+            <label className={labelClassName}>Battery Type</label>
+            <input
+              type="text"
+              value={batteryType}
+              onChange={(e) => onBatteryTypeChange(e.target.value)}
+              placeholder="e.g. CR2032, AA"
+              className={inputClassName}
+            />
+          </div>
+          <div>
+            <label className={labelClassName}>Replace Every (days)</label>
+            <input
+              type="number"
+              min="1"
+              value={batteryIntervalDays}
+              onChange={(e) => onBatteryIntervalDaysChange(e.target.value)}
+              placeholder="e.g. 365"
+              className={inputClassName}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- extracted the battery checkbox + maintenance inputs into a shared component: `src/components/shared/BatterySettingsFields.tsx`
- updated `src/app/accessories/new/page.tsx` to reuse the shared battery settings fields for creating new accessories
- updated `src/app/accessories/[id]/page.tsx` to reuse the same shared battery settings fields in the Battery Settings form
- kept support for all accessory types by using an explicit battery toggle instead of type-based assumptions

## Validation
- ran eslint against touched files
- captured updated UI screenshot from `/accessories/new` (redirected through auth flow in this environment)

## Screenshot
![Accessory new page battery settings](browser:/tmp/codex_browser_invocations/02768157834321df/artifacts/artifacts/accessories-new-battery-reused.png)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d2cf54a083268f014a22791a0328)