### PR TITLE
fix: support Apple Silicon / ARM64 in default Docker install path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -30,6 +33,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/theaveragedeveloper/projectblackvault:latest
             ghcr.io/theaveragedeveloper/projectblackvault:${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3.8'
 
-# Production compose — pulls pre-built image from GitHub Container Registry.
+# Production compose — builds image locally from source (works on amd64 and arm64).
 # Run `./install.sh` (or install.bat on Windows) for first-time setup.
-# Run `./update.sh` to pull the latest version.
+# Run `./update.sh` to rebuild and restart with the latest source.
 # For local development, use docker-compose.dev.yml instead.
 
 services:
   blackvault:
-    image: ghcr.io/theaveragedeveloper/projectblackvault:latest
+    build: .
     container_name: blackvault
     restart: unless-stopped
     ports:

--- a/install.bat
+++ b/install.bat
@@ -68,10 +68,10 @@ if not exist "!DATA_DIR!\uploads" mkdir "!DATA_DIR!\uploads"
 
 echo Configuration written to .blackvault.env
 
-:: ── Pull and start ────────────────────────────────────────────
+:: ── Build and start ───────────────────────────────────────────
 echo.
-echo Pulling latest BlackVault image...
-%COMPOSE% --env-file .blackvault.env pull
+echo Building BlackVault image (this may take a few minutes)...
+%COMPOSE% --env-file .blackvault.env build
 
 echo.
 echo Starting BlackVault...

--- a/install.sh
+++ b/install.sh
@@ -70,10 +70,10 @@ EOF
 
 echo "Configuration written to .blackvault.env"
 
-# ── Pull and start ────────────────────────────────────────────
+# ── Build and start ───────────────────────────────────────────
 echo ""
-echo "Pulling latest BlackVault image..."
-$COMPOSE --env-file .blackvault.env pull
+echo "Building BlackVault image (this may take a few minutes)..."
+$COMPOSE --env-file .blackvault.env build
 
 echo ""
 echo "Starting BlackVault..."

--- a/update.sh
+++ b/update.sh
@@ -12,8 +12,8 @@ if [ -f ".blackvault.env" ]; then
   echo "Using config from .blackvault.env"
 fi
 
-echo "Pulling latest BlackVault image from registry..."
-docker compose $ENV_ARGS pull
+echo "Rebuilding BlackVault image from source..."
+docker compose $ENV_ARGS build --pull
 
 echo ""
 echo "Restarting with updated image..."


### PR DESCRIPTION
The default install path (install.sh / install.bat) was pulling a pre-built GHCR image that only had a linux/amd64 manifest, causing fresh clones on Apple Silicon to fail with:
  no matching manifest for linux/arm64/v8 in the manifest list entries

Changes:
- docker-compose.yml: replace `image: ghcr.io/...` with `build: .` so the default path always builds locally (arch-agnostic)
- install.sh / install.bat: replace `pull` with `build`
- update.sh: replace `pull` with `build --pull`
- .github/workflows/docker.yml: add QEMU setup + publish linux/amd64 and linux/arm64 manifests from CI