### PR TITLE
feat: display build photos in GunBanner, vault card, and build cards

### DIFF
--- a/src/app/vault/[id]/builds/[buildId]/page.tsx
+++ b/src/app/vault/[id]/builds/[buildId]/page.tsx
@@ -693,7 +693,10 @@ function GunBanner({ build }: { build: Build }) {
   const availableSlots = SLOTS_BY_FIREARM_TYPE[firearmType] ?? [];
   const filledCount = build.slots.filter((s) => s.accessoryId).length;
   const pct = Math.round((filledCount / (availableSlots.length || 1)) * 100);
-  const hasPhoto = !!(build.firearm.imageUrl && !imgError);
+  // Build's own photo takes priority; fall back to firearm photo for the blurred background
+  const buildPhoto = build.imageUrl;
+  const bgPhoto = buildPhoto ?? build.firearm.imageUrl;
+  const hasPhoto = !!(bgPhoto && !imgError);
 
   return (
     <div className="relative h-28 shrink-0 overflow-hidden bg-vault-canvas border-b border-vault-border">
@@ -701,7 +704,7 @@ function GunBanner({ build }: { build: Build }) {
         <>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={build.firearm.imageUrl!}
+            src={bgPhoto!}
             alt=""
             className="absolute inset-0 w-full h-full object-cover"
             onError={() => setImgError(true)}
@@ -737,11 +740,22 @@ function GunBanner({ build }: { build: Build }) {
             )}
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-[10px] text-vault-text-faint font-mono">{filledCount}/{availableSlots.length} slots</span>
-            <div className="w-20 h-1 bg-vault-border rounded-full overflow-hidden">
-              <div className="h-full bg-[#00C2FF] rounded-full transition-all duration-500" style={{ width: `${pct}%` }} />
+            {buildPhoto && !imgError && (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={buildPhoto}
+                alt={build.name}
+                className="h-16 w-16 object-cover rounded border border-vault-border/40 shrink-0"
+                onError={() => setImgError(true)}
+              />
+            )}
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] text-vault-text-faint font-mono">{filledCount}/{availableSlots.length} slots</span>
+              <div className="w-20 h-1 bg-vault-border rounded-full overflow-hidden">
+                <div className="h-full bg-[#00C2FF] rounded-full transition-all duration-500" style={{ width: `${pct}%` }} />
+              </div>
+              <span className="text-[10px] font-mono" style={{ color: "rgba(0,194,255,0.6)" }}>{pct}%</span>
             </div>
-            <span className="text-[10px] font-mono" style={{ color: "rgba(0,194,255,0.6)" }}>{pct}%</span>
           </div>
         </div>
       </div>

--- a/src/app/vault/[id]/page.tsx
+++ b/src/app/vault/[id]/page.tsx
@@ -61,6 +61,7 @@ interface Build {
   name: string;
   description: string | null;
   isActive: boolean;
+  imageUrl: string | null;
   slots: BuildSlot[];
 }
 
@@ -523,6 +524,14 @@ export default function FirearmDetailPage() {
                             <p className="text-xs text-vault-text-muted truncate">{build.description}</p>
                           )}
                         </div>
+                        {build.imageUrl && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={build.imageUrl}
+                            alt={build.name}
+                            className="w-14 h-14 object-cover rounded border border-vault-border ml-3 shrink-0"
+                          />
+                        )}
                       </div>
 
                       <div className="mb-4">

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -34,6 +34,7 @@ interface ActiveBuild {
   id: string;
   name: string;
   isActive: boolean;
+  imageUrl: string | null;
   slots: { id: string; slotType: string; accessoryId: string | null; accessory: { roundCount: number } | null }[];
 }
 
@@ -96,13 +97,15 @@ function FirearmCard({ firearm, editMode, editBuilds, onDeleteBuild }: FirearmCa
   const activeBuild = firearm.activeBuild;
   const accessoryCount = activeBuild?.slots?.filter((s) => s.accessoryId).length ?? 0;
   const totalRounds = activeBuild?.slots?.reduce((sum, s) => sum + (s.accessory?.roundCount ?? 0), 0) ?? 0;
+  // Use firearm photo if available; fall back to active build's photo
+  const displayImageUrl = firearm.imageUrl ?? activeBuild?.imageUrl ?? null;
 
   return (
     <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden hover:border-[#00C2FF]/30 transition-colors group flex flex-col">
       {/* Image / Placeholder */}
       <div className="h-40 bg-vault-bg relative overflow-hidden border-b border-vault-border">
         <SafeImage
-          src={firearm.imageUrl}
+          src={displayImageUrl}
           alt={firearm.name}
           fill
           sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"


### PR DESCRIPTION
- GunBanner (build configurator): prefer build.imageUrl as blurred background; show a crisp 16×16 thumbnail on the right side of the banner when the build has its own photo; fall back to firearm photo
- Vault list FirearmCard: add imageUrl to ActiveBuild interface and use the active build's photo as a fallback when the firearm has no photo
- Firearm detail BUILDS section: add imageUrl to Build interface and render a 14×14 thumbnail in the top-right corner of each build card

No API changes needed — Prisma already returns all scalar fields (including imageUrl) on Build records in both /api/firearms and /api/firearms/[id] responses.

https://claude.ai/code/session_01BtRMaJDnER6TG67XmWaEHn