### PR TITLE
Restore Wave 1: maintenance due widget, firearm maintenance fields, accessory battery tracking

### DIFF
--- a/prisma/migrations/20260322090000_wave1_maintenance_and_battery/migration.sql
+++ b/prisma/migrations/20260322090000_wave1_maintenance_and_battery/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Firearm" ADD COLUMN "lastMaintenanceDate" DATETIME;
+ALTER TABLE "Firearm" ADD COLUMN "maintenanceIntervalDays" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Accessory" ADD COLUMN "hasBattery" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Accessory" ADD COLUMN "batteryType" TEXT;
+ALTER TABLE "Accessory" ADD COLUMN "lastBatteryChangeDate" DATETIME;
+ALTER TABLE "Accessory" ADD COLUMN "replacementIntervalDays" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,10 @@ model Firearm {
   // imageSource: "uploaded" | "google_cse" | "seed" | "url"
   imageSource     String?
 
+  // Maintenance tracking
+  lastMaintenanceDate DateTime?
+  maintenanceIntervalDays Int?
+
   builds          Build[]
 
   createdAt       DateTime @default(now())
@@ -104,6 +108,12 @@ model Accessory {
   // Comma-separated compatible values, e.g. "RIFLE,SMG"
   compatibleFirearmTypes String?
   compatibleCalibers     String?
+
+  // Battery tracking
+  hasBattery             Boolean         @default(false)
+  batteryType            String?
+  lastBatteryChangeDate  DateTime?
+  replacementIntervalDays Int?
 
   createdAt              DateTime        @default(now())
   updatedAt              DateTime        @updatedAt

--- a/src/app/accessories/[id]/edit/page.tsx
+++ b/src/app/accessories/[id]/edit/page.tsx
@@ -22,6 +22,10 @@ interface Accessory {
   purchasePrice: number | null;
   notes: string | null;
   imageUrl: string | null;
+  hasBattery: boolean;
+  batteryType: string | null;
+  lastBatteryChangeDate: string | null;
+  replacementIntervalDays: number | null;
 }
 
 function toDateInputValue(dateStr: string | null): string {
@@ -91,6 +95,10 @@ export default function EditAccessoryPage() {
       notes: (data.get("notes") as string) || null,
       imageUrl: (data.get("imageUrl") as string) || null,
       imageSource: data.get("imageUrl") ? "url" : null,
+      hasBattery: data.get("hasBattery") === "on",
+      batteryType: (data.get("batteryType") as string) || null,
+      lastBatteryChangeDate: (data.get("lastBatteryChangeDate") as string) || null,
+      replacementIntervalDays: data.get("replacementIntervalDays") ? Number(data.get("replacementIntervalDays")) : null,
     };
 
     try {
@@ -323,6 +331,36 @@ export default function EditAccessoryPage() {
                   />
                 </div>
               </div>
+            </div>
+          </fieldset>
+
+
+
+          {/* Battery Tracking */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
+              Battery Tracking
+            </legend>
+
+            <label className="flex items-center gap-2 text-sm text-vault-text">
+              <input id="hasBattery" name="hasBattery" type="checkbox" defaultChecked={accessory.hasBattery} className="rounded border-vault-border" />
+              This accessory uses a battery
+            </label>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="batteryType" className={LABEL_CLASS}>Battery Type</label>
+                <input id="batteryType" name="batteryType" type="text" defaultValue={accessory.batteryType ?? ""} placeholder="e.g. CR2032" className={INPUT_CLASS} />
+              </div>
+              <div>
+                <label htmlFor="replacementIntervalDays" className={LABEL_CLASS}>Replacement Interval (days)</label>
+                <input id="replacementIntervalDays" name="replacementIntervalDays" type="number" min="1" step="1" defaultValue={accessory.replacementIntervalDays ?? ""} placeholder="e.g. 180" className={INPUT_CLASS} />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="lastBatteryChangeDate" className={LABEL_CLASS}>Last Battery Change</label>
+              <input id="lastBatteryChangeDate" name="lastBatteryChangeDate" type="date" defaultValue={toDateInputValue(accessory.lastBatteryChangeDate)} className={INPUT_CLASS} />
             </div>
           </fieldset>
 

--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -40,6 +40,10 @@ export default function NewAccessoryPage() {
       notes: (data.get("notes") as string) || null,
       imageUrl: (data.get("imageUrl") as string) || null,
       imageSource: data.get("imageUrl") ? "url" : null,
+      hasBattery: data.get("hasBattery") === "on",
+      batteryType: (data.get("batteryType") as string) || null,
+      lastBatteryChangeDate: (data.get("lastBatteryChangeDate") as string) || null,
+      replacementIntervalDays: data.get("replacementIntervalDays") ? Number(data.get("replacementIntervalDays")) : null,
     };
 
     try {
@@ -231,6 +235,36 @@ export default function NewAccessoryPage() {
                   />
                 </div>
               </div>
+            </div>
+          </fieldset>
+
+
+
+          {/* Battery Tracking */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
+              Battery Tracking
+            </legend>
+
+            <label className="flex items-center gap-2 text-sm text-vault-text">
+              <input id="hasBattery" name="hasBattery" type="checkbox" className="rounded border-vault-border" />
+              This accessory uses a battery
+            </label>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="batteryType" className={LABEL_CLASS}>Battery Type</label>
+                <input id="batteryType" name="batteryType" type="text" placeholder="e.g. CR2032" className={INPUT_CLASS} />
+              </div>
+              <div>
+                <label htmlFor="replacementIntervalDays" className={LABEL_CLASS}>Replacement Interval (days)</label>
+                <input id="replacementIntervalDays" name="replacementIntervalDays" type="number" min="1" step="1" placeholder="e.g. 180" className={INPUT_CLASS} />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="lastBatteryChangeDate" className={LABEL_CLASS}>Last Battery Change</label>
+              <input id="lastBatteryChangeDate" name="lastBatteryChangeDate" type="date" className={INPUT_CLASS} />
             </div>
           </fieldset>
 

--- a/src/app/api/accessories/[id]/battery/route.ts
+++ b/src/app/api/accessories/[id]/battery/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// POST /api/accessories/[id]/battery - mark battery replacement
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const changeDate = body.lastBatteryChangeDate
+      ? new Date(body.lastBatteryChangeDate)
+      : new Date();
+
+    const updated = await prisma.accessory.update({
+      where: { id },
+      data: {
+        hasBattery: true,
+        batteryType: body.batteryType ?? undefined,
+        replacementIntervalDays:
+          body.replacementIntervalDays !== undefined
+            ? body.replacementIntervalDays
+            : undefined,
+        lastBatteryChangeDate: changeDate,
+      },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("POST /api/accessories/[id]/battery error:", error);
+    return NextResponse.json(
+      { error: "Failed to update battery tracking" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/accessories/[id]/route.ts
+++ b/src/app/api/accessories/[id]/route.ts
@@ -91,6 +91,10 @@ export async function PUT(
       imageSource,
       compatibleFirearmTypes,
       compatibleCalibers,
+      hasBattery,
+      batteryType,
+      lastBatteryChangeDate,
+      replacementIntervalDays,
     } = body;
 
     const existing = await prisma.accessory.findUnique({ where: { id } });
@@ -118,6 +122,12 @@ export async function PUT(
         ...(imageSource !== undefined && { imageSource }),
         ...(compatibleFirearmTypes !== undefined && { compatibleFirearmTypes }),
         ...(compatibleCalibers !== undefined && { compatibleCalibers }),
+        ...(hasBattery !== undefined && { hasBattery: Boolean(hasBattery) }),
+        ...(batteryType !== undefined && { batteryType }),
+        ...(lastBatteryChangeDate !== undefined && {
+          lastBatteryChangeDate: lastBatteryChangeDate ? new Date(lastBatteryChangeDate) : null,
+        }),
+        ...(replacementIntervalDays !== undefined && { replacementIntervalDays }),
       },
       include: {
         roundCountLogs: {

--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -73,6 +73,10 @@ export async function POST(request: NextRequest) {
       imageSource,
       compatibleFirearmTypes,
       compatibleCalibers,
+      hasBattery,
+      batteryType,
+      lastBatteryChangeDate,
+      replacementIntervalDays,
     } = body;
 
     if (!name || !manufacturer || !type) {
@@ -96,6 +100,10 @@ export async function POST(request: NextRequest) {
         imageSource: imageSource ?? null,
         compatibleFirearmTypes: compatibleFirearmTypes ?? null,
         compatibleCalibers: compatibleCalibers ?? null,
+        hasBattery: Boolean(hasBattery),
+        batteryType: batteryType ?? null,
+        lastBatteryChangeDate: lastBatteryChangeDate ? new Date(lastBatteryChangeDate) : null,
+        replacementIntervalDays: replacementIntervalDays ?? null,
       },
     });
 

--- a/src/app/api/firearms/[id]/route.ts
+++ b/src/app/api/firearms/[id]/route.ts
@@ -74,6 +74,8 @@ export async function PUT(
       notes,
       imageUrl,
       imageSource,
+      lastMaintenanceDate,
+      maintenanceIntervalDays,
     } = body;
 
     const existing = await prisma.firearm.findUnique({ where: { id } });
@@ -98,6 +100,10 @@ export async function PUT(
         ...(notes !== undefined && { notes: notes ? encryptField(notes) : null }),
         ...(imageUrl !== undefined && { imageUrl }),
         ...(imageSource !== undefined && { imageSource }),
+        ...(lastMaintenanceDate !== undefined && {
+          lastMaintenanceDate: lastMaintenanceDate ? new Date(lastMaintenanceDate) : null,
+        }),
+        ...(maintenanceIntervalDays !== undefined && { maintenanceIntervalDays }),
       },
       include: {
         _count: {

--- a/src/app/api/firearms/route.ts
+++ b/src/app/api/firearms/route.ts
@@ -63,6 +63,8 @@ export async function POST(request: NextRequest) {
       notes,
       imageUrl,
       imageSource,
+      lastMaintenanceDate,
+      maintenanceIntervalDays,
     } = body;
 
     if (!name || !manufacturer || !model || !caliber || !serialNumber || !type || !acquisitionDate) {
@@ -86,6 +88,8 @@ export async function POST(request: NextRequest) {
         notes: notes ? encryptField(notes) : null,
         imageUrl: imageUrl ?? null,
         imageSource: imageSource ?? null,
+        lastMaintenanceDate: lastMaintenanceDate ? new Date(lastMaintenanceDate) : null,
+        maintenanceIntervalDays: maintenanceIntervalDays ?? null,
       },
       include: {
         _count: {

--- a/src/app/vault/[id]/edit/page.tsx
+++ b/src/app/vault/[id]/edit/page.tsx
@@ -24,6 +24,8 @@ interface Firearm {
   currentValue: number | null;
   notes: string | null;
   imageUrl: string | null;
+  lastMaintenanceDate: string | null;
+  maintenanceIntervalDays: number | null;
 }
 
 function toDateInputValue(dateStr: string | null): string {
@@ -96,6 +98,8 @@ export default function EditFirearmPage() {
       notes: (data.get("notes") as string) || null,
       imageUrl: (data.get("imageUrl") as string) || null,
       imageSource: data.get("imageUrl") ? "url" : null,
+      lastMaintenanceDate: (data.get("lastMaintenanceDate") as string) || null,
+      maintenanceIntervalDays: data.get("maintenanceIntervalDays") ? Number(data.get("maintenanceIntervalDays")) : null,
     };
 
     try {
@@ -367,6 +371,24 @@ export default function EditFirearmPage() {
                     className={`${INPUT_CLASS} pl-7`}
                   />
                 </div>
+              </div>
+            </div>
+          </fieldset>
+
+          {/* Maintenance */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
+              Maintenance
+            </legend>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="lastMaintenanceDate" className={LABEL_CLASS}>Last Maintenance</label>
+                <input id="lastMaintenanceDate" name="lastMaintenanceDate" type="date" defaultValue={toDateInputValue(firearm.lastMaintenanceDate)} className={INPUT_CLASS} />
+              </div>
+              <div>
+                <label htmlFor="maintenanceIntervalDays" className={LABEL_CLASS}>Maintenance Interval (days)</label>
+                <input id="maintenanceIntervalDays" name="maintenanceIntervalDays" type="number" min="1" step="1" defaultValue={firearm.maintenanceIntervalDays ?? ""} placeholder="e.g. 180" className={INPUT_CLASS} />
               </div>
             </div>
           </fieldset>

--- a/src/app/vault/new/page.tsx
+++ b/src/app/vault/new/page.tsx
@@ -43,6 +43,8 @@ export default function NewFirearmPage() {
       notes: (data.get("notes") as string) || null,
       imageUrl: (data.get("imageUrl") as string) || null,
       imageSource: data.get("imageUrl") ? "url" : null,
+      lastMaintenanceDate: (data.get("lastMaintenanceDate") as string) || null,
+      maintenanceIntervalDays: data.get("maintenanceIntervalDays") ? Number(data.get("maintenanceIntervalDays")) : null,
     };
 
     try {
@@ -273,6 +275,24 @@ export default function NewFirearmPage() {
                     className={`${INPUT_CLASS} pl-7`}
                   />
                 </div>
+              </div>
+            </div>
+          </fieldset>
+
+          {/* Maintenance */}
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
+              Maintenance
+            </legend>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="lastMaintenanceDate" className={LABEL_CLASS}>Last Maintenance</label>
+                <input id="lastMaintenanceDate" name="lastMaintenanceDate" type="date" className={INPUT_CLASS} defaultValue={new Date().toISOString().split("T")[0]} />
+              </div>
+              <div>
+                <label htmlFor="maintenanceIntervalDays" className={LABEL_CLASS}>Maintenance Interval (days)</label>
+                <input id="maintenanceIntervalDays" name="maintenanceIntervalDays" type="number" min="1" step="1" placeholder="e.g. 180" className={INPUT_CLASS} />
               </div>
             </div>
           </fieldset>

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -55,7 +55,7 @@ const TYPE_BADGE_COLORS: Record<string, string> = {
   LEVER_ACTION: "border-[#FF7043]/40 text-[#FF7043]",
 };
 
-const DEFAULT_ORDER = ["stats", "low-ammo", "recent", "ammo-summary"];
+const DEFAULT_ORDER = ["stats", "maintenance-due", "low-ammo", "recent", "ammo-summary"];
 const STORAGE_KEY = "vault-dashboard-layout";
 
 interface AmmoStockItem {
@@ -81,6 +81,80 @@ interface RecentFirearm {
   createdAt: Date;
 }
 
+
+interface MaintenanceDueItem {
+  id: string;
+  name: string;
+  manufacturer: string;
+  model: string;
+  lastMaintenanceDate: string | null;
+  maintenanceIntervalDays: number | null;
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function MaintenanceDueWidget() {
+  const [items, setItems] = useState<MaintenanceDueItem[]>([]);
+
+  useEffect(() => {
+    fetch("/api/firearms")
+      .then((r) => r.json())
+      .then((firearms) => {
+        const now = new Date();
+        const due = (Array.isArray(firearms) ? firearms : [])
+          .filter((f) => f.lastMaintenanceDate && f.maintenanceIntervalDays)
+          .map((f) => ({
+            ...f,
+            dueDate: addDays(new Date(f.lastMaintenanceDate), Number(f.maintenanceIntervalDays)),
+          }))
+          .filter((f) => f.dueDate <= now)
+          .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime())
+          .slice(0, 8);
+        setItems(due);
+      })
+      .catch(() => setItems([]));
+  }, []);
+
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-3">
+        <Clock className="w-4 h-4 text-[#E53935]" />
+        <h2 className="text-sm font-semibold tracking-widest uppercase text-[#E53935]">
+          Maintenance Due
+        </h2>
+      </div>
+      <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+        {items.length === 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-sm text-vault-text-muted">No firearms currently due for maintenance</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-vault-border">
+            {items.map((item) => (
+              <Link
+                key={item.id}
+                href={`/vault/${item.id}`}
+                className="flex items-center justify-between px-4 py-3 hover:bg-vault-surface-2 transition-colors"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-vault-text">{item.name}</p>
+                  <p className="text-xs text-vault-text-muted">{item.manufacturer} · {item.model}</p>
+                </div>
+                <span className="text-xs text-[#E53935] font-mono">
+                  Due
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
 interface DashboardData {
   firearmCount: number;
   accessoryCount: number;
@@ -414,27 +488,22 @@ function AmmoSummaryWidget({ ammoStocks }: { ammoStocks: AmmoStockItem[] }) {
 
 // ── Main client component ─────────────────────────────────────
 export function DashboardClient({ data }: { data: DashboardData }) {
-  const [order, setOrder] = useState<string[]>(DEFAULT_ORDER);
-  const [editMode, setEditMode] = useState(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
+  const [order, setOrder] = useState<string[]>(() => {
+    if (typeof window === "undefined") return DEFAULT_ORDER;
     try {
       const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved) {
-        const parsed: string[] = JSON.parse(saved);
-        // Ensure all default widgets are present (in case new ones were added)
-        const merged = [
-          ...parsed.filter((id) => DEFAULT_ORDER.includes(id)),
-          ...DEFAULT_ORDER.filter((id) => !parsed.includes(id)),
-        ];
-        setOrder(merged);
-      }
+      if (!saved) return DEFAULT_ORDER;
+      const parsed: string[] = JSON.parse(saved);
+      return [
+        ...parsed.filter((id) => DEFAULT_ORDER.includes(id)),
+        ...DEFAULT_ORDER.filter((id) => !parsed.includes(id)),
+      ];
     } catch {
-      // ignore
+      return DEFAULT_ORDER;
     }
-  }, []);
+  });
+  const [editMode, setEditMode] = useState(false);
+  const [mounted] = useState(() => typeof window !== "undefined");
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -458,6 +527,8 @@ export function DashboardClient({ data }: { data: DashboardData }) {
     switch (id) {
       case "stats":
         return <StatsWidget data={data} />;
+      case "maintenance-due":
+        return <MaintenanceDueWidget />;
       case "low-ammo":
         return <LowAmmoWidget items={data.lowStockItems} />;
       case "recent":


### PR DESCRIPTION
### Motivation
- Restore the Wave 1 feature set that was missing from the branch: a Command Center "Maintenance Due" section, the firearm maintenance add/edit flow, and accessory battery tracking fields.
- Persist maintenance and battery metadata so maintenance due dates and battery replacement info can be recorded and surfaced in the UI.
- Keep changes minimal and limited to only the files needed to implement Wave 1 (no layout, auth, Docker, export, or range/drill work). 

### Description
- Added persisted schema fields for firearms (`lastMaintenanceDate`, `maintenanceIntervalDays`) and accessories (`hasBattery`, `batteryType`, `lastBatteryChangeDate`, `replacementIntervalDays`) and included a Prisma migration file to apply them.
- Wired maintenance fields through the firearm APIs (`src/app/api/firearms/route.ts`, `src/app/api/firearms/[id]/route.ts`) and the vault add/edit forms (`src/app/vault/new/page.tsx`, `src/app/vault/[id]/edit/page.tsx`) so maintenance date and interval are captured and stored.
- Restored accessory battery fields in the accessory APIs and forms (`src/app/api/accessories/route.ts`, `src/app/api/accessories/[id]/route.ts`, `src/app/accessories/new/page.tsx`, `src/app/accessories/[id]/edit/page.tsx`) and added a dedicated endpoint `POST /api/accessories/[id]/battery` at `src/app/api/accessories/[id]/battery/route.ts` for explicit battery-change updates.
- Added a client-side `Maintenance Due` widget to the Command Center dashboard and integrated it into the widget order in `src/components/dashboard/DashboardClient.tsx`, which fetches firearms and computes due items based on `lastMaintenanceDate + maintenanceIntervalDays`.

### Testing
- Ran targeted linter on changed files with `npm run lint -- <changed files>` and it completed successfully for the modified files.
- Ran full `npm run lint` which failed due to pre-existing unrelated lint issues (not introduced by this change) in `src/app/ammo/page.tsx` and `src/components/layout/ThemeProvider.tsx`.
- Ran `npm run build` which failed in this environment because the Next build attempted to fetch the `Inter` font from Google Fonts and the fetch failed (external resource issue), not due to the Wave 1 code changes.
- Attempted `docker compose build`, `docker compose up -d`, and `docker compose ps` but `docker` is not available in this execution environment, so those verification steps could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0433b08b08326a952c4bf46a6b5b6)