### PR TITLE
Fix duplicate desktop sidebar rendering from MobileHeader Sidebar usage

### DIFF
--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -26,7 +26,7 @@ export function MobileHeader() {
           </p>
         </div>
       </header>
-      <Sidebar mobileOpen={open} onMobileClose={() => setOpen(false)} />
+      <Sidebar mobileOnly mobileOpen={open} onMobileClose={() => setOpen(false)} />
     </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -63,11 +63,16 @@ const NAV_ITEMS = [
 ];
 
 interface SidebarProps {
+  mobileOnly?: boolean;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
 }
 
-export function Sidebar({ mobileOpen = false, onMobileClose }: SidebarProps) {
+export function Sidebar({
+  mobileOnly = false,
+  mobileOpen = false,
+  onMobileClose,
+}: SidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
 
@@ -166,14 +171,16 @@ export function Sidebar({ mobileOpen = false, onMobileClose }: SidebarProps) {
   return (
     <>
       {/* Desktop sidebar */}
-      <aside
-        className={cn(
-          "hidden md:flex flex-col h-screen border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0",
-          collapsed ? "w-16" : "w-56"
-        )}
-      >
-        {navContent}
-      </aside>
+      {!mobileOnly && (
+        <aside
+          className={cn(
+            "hidden md:flex flex-col h-screen border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0",
+            collapsed ? "w-16" : "w-56"
+          )}
+        >
+          {navContent}
+        </aside>
+      )}
 
       {/* Mobile overlay */}
       {mobileOpen && (


### PR DESCRIPTION
## Summary
- added optional `mobileOnly?: boolean` prop to `Sidebar`
- gated desktop `<aside>` rendering behind `!mobileOnly`
- updated `MobileHeader` to render `<Sidebar mobileOnly ... />` so the header-owned sidebar instance only handles mobile drawer behavior

## Why
Desktop was rendering two sidebar instances: one from app layout and one from `MobileHeader`. The second instance also rendered a desktop `<aside>`, which caused layout issues and blanked main content.

## Scope
- `src/components/layout/Sidebar.tsx`
- `src/components/layout/MobileHeader.tsx`

## Validation
- static inspection only (no runtime/test execution requested)
- confirmed mobile drawer code path is unchanged and still keyed off `mobileOpen`/`onMobileClose`
- confirmed desktop `<aside>` is now omitted when `mobileOnly` is set

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0292c45ec8326b1596cbe75c0a69e)