### PR TITLE
Fix login page hanging when auto-login fails in dev

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,11 +19,19 @@ export default function LoginPage() {
       .then(async (data) => {
         if (!data.passwordRequired) {
           // No password set — auto-login and redirect
-          await fetch("/api/auth/login", {
+          const autoLoginRes = await fetch("/api/auth/login", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ password: "" }),
           });
+
+          if (!autoLoginRes.ok) {
+            const json = await autoLoginRes.json().catch(() => null);
+            setError(json?.error ?? "Auto-login failed. Set SESSION_SECRET in your .env and restart dev mode.");
+            setLoading(false);
+            return;
+          }
+
           router.replace("/");
         } else if (data.authenticated) {
           router.replace("/");


### PR DESCRIPTION
## Summary
- updated `src/app/login/page.tsx` to handle failed auto-login responses from `POST /api/auth/login`
- when `passwordRequired` is false but auto-login returns a non-OK response (e.g. missing `SESSION_SECRET`), the page now exits loading state and shows an actionable error message
- avoids the previous behavior where the UI could remain on an indefinite spinner

## Why
In development, missing or invalid auth configuration can cause auto-login to fail. The login page previously ignored that failure and kept showing a loading spinner, giving no recovery path.

## Validation
- `npm run typecheck` *(fails due to pre-existing unrelated TypeScript errors in other files; no new errors tied to this change)*
- attempted browser screenshot capture, but dev server did not remain running in this environment (`next dev` process became defunct), so screenshot could not be produced

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b971d3ae908326b5ad4692e231ec60)