### PR TITLE
Add workflow_dispatch trigger so releases can be built on demand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,30 @@ name: Build & Release Launcher
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: write  # Required to upload assets to the GitHub Release
 
 jobs:
+  prepare:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub release for current launcher version
+        run: |
+          VERSION=$(node -p "require('./launcher/package.json').version")
+          gh release create "v${VERSION}" \
+            --title "ProjectBlackVault Launcher v${VERSION}" \
+            --notes "Desktop launcher for ProjectBlackVault. Requires Docker Desktop." \
+            --latest || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
+    needs: prepare
+    if: always() && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The download buttons on the GitHub Pages site were 404ing because no GitHub Release existed — the workflow only ran when a release was manually created first (chicken-and-egg).

A new `prepare` job now creates the GitHub Release automatically by reading the version from launcher/package.json, then the existing build matrix runs and uploads the three platform installers (Windows, macOS, Linux) to it. The workflow can now be kicked off from the Actions tab with one click; the existing release: [created] trigger is kept for normal version bumps.

https://claude.ai/code/session_01TNCCJAvHNsS5tVvYSNsD4i