### PR TITLE
fix: resolve Docker fresh-install restart loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 
 # Copy production deps from stage 1
 COPY --from=deps /app/node_modules ./node_modules
@@ -30,14 +30,16 @@ RUN npx prisma generate
 
 # Build Next.js in standalone mode
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+# Provide a throw-away DB so pages that call Prisma can prerender during build
+ENV DATABASE_URL="file:/tmp/prisma-build.db"
+RUN npx prisma migrate deploy && npm run build
 
 # ─── Stage 3: Production runner ───────────────────────────────────────────────
 FROM node:20-alpine AS runner
 
 WORKDIR /app
 
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -55,6 +57,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 
 # Create persistent data directories
 RUN mkdir -p /app/data /app/uploads && \
@@ -69,4 +72,4 @@ ENV HOSTNAME="0.0.0.0"
 ENV DATABASE_URL="file:/app/data/vault.db"
 
 # Run migrations then start the server
-CMD ["sh", "-c", "npx prisma migrate deploy && node server.js"]
+CMD ["sh", "-c", "node node_modules/prisma/build/index.js migrate deploy && node server.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       - blackvault-dev-db:/app/data
       - blackvault-dev-uploads:/app/uploads
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ${DATA_DIR:-./data}/db:/app/data
       - ${DATA_DIR:-./data}/uploads:/app/uploads
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Three bugs caused the container to crash-loop on first startup:

1. Prisma engine binary mismatch: node:20-alpine ships only OpenSSL 3.x (libssl.so.3) but Prisma couldn't detect it and defaulted to generating openssl-1.1.x binaries. The schema-engine then failed to load at runtime with 'libssl.so.1.1: No such file or directory', exiting CMD non-zero and triggering restart: unless-stopped in a loop. Fix: install openssl in builder + runner apk stages so Prisma detects OpenSSL 3.x correctly; add explicit binaryTargets in schema.prisma as a belt-and-suspenders guarantee.

2. Prisma CLI missing from runner stage: npx prisma migrate deploy fell back to downloading the latest prisma from npm at container startup, risking version mismatch and failing in offline/air-gapped environments. Fix: COPY node_modules/prisma to runner; update CMD to invoke the CLI directly via node instead of npx.

3. Next.js build failed with Prisma prerender errors: pages call Prisma at static-generation time but no DATABASE_URL existed in the builder stage. Fix: set a throw-away DATABASE_URL and run prisma migrate deploy before npm run build so the build has a schema-ready SQLite to query.

Also fix healthcheck in both compose files: Alpine resolves 'localhost' to ::1 (IPv6) while Next.js binds IPv4 only, so wget always failed. Changed to 127.0.0.1 — verified healthy inside the container.

Verified: fresh docker compose build + up produces a 'running healthy' container with both migrations applied and /api/health returning 200.

## Summary of Changes
- 

## Testing Performed
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run typecheck`
- [ ] Manual validation completed (describe below)

### Manual Validation Notes
- 

## Checklist
- [ ] I ran linting and tests locally.
- [ ] I validated the user-facing behavior.
- [ ] I updated docs/README for any UX, config, or API changes.
- [ ] I did not commit secrets or environment files.
