### PR TITLE
Fix macOS launcher download link 404

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -298,7 +298,7 @@
     </a>
 
     <a class="download-card" id="card-mac"
-       href="https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest/download/ProjectBlackVault.dmg">
+       href="https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest">
       <div class="platform-icon">🍎</div>
       <div class="platform-name">macOS</div>
       <div class="platform-detail">macOS 12+</div>
@@ -388,7 +388,7 @@
         mac: {
           label: '↓ Download for macOS',
           sub: 'macOS 12+ · .dmg',
-          href: 'https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest/download/ProjectBlackVault.dmg',
+          href: 'https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest',
           card: 'card-mac',
         },
         linux: {

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -15,7 +15,7 @@ const DOWNLOADS = {
   mac: {
     label: "Download for macOS",
     detail: "macOS 12+ · .dmg",
-    href: "https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest/download/ProjectBlackVault.dmg",
+    href: "https://github.com/theaveragedeveloper/ProjectBlackVault/releases/latest",
     icon: Apple,
     ext: ".dmg",
   },


### PR DESCRIPTION
### Motivation
- Prevent users from hitting a GitHub 404 when the macOS DMG asset name changes by sending macOS download links to the releases page instead of a hardcoded DMG filename.

### Description
- Replace the hardcoded macOS DMG download URL with the repository `releases/latest` URL in `src/app/download/page.tsx` and mirror the same change in `docs/index.html` so both in-app and static pages are consistent.

### Testing
- Ran `npm run lint -- src/app/download/page.tsx` which reported an existing unrelated `react-hooks/set-state-in-effect` lint warning; ran the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` which successfully served the app; captured the updated `/download` page with Playwright and produced a screenshot artifact; and ran `git diff --check` which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f8bc7f408326a3493317da78cb74)