### PR TITLE
Auto-publish launcher on every push to main that touches launcher/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Build & Release Launcher
 
 on:
-  release:
-    types: [created]
+  push:
+    branches: [main]
+    paths:
+      - 'launcher/**'
   workflow_dispatch:
 
 permissions:
@@ -10,23 +12,23 @@ permissions:
 
 jobs:
   prepare:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub release for current launcher version
+      - name: Create or refresh GitHub release
         run: |
           VERSION=$(node -p "require('./launcher/package.json').version")
-          gh release create "v${VERSION}" \
-            --title "ProjectBlackVault Launcher v${VERSION}" \
+          TAG="v${VERSION}"
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$TAG" \
+            --title "ProjectBlackVault Launcher ${TAG}" \
             --notes "Desktop launcher for ProjectBlackVault. Requires Docker Desktop." \
-            --latest || true
+            --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     needs: prepare
-    if: always() && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Replace the manual release: [created] trigger with push to main (path-filtered to launcher/**) plus workflow_dispatch. A prepare job now creates/refreshes the GitHub Release automatically before the three platform build jobs run, so the download buttons stay current without any manual steps.

https://claude.ai/code/session_01TNCCJAvHNsS5tVvYSNsD4i