### PR TITLE
Restore Wave 2 media flows, document library, and full-armory export

### DIFF
--- a/src/app/accessories/[id]/edit/page.tsx
+++ b/src/app/accessories/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { SLOT_TYPES, SLOT_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
+import { ImagePicker } from "@/components/shared/ImagePicker";
 import { ArrowLeft, Save, Loader2, AlertCircle } from "lucide-react";
 
 const INPUT_CLASS =
@@ -66,6 +67,7 @@ export default function EditAccessoryPage() {
         } else {
           setAccessory(data);
           setCaliberInput(data.caliber ?? "");
+          setImageUrl(data.imageUrl ?? "");
         }
         setDataLoading(false);
       })
@@ -93,8 +95,8 @@ export default function EditAccessoryPage() {
       acquisitionDate: (data.get("acquisitionDate") as string) || null,
       purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
       notes: (data.get("notes") as string) || null,
-      imageUrl: (data.get("imageUrl") as string) || null,
-      imageSource: data.get("imageUrl") ? "url" : null,
+      imageUrl: imageUrl || null,
+      imageSource: imageUrl ? "uploaded" : null,
       hasBattery: data.get("hasBattery") === "on",
       batteryType: (data.get("batteryType") as string) || null,
       lastBatteryChangeDate: (data.get("lastBatteryChangeDate") as string) || null,
@@ -207,13 +209,12 @@ export default function EditAccessoryPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="manufacturer" className={LABEL_CLASS}>
-                  Manufacturer <span className="text-[#E53935]">*</span>
+                  Manufacturer
                 </label>
                 <input
                   id="manufacturer"
                   name="manufacturer"
                   type="text"
-                  required
                   defaultValue={accessory.manufacturer}
                   className={INPUT_CLASS}
                 />
@@ -236,12 +237,11 @@ export default function EditAccessoryPage() {
               {/* Type */}
               <div>
                 <label htmlFor="type" className={LABEL_CLASS}>
-                  Type / Slot <span className="text-[#E53935]">*</span>
+                  Type / Slot
                 </label>
                 <select
                   id="type"
                   name="type"
-                  required
                   defaultValue={accessory.type}
                   className={INPUT_CLASS}
                 >
@@ -369,29 +369,7 @@ export default function EditAccessoryPage() {
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
               Image
             </legend>
-            <div>
-              <label htmlFor="imageUrl" className={LABEL_CLASS}>
-                Image URL
-              </label>
-              <input
-                id="imageUrl"
-                name="imageUrl"
-                type="url"
-                defaultValue={accessory.imageUrl ?? ""}
-                placeholder="https://example.com/image.jpg"
-                className={INPUT_CLASS}
-              />
-              {accessory.imageUrl && (
-                <div className="mt-3 w-full h-28 rounded-md overflow-hidden border border-vault-border">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={accessory.imageUrl}
-                    alt={accessory.name}
-                    className="w-full h-full object-contain bg-vault-bg"
-                  />
-                </div>
-              )}
-            </div>
+            <ImagePicker entityType="accessory" value={imageUrl} onChange={setImageUrl} />
           </fieldset>
 
           {/* Notes */}

--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { SLOT_TYPES, SLOT_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
+import { ImagePicker } from "@/components/shared/ImagePicker";
 import { ArrowLeft, Plus, Loader2, AlertCircle } from "lucide-react";
 
 const INPUT_CLASS =
@@ -38,8 +39,8 @@ export default function NewAccessoryPage() {
       acquisitionDate: (data.get("acquisitionDate") as string) || null,
       purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
       notes: (data.get("notes") as string) || null,
-      imageUrl: (data.get("imageUrl") as string) || null,
-      imageSource: data.get("imageUrl") ? "url" : null,
+      imageUrl: imageUrl || null,
+      imageSource: imageUrl ? "uploaded" : null,
       hasBattery: data.get("hasBattery") === "on",
       batteryType: (data.get("batteryType") as string) || null,
       lastBatteryChangeDate: (data.get("lastBatteryChangeDate") as string) || null,
@@ -122,13 +123,12 @@ export default function NewAccessoryPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="manufacturer" className={LABEL_CLASS}>
-                  Manufacturer <span className="text-[#E53935]">*</span>
+                  Manufacturer
                 </label>
                 <input
                   id="manufacturer"
                   name="manufacturer"
                   type="text"
-                  required
                   placeholder="e.g. Trijicon"
                   className={INPUT_CLASS}
                 />
@@ -150,9 +150,9 @@ export default function NewAccessoryPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="type" className={LABEL_CLASS}>
-                  Type / Slot <span className="text-[#E53935]">*</span>
+                  Type / Slot
                 </label>
-                <select id="type" name="type" required className={INPUT_CLASS}>
+                <select id="type" name="type" className={INPUT_CLASS}>
                   <option value="">Select slot type...</option>
                   {SLOT_TYPES.map((t) => (
                     <option key={t} value={t}>
@@ -273,18 +273,7 @@ export default function NewAccessoryPage() {
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
               Image
             </legend>
-            <div>
-              <label htmlFor="imageUrl" className={LABEL_CLASS}>
-                Image URL
-              </label>
-              <input
-                id="imageUrl"
-                name="imageUrl"
-                type="url"
-                placeholder="https://example.com/image.jpg"
-                className={INPUT_CLASS}
-              />
-            </div>
+            <ImagePicker entityType="accessory" value={imageUrl} onChange={setImageUrl} />
           </fieldset>
 
           {/* Notes */}

--- a/src/app/api/accessories/[id]/route.ts
+++ b/src/app/api/accessories/[id]/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+
+function normalizeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 // GET /api/accessories/[id] - Get a single accessory with roundCountLogs and current buildSlots
 export async function GET(
   _request: NextRequest,
@@ -108,10 +113,10 @@ export async function PUT(
     const updated = await prisma.accessory.update({
       where: { id },
       data: {
-        ...(name !== undefined && { name }),
-        ...(manufacturer !== undefined && { manufacturer }),
-        ...(model !== undefined && { model }),
-        ...(type !== undefined && { type }),
+        ...(name !== undefined && { name: normalizeString(name) || existing.name }),
+        ...(manufacturer !== undefined && { manufacturer: normalizeString(manufacturer) || "Unknown" }),
+        ...(model !== undefined && { model: normalizeString(model) || null }),
+        ...(type !== undefined && { type: normalizeString(type) || "UNSPECIFIED" }),
         ...(caliber !== undefined && { caliber }),
         ...(purchasePrice !== undefined && { purchasePrice }),
         ...(acquisitionDate !== undefined && {

--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+
+function normalizeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 // GET /api/accessories - List all accessories with current build name
 export async function GET() {
   try {
@@ -79,19 +84,20 @@ export async function POST(request: NextRequest) {
       replacementIntervalDays,
     } = body;
 
-    if (!name || !manufacturer || !type) {
+    const normalizedName = normalizeString(name);
+    if (!normalizedName) {
       return NextResponse.json(
-        { error: "Missing required fields: name, manufacturer, type" },
+        { error: "Missing required field: name" },
         { status: 400 }
       );
     }
 
     const accessory = await prisma.accessory.create({
       data: {
-        name,
-        manufacturer,
-        model: model ?? null,
-        type,
+        name: normalizedName,
+        manufacturer: normalizeString(manufacturer) || "Unknown",
+        model: normalizeString(model) || null,
+        type: normalizeString(type) || "UNSPECIFIED",
         caliber: caliber ?? null,
         purchasePrice: purchasePrice ?? null,
         acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : null,

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const safeId = id.replace(/[^a-zA-Z0-9._-]/g, "");
+    const filePath = path.join(process.cwd(), "public", "uploads", "documents", safeId);
+    await fs.unlink(filePath);
+    return NextResponse.json({ success: true, id: safeId });
+  } catch (error) {
+    console.error("DELETE /api/documents/[id] error:", error);
+    return NextResponse.json({ error: "Failed to delete document" }, { status: 500 });
+  }
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function GET() {
+  try {
+    const uploadsDir = path.join(process.cwd(), "public", "uploads", "documents");
+    await fs.mkdir(uploadsDir, { recursive: true });
+
+    const files = await fs.readdir(uploadsDir, { withFileTypes: true });
+    const docs = await Promise.all(
+      files
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const stat = await fs.stat(path.join(uploadsDir, entry.name));
+          return {
+            id: entry.name,
+            name: entry.name,
+            url: `/uploads/documents/${entry.name}`,
+            size: stat.size,
+            updatedAt: stat.mtime.toISOString(),
+          };
+        })
+    );
+
+    docs.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+    return NextResponse.json({ documents: docs });
+  } catch (error) {
+    console.error("GET /api/documents error:", error);
+    return NextResponse.json({ error: "Failed to fetch documents" }, { status: 500 });
+  }
+}

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: "Missing required field: file" }, { status: 400 });
+    }
+
+    const safeName = `${Date.now()}-${(file.name || "document").replace(/[^a-zA-Z0-9._-]/g, "_")}`;
+    const uploadsDir = path.join(process.cwd(), "public", "uploads", "documents");
+    await fs.mkdir(uploadsDir, { recursive: true });
+
+    const filePath = path.join(uploadsDir, safeName);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    await fs.writeFile(filePath, buffer);
+
+    return NextResponse.json({
+      id: safeName,
+      name: file.name,
+      url: `/uploads/documents/${safeName}`,
+      size: file.size,
+      mimeType: file.type || "application/octet-stream",
+    }, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/documents/upload error:", error);
+    return NextResponse.json({ error: "Failed to upload document" }, { status: 500 });
+  }
+}

--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildArmoryRows, rowsToCsv } from "@/lib/exports/full-armory";
+import { DEFAULT_EXPORT_FIELDS } from "@/lib/exports/full-armory-fields";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const format = body.format === "json" ? "json" : "csv";
+    const requestedFields = Array.isArray(body.fields) ? body.fields.filter((v: unknown): v is string => typeof v === "string") : [];
+    const fields = requestedFields.length > 0 ? requestedFields : [...DEFAULT_EXPORT_FIELDS];
+
+    const rows = await buildArmoryRows(fields);
+
+    if (format === "json") {
+      return new NextResponse(JSON.stringify(rows, null, 2), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Disposition": 'attachment; filename="full-armory-export.json"',
+        },
+      });
+    }
+
+    const csv = rowsToCsv(rows);
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv",
+        "Content-Disposition": 'attachment; filename="full-armory-export.csv"',
+      },
+    });
+  } catch (error) {
+    console.error("POST /api/exports/full-armory error:", error);
+    return NextResponse.json({ error: "Failed to export armory" }, { status: 500 });
+  }
+}

--- a/src/app/api/firearms/[id]/route.ts
+++ b/src/app/api/firearms/[id]/route.ts
@@ -2,6 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
 
+
+function normalizeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function fallbackSerialNumber() {
+  return `AUTO-${Date.now()}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+}
+
 // GET /api/firearms/[id] - Get a single firearm with active build, slots, and accessories
 export async function GET(
   _request: NextRequest,
@@ -86,14 +95,14 @@ export async function PUT(
     const updated = await prisma.firearm.update({
       where: { id },
       data: {
-        ...(name !== undefined && { name }),
-        ...(manufacturer !== undefined && { manufacturer }),
-        ...(model !== undefined && { model }),
-        ...(caliber !== undefined && { caliber }),
-        ...(serialNumber !== undefined && { serialNumber: encryptField(serialNumber) }),
-        ...(type !== undefined && { type }),
+        ...(name !== undefined && { name: normalizeString(name) || existing.name }),
+        ...(manufacturer !== undefined && { manufacturer: normalizeString(manufacturer) || "Unknown" }),
+        ...(model !== undefined && { model: normalizeString(model) || "Unknown" }),
+        ...(caliber !== undefined && { caliber: normalizeString(caliber) || "Unknown" }),
+        ...(serialNumber !== undefined && { serialNumber: encryptField(normalizeString(serialNumber) || fallbackSerialNumber()) }),
+        ...(type !== undefined && { type: normalizeString(type) || "UNSPECIFIED" }),
         ...(acquisitionDate !== undefined && {
-          acquisitionDate: new Date(acquisitionDate),
+          acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : existing.acquisitionDate,
         }),
         ...(purchasePrice !== undefined && { purchasePrice }),
         ...(currentValue !== undefined && { currentValue }),

--- a/src/app/api/firearms/route.ts
+++ b/src/app/api/firearms/route.ts
@@ -2,6 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { encryptField, decryptField } from "@/lib/crypto";
 
+
+function normalizeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function fallbackSerialNumber() {
+  return `AUTO-${Date.now()}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+}
+
 // GET /api/firearms - List all firearms with build count
 export async function GET() {
   try {
@@ -67,22 +76,23 @@ export async function POST(request: NextRequest) {
       maintenanceIntervalDays,
     } = body;
 
-    if (!name || !manufacturer || !model || !caliber || !serialNumber || !type || !acquisitionDate) {
+    const normalizedName = normalizeString(name);
+    if (!normalizedName) {
       return NextResponse.json(
-        { error: "Missing required fields: name, manufacturer, model, caliber, serialNumber, type, acquisitionDate" },
+        { error: "Missing required field: name" },
         { status: 400 }
       );
     }
 
     const firearm = await prisma.firearm.create({
       data: {
-        name,
-        manufacturer,
-        model,
-        caliber,
-        serialNumber: encryptField(serialNumber),
-        type,
-        acquisitionDate: new Date(acquisitionDate),
+        name: normalizedName,
+        manufacturer: normalizeString(manufacturer) || "Unknown",
+        model: normalizeString(model) || "Unknown",
+        caliber: normalizeString(caliber) || "Unknown",
+        serialNumber: encryptField(normalizeString(serialNumber) || fallbackSerialNumber()),
+        type: normalizeString(type) || "UNSPECIFIED",
+        acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : new Date(),
         purchasePrice: purchasePrice ?? null,
         currentValue: currentValue ?? null,
         notes: notes ? encryptField(notes) : null,

--- a/src/app/api/images/library/route.ts
+++ b/src/app/api/images/library/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+const IMAGE_FOLDERS = ["firearms", "accessories", "ammo"];
+
+export async function GET() {
+  try {
+    const root = path.join(process.cwd(), "public", "uploads");
+    const images = [] as Array<{ id: string; url: string; folder: string; updatedAt: string }>;
+
+    for (const folder of IMAGE_FOLDERS) {
+      const dir = path.join(root, folder);
+      await fs.mkdir(dir, { recursive: true });
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        const filePath = path.join(dir, entry.name);
+        const stat = await fs.stat(filePath);
+        images.push({
+          id: `${folder}/${entry.name}`,
+          url: `/uploads/${folder}/${entry.name}`,
+          folder,
+          updatedAt: stat.mtime.toISOString(),
+        });
+      }
+    }
+
+    images.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+    return NextResponse.json({ images });
+  } catch (error) {
+    console.error("GET /api/images/library error:", error);
+    return NextResponse.json({ error: "Failed to load image library" }, { status: 500 });
+  }
+}

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { DocumentUploader } from "@/components/shared/DocumentUploader";
+import { PageHeader } from "@/components/shared/PageHeader";
+
+interface DocumentItem {
+  id: string;
+  name: string;
+  url: string;
+  size: number;
+  updatedAt: string;
+}
+
+interface ImageItem {
+  id: string;
+  url: string;
+  folder: string;
+}
+
+export default function DocumentsPage() {
+  const [documents, setDocuments] = useState<DocumentItem[]>([]);
+  const [images, setImages] = useState<ImageItem[]>([]);
+
+  async function load() {
+    const [docRes, imageRes] = await Promise.all([
+      fetch("/api/documents"),
+      fetch("/api/images/library"),
+    ]);
+
+    const docsJson = await docRes.json();
+    const imagesJson = await imageRes.json();
+    setDocuments(docsJson.documents ?? []);
+    setImages(imagesJson.images ?? []);
+  }
+
+  async function deleteDocument(id: string) {
+    await fetch(`/api/documents/${id}`, { method: "DELETE" });
+    await load();
+  }
+
+  useEffect(() => {
+    void (async () => {
+      await load();
+    })();
+  }, []);
+
+  return (
+    <div className="min-h-full">
+      <PageHeader title="LIBRARY" subtitle="Images and documents" />
+      <div className="p-6 space-y-6">
+        <DocumentUploader onUploaded={load} />
+
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-vault-text mb-3">Documents</h2>
+          <div className="space-y-2">
+            {documents.length === 0 && <p className="text-sm text-vault-text-faint">No documents uploaded yet.</p>}
+            {documents.map((doc) => (
+              <div key={doc.id} className="flex items-center justify-between gap-3 border border-vault-border rounded px-3 py-2">
+                <a href={doc.url} target="_blank" className="text-sm text-[#00C2FF] hover:underline" rel="noreferrer">
+                  {doc.name}
+                </a>
+                <button
+                  type="button"
+                  onClick={() => deleteDocument(doc.id)}
+                  className="text-xs text-[#E53935] hover:underline"
+                >
+                  Delete
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-vault-surface border border-vault-border rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-vault-text mb-3">Images</h2>
+          {images.length === 0 ? (
+            <p className="text-sm text-vault-text-faint">No uploaded images yet.</p>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+              {images.map((image) => (
+                <a key={image.id} href={image.url} target="_blank" rel="noreferrer" className="block border border-vault-border rounded overflow-hidden bg-vault-bg">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={image.url} alt={image.id} className="w-full h-24 object-cover" />
+                </a>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/exports/full-armory/page.tsx
+++ b/src/app/exports/full-armory/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { DEFAULT_EXPORT_FIELDS } from "@/lib/exports/full-armory-fields";
+
+export default function FullArmoryExportPage() {
+  const [format, setFormat] = useState<"csv" | "json">("csv");
+  const [fields, setFields] = useState<string[]>([...DEFAULT_EXPORT_FIELDS]);
+  const [loading, setLoading] = useState(false);
+
+  async function runExport() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/exports/full-armory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ format, fields }),
+      });
+      if (!res.ok) return;
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = format === "csv" ? "full-armory-export.csv" : "full-armory-export.json";
+      link.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-full">
+      <PageHeader title="FULL ARMORY EXPORT" subtitle="Choose fields and file format" />
+      <div className="p-6 space-y-6">
+        <div className="bg-vault-surface border border-vault-border rounded-lg p-4 space-y-4">
+          <div>
+            <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-2">File type</p>
+            <select value={format} onChange={(e) => setFormat(e.target.value as "csv" | "json")} className="bg-vault-bg border border-vault-border rounded px-3 py-2 text-sm text-vault-text">
+              <option value="csv">CSV</option>
+              <option value="json">JSON</option>
+            </select>
+          </div>
+
+          <div>
+            <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-2">Fields</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {DEFAULT_EXPORT_FIELDS.map((field) => {
+                const checked = fields.includes(field);
+                return (
+                  <label key={field} className="text-sm text-vault-text flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        setFields((prev) =>
+                          e.target.checked ? [...prev, field] : prev.filter((f) => f !== field)
+                        );
+                      }}
+                    />
+                    {field}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={runExport}
+            disabled={loading || fields.length === 0}
+            className="bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 px-4 py-2 rounded text-sm"
+          >
+            {loading ? "Exporting..." : "Export"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/vault/[id]/edit/page.tsx
+++ b/src/app/vault/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { ImagePicker } from "@/components/shared/ImagePicker";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { FIREARM_TYPES, FIREARM_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
@@ -52,6 +53,7 @@ export default function EditFirearmPage() {
 
   const [caliberInput, setCaliberInput] = useState("");
   const [caliberDropdownOpen, setCaliberDropdownOpen] = useState(false);
+  const [imageUrl, setImageUrl] = useState("");
   const caliberRef = useRef<HTMLDivElement>(null);
 
   const filteredCalibers = COMMON_CALIBERS.filter((c) =>
@@ -67,6 +69,7 @@ export default function EditFirearmPage() {
         } else {
           setFirearm(data);
           setCaliberInput(data.caliber ?? "");
+          setImageUrl(data.imageUrl ?? "");
         }
         setDataLoading(false);
       })
@@ -96,8 +99,8 @@ export default function EditFirearmPage() {
       purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
       currentValue: data.get("currentValue") ? Number(data.get("currentValue")) : null,
       notes: (data.get("notes") as string) || null,
-      imageUrl: (data.get("imageUrl") as string) || null,
-      imageSource: data.get("imageUrl") ? "url" : null,
+      imageUrl: imageUrl || null,
+      imageSource: imageUrl ? "uploaded" : null,
       lastMaintenanceDate: (data.get("lastMaintenanceDate") as string) || null,
       maintenanceIntervalDays: data.get("maintenanceIntervalDays") ? Number(data.get("maintenanceIntervalDays")) : null,
     };
@@ -208,26 +211,24 @@ export default function EditFirearmPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="manufacturer" className={LABEL_CLASS}>
-                  Manufacturer <span className="text-[#E53935]">*</span>
+                  Manufacturer
                 </label>
                 <input
                   id="manufacturer"
                   name="manufacturer"
                   type="text"
-                  required
                   defaultValue={firearm.manufacturer}
                   className={INPUT_CLASS}
                 />
               </div>
               <div>
                 <label htmlFor="model" className={LABEL_CLASS}>
-                  Model <span className="text-[#E53935]">*</span>
+                  Model
                 </label>
                 <input
                   id="model"
                   name="model"
                   type="text"
-                  required
                   defaultValue={firearm.model}
                   className={INPUT_CLASS}
                 />
@@ -238,7 +239,7 @@ export default function EditFirearmPage() {
               {/* Caliber Combobox */}
               <div>
                 <label className={LABEL_CLASS}>
-                  Caliber <span className="text-[#E53935]">*</span>
+                  Caliber
                 </label>
                 <div className="relative" ref={caliberRef}>
                   <input
@@ -250,7 +251,6 @@ export default function EditFirearmPage() {
                     }}
                     onFocus={() => setCaliberDropdownOpen(true)}
                     onBlur={() => setTimeout(() => setCaliberDropdownOpen(false), 150)}
-                    required
                     placeholder="e.g. 9mm Luger"
                     className={INPUT_CLASS}
                   />
@@ -277,12 +277,11 @@ export default function EditFirearmPage() {
               {/* Type */}
               <div>
                 <label htmlFor="type" className={LABEL_CLASS}>
-                  Type <span className="text-[#E53935]">*</span>
+                  Type
                 </label>
                 <select
                   id="type"
                   name="type"
-                  required
                   defaultValue={firearm.type}
                   className={INPUT_CLASS}
                 >
@@ -298,13 +297,12 @@ export default function EditFirearmPage() {
 
             <div>
               <label htmlFor="serialNumber" className={LABEL_CLASS}>
-                Serial Number <span className="text-[#E53935]">*</span>
+                Serial Number
               </label>
               <input
                 id="serialNumber"
                 name="serialNumber"
                 type="text"
-                required
                 defaultValue={firearm.serialNumber}
                 className={`${INPUT_CLASS} font-mono`}
               />
@@ -319,13 +317,12 @@ export default function EditFirearmPage() {
 
             <div>
               <label htmlFor="acquisitionDate" className={LABEL_CLASS}>
-                Date Acquired <span className="text-[#E53935]">*</span>
+                Date Acquired
               </label>
               <input
                 id="acquisitionDate"
                 name="acquisitionDate"
                 type="date"
-                required
                 defaultValue={toDateInputValue(firearm.acquisitionDate)}
                 className={INPUT_CLASS}
               />
@@ -398,29 +395,7 @@ export default function EditFirearmPage() {
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
               Image
             </legend>
-            <div>
-              <label htmlFor="imageUrl" className={LABEL_CLASS}>
-                Image URL
-              </label>
-              <input
-                id="imageUrl"
-                name="imageUrl"
-                type="url"
-                defaultValue={firearm.imageUrl ?? ""}
-                placeholder="https://example.com/image.jpg"
-                className={INPUT_CLASS}
-              />
-              {firearm.imageUrl && (
-                <div className="mt-3 w-full h-32 rounded-md overflow-hidden border border-vault-border">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={firearm.imageUrl}
-                    alt={firearm.name}
-                    className="w-full h-full object-contain bg-vault-bg"
-                  />
-                </div>
-              )}
-            </div>
+            <ImagePicker entityType="firearm" value={imageUrl} onChange={setImageUrl} />
           </fieldset>
 
           {/* Notes */}

--- a/src/app/vault/new/page.tsx
+++ b/src/app/vault/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { ImagePicker } from "@/components/shared/ImagePicker";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { FIREARM_TYPES, FIREARM_TYPE_LABELS, COMMON_CALIBERS } from "@/lib/types";
@@ -16,6 +17,7 @@ export default function NewFirearmPage() {
   const [error, setError] = useState<string | null>(null);
   const [caliberInput, setCaliberInput] = useState("");
   const [caliberDropdownOpen, setCaliberDropdownOpen] = useState(false);
+  const [imageUrl, setImageUrl] = useState("");
   const caliberRef = useRef<HTMLDivElement>(null);
 
   const filteredCalibers = COMMON_CALIBERS.filter((c) =>
@@ -41,8 +43,8 @@ export default function NewFirearmPage() {
       purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
       currentValue: data.get("currentValue") ? Number(data.get("currentValue")) : null,
       notes: (data.get("notes") as string) || null,
-      imageUrl: (data.get("imageUrl") as string) || null,
-      imageSource: data.get("imageUrl") ? "url" : null,
+      imageUrl: imageUrl || null,
+      imageSource: imageUrl ? "uploaded" : null,
       lastMaintenanceDate: (data.get("lastMaintenanceDate") as string) || null,
       maintenanceIntervalDays: data.get("maintenanceIntervalDays") ? Number(data.get("maintenanceIntervalDays")) : null,
     };
@@ -123,26 +125,24 @@ export default function NewFirearmPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="manufacturer" className={LABEL_CLASS}>
-                  Manufacturer <span className="text-[#E53935]">*</span>
+                  Manufacturer
                 </label>
                 <input
                   id="manufacturer"
                   name="manufacturer"
                   type="text"
-                  required
                   placeholder="e.g. Glock"
                   className={INPUT_CLASS}
                 />
               </div>
               <div>
                 <label htmlFor="model" className={LABEL_CLASS}>
-                  Model <span className="text-[#E53935]">*</span>
+                  Model
                 </label>
                 <input
                   id="model"
                   name="model"
                   type="text"
-                  required
                   placeholder="e.g. G19 Gen5"
                   className={INPUT_CLASS}
                 />
@@ -153,7 +153,7 @@ export default function NewFirearmPage() {
               {/* Caliber Combobox */}
               <div>
                 <label className={LABEL_CLASS}>
-                  Caliber <span className="text-[#E53935]">*</span>
+                  Caliber
                 </label>
                 <div className="relative" ref={caliberRef}>
                   <input
@@ -165,7 +165,6 @@ export default function NewFirearmPage() {
                     }}
                     onFocus={() => setCaliberDropdownOpen(true)}
                     onBlur={() => setTimeout(() => setCaliberDropdownOpen(false), 150)}
-                    required
                     placeholder="e.g. 9mm Luger"
                     className={INPUT_CLASS}
                   />
@@ -192,9 +191,9 @@ export default function NewFirearmPage() {
               {/* Type */}
               <div>
                 <label htmlFor="type" className={LABEL_CLASS}>
-                  Type <span className="text-[#E53935]">*</span>
+                  Type
                 </label>
-                <select id="type" name="type" required className={INPUT_CLASS}>
+                <select id="type" name="type" className={INPUT_CLASS}>
                   <option value="">Select type...</option>
                   {FIREARM_TYPES.map((t) => (
                     <option key={t} value={t}>
@@ -207,13 +206,12 @@ export default function NewFirearmPage() {
 
             <div>
               <label htmlFor="serialNumber" className={LABEL_CLASS}>
-                Serial Number <span className="text-[#E53935]">*</span>
+                Serial Number
               </label>
               <input
                 id="serialNumber"
                 name="serialNumber"
                 type="text"
-                required
                 placeholder="e.g. ABC123456"
                 className={`${INPUT_CLASS} font-mono`}
               />
@@ -229,13 +227,12 @@ export default function NewFirearmPage() {
 
             <div>
               <label htmlFor="acquisitionDate" className={LABEL_CLASS}>
-                Date Acquired <span className="text-[#E53935]">*</span>
+                Date Acquired
               </label>
               <input
                 id="acquisitionDate"
                 name="acquisitionDate"
                 type="date"
-                required
                 className={INPUT_CLASS}
                 defaultValue={new Date().toISOString().split("T")[0]}
               />
@@ -302,21 +299,7 @@ export default function NewFirearmPage() {
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
               Image
             </legend>
-            <div>
-              <label htmlFor="imageUrl" className={LABEL_CLASS}>
-                Image URL
-              </label>
-              <input
-                id="imageUrl"
-                name="imageUrl"
-                type="url"
-                placeholder="https://example.com/image.jpg"
-                className={INPUT_CLASS}
-              />
-              <p className="text-xs text-vault-text-faint mt-1">
-                Paste a direct link to an image. Leave blank to use a placeholder.
-              </p>
-            </div>
+            <ImagePicker entityType="firearm" value={imageUrl} onChange={setImageUrl} />
           </fieldset>
 
           {/* Notes */}

--- a/src/components/shared/DocumentUploader.tsx
+++ b/src/components/shared/DocumentUploader.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload, Loader2 } from "lucide-react";
+
+interface DocumentUploaderProps {
+  onUploaded: () => void;
+}
+
+export function DocumentUploader({ onUploaded }: DocumentUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function uploadFile(file: File) {
+    setError(null);
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch("/api/documents/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error ?? "Upload failed");
+        return;
+      }
+      onUploaded();
+    } catch {
+      setError("Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="bg-vault-surface border border-vault-border rounded-lg p-4">
+      <input
+        ref={inputRef}
+        type="file"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) uploadFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={uploading}
+        className="inline-flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 px-3 py-2 rounded text-sm transition-colors"
+      >
+        {uploading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Upload className="w-4 h-4" />}
+        Upload document
+      </button>
+      {error && <p className="text-xs text-[#E53935] mt-2">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/shared/ImagePicker.tsx
+++ b/src/components/shared/ImagePicker.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload, Loader2 } from "lucide-react";
+
+interface ImagePickerProps {
+  entityType: "firearm" | "accessory" | "ammo";
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+}
+
+export function ImagePicker({ entityType, value, onChange, label = "Image" }: ImagePickerProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onFileSelected(file: File) {
+    setError(null);
+    setUploading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("entityType", entityType);
+      formData.append("entityId", `temp-${Date.now()}`);
+
+      const res = await fetch("/api/images/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const json = await res.json();
+
+      if (!res.ok) {
+        setError(json.error ?? "Failed to upload image");
+        return;
+      }
+
+      onChange(json.url);
+    } catch {
+      setError("Failed to upload image");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <label className="block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5">
+        {label}
+      </label>
+
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="https://example.com/image.jpg"
+        className="w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors"
+      />
+
+      <div className="flex items-center gap-3">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) {
+              onFileSelected(file);
+            }
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          className="inline-flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 px-3 py-1.5 rounded text-xs transition-colors"
+        >
+          {uploading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+          Upload image
+        </button>
+        {value && (
+          <span className="text-xs text-[#00C853]">Image selected</span>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-[#E53935]">{error}</p>}
+
+      {value && (
+        <div className="w-full h-32 rounded-md overflow-hidden border border-vault-border">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={value} alt="Preview" className="w-full h-full object-contain bg-vault-bg" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/exports/full-armory-fields.ts
+++ b/src/lib/exports/full-armory-fields.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_EXPORT_FIELDS = [
+  "category",
+  "name",
+  "manufacturer",
+  "model",
+  "type",
+  "caliber",
+  "serialNumber",
+  "purchasePrice",
+  "currentValue",
+  "acquisitionDate",
+  "notes",
+] as const;

--- a/src/lib/exports/full-armory.ts
+++ b/src/lib/exports/full-armory.ts
@@ -1,0 +1,73 @@
+import { prisma } from "@/lib/prisma";
+import { DEFAULT_EXPORT_FIELDS } from "@/lib/exports/full-armory-fields";
+
+export type ArmoryField = (typeof DEFAULT_EXPORT_FIELDS)[number];
+
+export async function buildArmoryRows(fields: string[]) {
+  const [firearms, accessories, ammo] = await Promise.all([
+    prisma.firearm.findMany(),
+    prisma.accessory.findMany(),
+    prisma.ammoStock.findMany(),
+  ]);
+
+  const rows = [
+    ...firearms.map((item) => ({
+      category: "firearm",
+      name: item.name,
+      manufacturer: item.manufacturer,
+      model: item.model,
+      type: item.type,
+      caliber: item.caliber,
+      serialNumber: item.serialNumber,
+      purchasePrice: item.purchasePrice,
+      currentValue: item.currentValue,
+      acquisitionDate: item.acquisitionDate?.toISOString() ?? null,
+      notes: item.notes,
+    })),
+    ...accessories.map((item) => ({
+      category: "accessory",
+      name: item.name,
+      manufacturer: item.manufacturer,
+      model: item.model,
+      type: item.type,
+      caliber: item.caliber,
+      serialNumber: null,
+      purchasePrice: item.purchasePrice,
+      currentValue: null,
+      acquisitionDate: item.acquisitionDate?.toISOString() ?? null,
+      notes: item.notes,
+    })),
+    ...ammo.map((item) => ({
+      category: "ammo",
+      name: `${item.brand} ${item.caliber}`.trim(),
+      manufacturer: item.brand,
+      model: null,
+      type: item.bulletType,
+      caliber: item.caliber,
+      serialNumber: null,
+      purchasePrice: item.purchasePrice,
+      currentValue: null,
+      acquisitionDate: item.purchaseDate?.toISOString() ?? null,
+      notes: item.notes,
+    })),
+  ];
+
+  return rows.map((row) => {
+    const selected: Record<string, unknown> = {};
+    for (const field of fields) {
+      selected[field] = row[field as keyof typeof row] ?? null;
+    }
+    return selected;
+  });
+}
+
+export function rowsToCsv(rows: Record<string, unknown>[]) {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0]);
+  const esc = (value: unknown) => `"${String(value ?? "").replaceAll('"', '""')}"`;
+
+  return [
+    headers.join(","),
+    ...rows.map((row) => headers.map((header) => esc(row[header])).join(",")),
+  ].join("\n");
+}


### PR DESCRIPTION
### Motivation
- Restore Wave 2 features for media and exports that were present in the Wave 2 source: in-app image upload UI, document/image library, and a full-armory export UX.  
- Relax create/edit validation so firearms and accessories require only `name` in the UI and API while keeping the DB intact.  
- Keep changes isolated to Wave 2 scope and avoid touching Docker, auth, layout/sidebar/logo, Wave 1 maintenance, or adding drills/loadouts.  

### Description
- Added a reusable `ImagePicker` component wired into firearm and accessory create/edit pages to enable URL entry, file upload (via existing `/api/images/upload`), and preview.  
- Restored document APIs (`/api/documents`, `/api/documents/upload`, `/api/documents/[id]`) and a `/documents` page plus a small `DocumentUploader` UI component to upload/list/delete filesystem-backed documents under `public/uploads/documents`.  
- Restored full-armory export end-to-end: `src/lib/exports/full-armory.ts` + `src/lib/exports/full-armory-fields.ts`, an API at `/api/exports/full-armory` supporting CSV/JSON and field selection, and a UI at `/exports/full-armory`.  
- Relaxed required-field handling in APIs and forms: firearm/accessory POST now only enforces `name` in the API and client forms, and APIs normalize/fallback other values (e.g. `Unknown`, `UNSPECIFIED`, generated serial) so no schema migrations were needed.  
- Key files changed/added: `src/components/shared/ImagePicker.tsx`, `src/components/shared/DocumentUploader.tsx`, `src/app/documents/page.tsx`, `src/app/api/documents/*`, `src/app/api/images/library/route.ts`, `src/lib/exports/*`, `src/app/api/exports/full-armory/route.ts`, plus edits to firearm/accessory APIs and create/edit pages to wire the UI.  

### Testing
- Ran `npm run lint`; linter reported pre-existing unrelated errors in `src/app/ammo/page.tsx` and `src/components/layout/ThemeProvider.tsx` that are not introduced by this change (lint exited with errors).  
- Ran `npm run build`; build failed in this environment due to a TLS/font fetch issue for Google Fonts during Next.js/Turbopack (environmental, not code-related).  
- Attempted `docker compose build`, `docker compose up -d`, and `docker compose ps` in this environment and they failed because `docker` is not available here.  
- Manual verification steps implemented in code: image upload endpoints and document APIs use the project's `public/uploads` folders and the UI pages call those endpoints; firearm/accessory create+edit forms now surface the `ImagePicker` and only require `name` client-side.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c051be1e048326a89e53e5e8afd6f6)