### PR TITLE
fix: resolve Docker fresh-install restart loop

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Three bugs caused the container to crash-loop on first startup:

1. Prisma engine binary mismatch: node:20-alpine ships only OpenSSL 3.x (libssl.so.3) but Prisma couldn't detect it and defaulted to generating openssl-1.1.x binaries. The schema-engine then failed to load at runtime with 'libssl.so.1.1: No such file or directory', exiting CMD non-zero and triggering restart: unless-stopped in a loop. Fix: install openssl in builder + runner apk stages so Prisma detects OpenSSL 3.x correctly; add explicit binaryTargets in schema.prisma as a belt-and-suspenders guarantee.

2. Prisma CLI missing from runner stage: npx prisma migrate deploy fell back to downloading the latest prisma from npm at container startup, risking version mismatch and failing in offline/air-gapped environments. Fix: COPY node_modules/prisma to runner; update CMD to invoke the CLI directly via node instead of npx.

3. Next.js build failed with Prisma prerender errors: pages call Prisma at static-generation time but no DATABASE_URL existed in the builder stage. Fix: set a throw-away DATABASE_URL and run prisma migrate deploy before npm run build so the build has a schema-ready SQLite to query.

Also fix healthcheck in both compose files: Alpine resolves 'localhost' to ::1 (IPv6) while Next.js binds IPv4 only, so wget always failed. Changed to 127.0.0.1 — verified healthy inside the container.

Verified: fresh docker compose build + up produces a 'running healthy' container with both migrations applied and /api/health returning 200.

## Summary of Changes
- 

## Testing Performed
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run typecheck`
- [ ] Manual validation completed (describe below)

### Manual Validation Notes
- 

## Checklist
- [ ] I ran linting and tests locally.
- [ ] I validated the user-facing behavior.
- [ ] I updated docs/README for any UX, config, or API changes.
- [ ] I did not commit secrets or environment files.
