### PR TITLE
Add deployment-aware system update modes

### DIFF
--- a/src/app/api/system-update/route.test.ts
+++ b/src/app/api/system-update/route.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  exec: vi.fn(),
+  existsSync: vi.fn(),
+  verifyTokenNode: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  exec: mocks.exec,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mocks.existsSync,
+}));
+
+vi.mock("@/lib/session", () => ({
+  verifyTokenNode: mocks.verifyTokenNode,
+}));
+
+import { POST } from "./route";
+
+const ORIGINAL_ENV = process.env;
+
+function createRequest() {
+  return new NextRequest("http://localhost/api/system-update", {
+    method: "POST",
+    headers: {
+      cookie: "vault_session=test-token",
+    },
+  });
+}
+
+function mockExecImplementation(handler: (command: string) => { stdout?: string; stderr?: string } | Error) {
+  mocks.exec.mockImplementation((command: string, _options: unknown, callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    const result = handler(command);
+
+    if (result instanceof Error) {
+      callback(result, { stdout: "", stderr: "" });
+      return {};
+    }
+
+    callback(null, { stdout: result.stdout ?? "", stderr: result.stderr ?? "" });
+    return {};
+  });
+}
+
+describe("POST /api/system-update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...ORIGINAL_ENV,
+      SYSTEM_UPDATE_STATUS_ENABLED: "true",
+      SYSTEM_UPDATE_EXEC_ENABLED: "true",
+      SESSION_SECRET: "secret",
+      NODE_ENV: "test",
+    };
+    mocks.verifyTokenNode.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("supports git mode success", async () => {
+    process.env.SYSTEM_UPDATE_MODE = "git";
+    delete process.env.SYSTEM_UPDATE_COMMAND;
+
+    mocks.existsSync.mockReturnValue(true);
+
+    let revParseCount = 0;
+    mockExecImplementation((command) => {
+      if (command === "git rev-parse --short HEAD") {
+        revParseCount += 1;
+        return { stdout: revParseCount === 1 ? "abc123\n" : "def456\n" };
+      }
+      if (command === "git pull --ff-only") {
+        return { stdout: "Already up to date.\n" };
+      }
+      return new Error(`Unexpected command: ${command}`);
+    });
+
+    const response = await POST(createRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.mode).toBe("git");
+    expect(json.changed).toBe(true);
+  });
+
+  it("returns clear error when git mode is requested but repo is unavailable", async () => {
+    process.env.SYSTEM_UPDATE_MODE = "git";
+
+    mocks.existsSync.mockReturnValue(false);
+    mockExecImplementation((command) => {
+      if (command === "git rev-parse --is-inside-work-tree") {
+        return new Error("fatal: not a git repository");
+      }
+      return new Error(`Unexpected command: ${command}`);
+    });
+
+    const response = await POST(createRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(json.error).toContain("Git repository unavailable");
+    expect(json.message).toContain("./update.sh");
+  });
+
+  it("supports non-git command mode success", async () => {
+    process.env.SYSTEM_UPDATE_MODE = "docker";
+    process.env.SYSTEM_UPDATE_COMMAND = "echo docker-update";
+
+    mocks.existsSync.mockReturnValue(false);
+    mockExecImplementation((command) => {
+      if (command === "git rev-parse --is-inside-work-tree") {
+        return new Error("fatal: not a git repository");
+      }
+      if (command === "echo docker-update") {
+        return { stdout: "docker-update\n" };
+      }
+      return new Error(`Unexpected command: ${command}`);
+    });
+
+    const response = await POST(createRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.mode).toBe("docker");
+    expect(json.changed).toBeNull();
+    expect(json.message).toContain("Revision probe unavailable");
+  });
+
+  it("returns unsupported mode guidance when repo and alternative command are unavailable", async () => {
+    delete process.env.SYSTEM_UPDATE_MODE;
+    delete process.env.SYSTEM_UPDATE_COMMAND;
+
+    mocks.existsSync.mockReturnValue(false);
+    mockExecImplementation((command) => {
+      if (command === "git rev-parse --is-inside-work-tree") {
+        return new Error("fatal: not a git repository");
+      }
+      return new Error(`Unexpected command: ${command}`);
+    });
+
+    const response = await POST(createRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(json.error).toContain("unsupported");
+    expect(json.recommendation).toContain("update.bat");
+  });
+});

--- a/src/app/api/system-update/route.ts
+++ b/src/app/api/system-update/route.ts
@@ -1,4 +1,6 @@
 import { exec } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { NextRequest, NextResponse } from "next/server";
 import { verifyTokenNode } from "@/lib/session";
@@ -9,6 +11,7 @@ export const runtime = "nodejs";
 
 const UPDATE_DEFAULT_COMMAND = "git pull --ff-only";
 const UPDATE_TIMEOUT_MS = Number(process.env.SYSTEM_UPDATE_TIMEOUT_MS ?? "120000");
+const UPDATE_MODE_UNSUPPORTED_STATUS = 422;
 
 type SystemUpdateMetadata = {
   currentVersion: string | null;
@@ -16,6 +19,14 @@ type SystemUpdateMetadata = {
   updateAvailable: boolean;
   source: string;
   checkedAt: string;
+};
+
+type SystemUpdateMode = "git" | "docker";
+
+type ExecutionContext = {
+  mode: SystemUpdateMode | null;
+  repoAvailable: boolean;
+  hasAlternativeCommand: boolean;
 };
 
 function isStatusRouteEnabled() {
@@ -66,6 +77,64 @@ async function runShellCommand(command: string) {
   return [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
 }
 
+async function isGitRepoAvailable() {
+  if (existsSync(path.join(process.cwd(), ".git"))) {
+    return true;
+  }
+
+  try {
+    await runShellCommand("git rev-parse --is-inside-work-tree");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function probeRevision() {
+  try {
+    return await runShellCommand("git rev-parse --short HEAD");
+  } catch {
+    return null;
+  }
+}
+
+async function resolveExecutionContext(): Promise<ExecutionContext> {
+  const configuredMode = (process.env.SYSTEM_UPDATE_MODE ?? "auto").trim().toLowerCase();
+  const commandFromEnv = process.env.SYSTEM_UPDATE_COMMAND?.trim();
+  const hasAlternativeCommand = Boolean(commandFromEnv);
+  const repoAvailable = await isGitRepoAvailable();
+
+  if (configuredMode === "git") {
+    return { mode: "git", repoAvailable, hasAlternativeCommand };
+  }
+
+  if (configuredMode === "docker") {
+    return { mode: "docker", repoAvailable, hasAlternativeCommand };
+  }
+
+  if (repoAvailable) {
+    return { mode: "git", repoAvailable, hasAlternativeCommand };
+  }
+
+  if (hasAlternativeCommand) {
+    return { mode: "docker", repoAvailable, hasAlternativeCommand };
+  }
+
+  return { mode: null, repoAvailable, hasAlternativeCommand };
+}
+
+function getUnsupportedModeResponse() {
+  return NextResponse.json(
+    {
+      error: "In-app update is unsupported for this deployment.",
+      message:
+        "No git repository is available and no SYSTEM_UPDATE_COMMAND is configured. Use ./update.sh (Linux/macOS) or update.bat (Windows) from the host instead.",
+      recommendation: "Run ./update.sh or update.bat on the host machine.",
+    },
+    { status: UPDATE_MODE_UNSUPPORTED_STATUS }
+  );
+}
+
 export async function GET(request: NextRequest) {
   if (!isStatusRouteEnabled() || !isProductionAllowed()) {
     return NextResponse.json(
@@ -81,12 +150,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
+  const execution = await resolveExecutionContext();
+
   return NextResponse.json({
     metadata: getMetadata(),
-    writable: isExecutionEnabled(),
+    writable: isExecutionEnabled() && execution.mode !== null,
+    mode: execution.mode,
     message: isExecutionEnabled()
       ? "System update endpoint is enabled."
       : "Update checks are enabled, but command execution is disabled.",
+    unsupported:
+      execution.mode === null
+        ? "In-app git updates are unavailable in this deployment. Configure SYSTEM_UPDATE_COMMAND for docker mode or run ./update.sh / update.bat on the host."
+        : null,
   });
 }
 
@@ -117,17 +193,36 @@ export async function POST(request: NextRequest) {
 
   const requestedCommand = process.env.SYSTEM_UPDATE_COMMAND?.trim() || UPDATE_DEFAULT_COMMAND;
   const postCommand = process.env.SYSTEM_UPDATE_POST_COMMAND?.trim();
+  const execution = await resolveExecutionContext();
+
+  if (execution.mode === null) {
+    return getUnsupportedModeResponse();
+  }
+
+  if (execution.mode === "git" && !execution.repoAvailable) {
+    return NextResponse.json(
+      {
+        error: "Git repository unavailable for in-app update.",
+        message:
+          "This deployment does not expose a working git checkout for in-app updates. Run ./update.sh or update.bat from the host machine, or configure docker mode with SYSTEM_UPDATE_MODE=docker and SYSTEM_UPDATE_COMMAND.",
+      },
+      { status: UPDATE_MODE_UNSUPPORTED_STATUS }
+    );
+  }
 
   try {
-    const before = await runShellCommand("git rev-parse --short HEAD");
+    const before = execution.mode === "git" ? await probeRevision() : null;
     const updateOutput = await runShellCommand(requestedCommand);
-    const after = await runShellCommand("git rev-parse --short HEAD");
+    const after = execution.mode === "git" ? await probeRevision() : null;
+
+    const changed = before && after ? before !== after : null;
 
     const commandLogs = [
+      `Mode: ${execution.mode}`,
       `Command: ${requestedCommand}`,
       `Timeout(ms): ${UPDATE_TIMEOUT_MS}`,
-      `Before: ${before}`,
-      `After: ${after}`,
+      `Before: ${before ?? "Unavailable"}`,
+      `After: ${after ?? "Unavailable"}`,
       "",
       updateOutput || "No output from update command.",
     ];
@@ -139,10 +234,16 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       ok: true,
-      changed: before !== after,
+      changed,
+      mode: execution.mode,
       output: commandLogs.join("\n"),
       metadata: getMetadata(),
-      message: before === after ? "Update command completed. No version change detected." : "Update completed successfully.",
+      message:
+        changed === null
+          ? "Update command completed. Revision probe unavailable for this deployment."
+          : changed
+            ? "Update completed successfully."
+            : "Update command completed. No version change detected.",
     });
   } catch (error) {
     return NextResponse.json(

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -585,6 +585,11 @@ export default function SettingsPage() {
         return;
       }
 
+      if (typeof statusJson.unsupported === "string") {
+        setUpdateError(statusJson.unsupported);
+        return;
+      }
+
       if (!statusJson.writable) {
         setUpdateError(
           statusJson.message ??
@@ -612,9 +617,11 @@ export default function SettingsPage() {
         `Current: ${currentVersion}`,
         latestVersion ? `Latest: ${latestVersion}` : null,
         checkedAtLine,
-        updateJson.changed
+        updateJson.changed === true
           ? "\nUpdate applied. Restart BlackVault if your process manager does not auto-reload."
-          : "\nUpdate command completed. Already on latest commit.",
+          : updateJson.changed === false
+            ? "\nUpdate command completed. Already on latest commit."
+            : "\nUpdate command completed. Revision comparison is unavailable in this deployment.",
       ]
         .filter(Boolean)
         .join("\n");
@@ -1158,7 +1165,7 @@ export default function SettingsPage() {
             </legend>
 
             <p className="text-xs text-vault-text-muted leading-relaxed">
-              Run the configured update command to pull and apply the newest version on this host. This action is disabled unless SYSTEM_UPDATE_EXEC_ENABLED=true.
+              Run the configured update command to pull and apply the newest version on this host. Source-checkout installs use git mode by default; container installs can set <code className="font-mono">SYSTEM_UPDATE_MODE=docker</code> with a host-level <code className="font-mono">SYSTEM_UPDATE_COMMAND</code>. If in-app updates are unsupported, use <code className="font-mono">./update.sh</code> or <code className="font-mono">update.bat</code> on the host.
             </p>
 
             {updateError && (


### PR DESCRIPTION
### Motivation
- Support non-source-checkout deployments (containers/host-level commands) for in-app updates while keeping existing git-based behavior for source-checkout installs.
- Avoid hard-failing when git revision probing is unavailable and provide clear guidance when in-app updates are unsupported for a given deployment.

### Description
- Implemented deployment-aware execution context in `src/app/api/system-update/route.ts` with `git` and `docker` modes, auto-resolution logic, `.git`/lightweight git probe, and explicit unsupported responses when neither a repo nor `SYSTEM_UPDATE_COMMAND` is available.
- Modified `POST` to run the configured command, annotate `mode`, and return a tri-state `changed` value (`true`/`false`/`null`) when revision probes are unavailable instead of hard-failing.
- Exposed mode/unsupported guidance in the `GET` status response and added clearer error messages recommending `./update.sh` / `update.bat` when appropriate.
- Updated settings UI in `src/app/settings/page.tsx` to surface unsupported guidance from the API, handle the tri-state `changed` messaging, and clarify `SYSTEM_UPDATE_MODE=docker`/`SYSTEM_UPDATE_COMMAND` usage.
- Added API tests at `src/app/api/system-update/route.test.ts` covering git success, git with missing repo, non-git command success, and unsupported-mode guidance.

### Testing
- Ran the API unit tests with `npm test -- src/app/api/system-update/route.test.ts` and all tests passed (`4 passed`).
- Performed an automated Playwright capture of the updated Settings page section, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d8ac21f88326b0e0a02ba16c6564)