### PR TITLE
Add password-mode session unlock/logout with signed cookie

### DIFF
--- a/src/app/api/session/logout/route.ts
+++ b/src/app/api/session/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { clearSessionCookie } from "@/lib/server/auth";
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  clearSessionCookie(response);
+  return response;
+}

--- a/src/app/api/session/unlock/route.ts
+++ b/src/app/api/session/unlock/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  SESSION_COOKIE_NAME,
+  createSessionCookieValue,
+  getSessionCookieOptions,
+} from "@/lib/server/auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const password = typeof body?.password === "string" ? body.password : "";
+
+    const settings = await prisma.appSettings.findUnique({
+      where: { id: "singleton" },
+      select: { appPassword: true },
+    });
+
+    const appPassword = settings?.appPassword ?? null;
+
+    if (!appPassword) {
+      return NextResponse.json({ ok: true, passwordRequired: false });
+    }
+
+    if (!password || password !== appPassword) {
+      return NextResponse.json(
+        { ok: false, error: "Invalid password" },
+        { status: 401 }
+      );
+    }
+
+    const response = NextResponse.json({ ok: true, passwordRequired: true });
+    response.cookies.set({
+      name: SESSION_COOKIE_NAME,
+      value: createSessionCookieValue(appPassword),
+      ...getSessionCookieOptions(),
+    });
+
+    return response;
+  } catch (error) {
+    console.error("POST /api/session/unlock error:", error);
+    return NextResponse.json(
+      { ok: false, error: "Failed to unlock session" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,17 +4,25 @@ import { Sidebar } from "@/components/layout/Sidebar";
 import { MobileHeader } from "@/components/layout/MobileHeader";
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
+import { UnlockScreen } from "@/components/auth/UnlockScreen";
+import { hasValidSessionCookie, isPasswordModeEnabled } from "@/lib/server/auth";
 
 export const metadata: Metadata = {
   title: "Project BlackVault",
   description: "Tactical firearm inventory & build management platform",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const [passwordModeEnabled, hasValidSession] = await Promise.all([
+    isPasswordModeEnabled(),
+    hasValidSessionCookie(),
+  ]);
+  const shouldShowUnlock = passwordModeEnabled && !hasValidSession;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -27,15 +35,19 @@ export default function RootLayout({
       </head>
       <body className="antialiased bg-vault-bg text-vault-text">
         <ThemeProvider>
-          <div className="flex h-screen overflow-hidden">
-            <Sidebar />
-            <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-              <MobileHeader />
-              <main className="flex-1 overflow-y-auto min-w-0">
-                {children}
-              </main>
+          {shouldShowUnlock ? (
+            <UnlockScreen />
+          ) : (
+            <div className="flex h-screen overflow-hidden">
+              <Sidebar passwordModeEnabled={passwordModeEnabled} />
+              <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+                <MobileHeader passwordModeEnabled={passwordModeEnabled} />
+                <main className="flex-1 overflow-y-auto min-w-0">
+                  {children}
+                </main>
+              </div>
             </div>
-          </div>
+          )}
           <ThemeToggle />
         </ThemeProvider>
       </body>

--- a/src/components/auth/UnlockScreen.tsx
+++ b/src/components/auth/UnlockScreen.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { Shield } from "lucide-react";
+
+export function UnlockScreen() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleUnlock(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const response = await fetch("/api/session/unlock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        setError("Incorrect password. Please try again.");
+        return;
+      }
+
+      sessionStorage.setItem("blackvault-unlocked", "1");
+      window.location.href = "/";
+    } catch {
+      setError("Unable to unlock right now. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-vault-bg text-vault-text flex items-center justify-center p-6">
+      <div className="w-full max-w-sm rounded-lg border border-vault-border bg-vault-surface p-6 shadow-lg">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-9 h-9 rounded bg-[#00C2FF]/10 border border-[#00C2FF]/30 flex items-center justify-center shrink-0">
+            <Shield className="w-5 h-5 text-[#00C2FF]" />
+          </div>
+          <div>
+            <p className="text-xs font-bold text-vault-text tracking-widest uppercase leading-none">
+              BlackVault Locked
+            </p>
+            <p className="text-[11px] text-vault-text-faint tracking-wider uppercase mt-1">
+              Enter app password
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={handleUnlock} className="space-y-3">
+          <label className="block text-xs uppercase tracking-wider text-vault-text-faint">
+            Password
+          </label>
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-vault-border bg-vault-bg text-sm focus:outline-none focus:ring-2 focus:ring-[#00C2FF]/40"
+            autoFocus
+            required
+          />
+
+          {error && <p className="text-xs text-red-400">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full py-2 rounded-md bg-[#00C2FF]/15 border border-[#00C2FF]/40 text-[#00C2FF] text-sm font-medium hover:bg-[#00C2FF]/20 transition-colors disabled:opacity-60"
+          >
+            {submitting ? "Unlocking..." : "Unlock"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,11 +1,33 @@
 "use client";
 
 import { useState } from "react";
-import { Shield, Menu } from "lucide-react";
+import { Shield, Menu, LogOut } from "lucide-react";
 import { Sidebar } from "./Sidebar";
 
-export function MobileHeader() {
+interface MobileHeaderProps {
+  passwordModeEnabled?: boolean;
+}
+
+export function MobileHeader({ passwordModeEnabled = false }: MobileHeaderProps) {
   const [open, setOpen] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  async function handleLogout() {
+    if (loggingOut) return;
+    setLoggingOut(true);
+
+    try {
+      await fetch("/api/session/logout", {
+        method: "POST",
+        cache: "no-store",
+      });
+    } finally {
+      sessionStorage.clear();
+      sessionStorage.removeItem("blackvault-unlocked");
+      localStorage.removeItem("blackvault-unlocked");
+      window.location.href = "/";
+    }
+  }
 
   return (
     <>
@@ -25,8 +47,23 @@ export function MobileHeader() {
             BlackVault
           </p>
         </div>
+        {passwordModeEnabled && (
+          <button
+            onClick={handleLogout}
+            disabled={loggingOut}
+            className="ml-auto p-1.5 text-vault-text-faint hover:text-vault-text-muted transition-colors disabled:opacity-60"
+            aria-label="Logout"
+          >
+            <LogOut className="w-4 h-4" />
+          </button>
+        )}
       </header>
-      <Sidebar mobileOnly mobileOpen={open} onMobileClose={() => setOpen(false)} />
+      <Sidebar
+        mobileOnly
+        mobileOpen={open}
+        onMobileClose={() => setOpen(false)}
+        passwordModeEnabled={passwordModeEnabled}
+      />
     </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   Zap,
   X,
+  LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useEffect } from "react";
@@ -66,20 +67,40 @@ interface SidebarProps {
   mobileOnly?: boolean;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
+  passwordModeEnabled?: boolean;
 }
 
 export function Sidebar({
   mobileOnly = false,
   mobileOpen = false,
   onMobileClose,
+  passwordModeEnabled = false,
 }: SidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
 
   // Close mobile menu on route change
   useEffect(() => {
     onMobileClose?.();
   }, [pathname, onMobileClose]);
+
+  async function handleLogout() {
+    if (loggingOut) return;
+    setLoggingOut(true);
+
+    try {
+      await fetch("/api/session/logout", {
+        method: "POST",
+        cache: "no-store",
+      });
+    } finally {
+      sessionStorage.clear();
+      sessionStorage.removeItem("blackvault-unlocked");
+      localStorage.removeItem("blackvault-unlocked");
+      window.location.href = "/";
+    }
+  }
 
   const navContent = (
     <>
@@ -149,11 +170,27 @@ export function Sidebar({
         })}
       </nav>
 
-      {/* Collapse toggle — desktop only */}
-      <div className="hidden md:block px-2 pb-3 shrink-0 border-t border-vault-border pt-2">
+      <div className="px-2 pb-3 shrink-0 border-t border-vault-border pt-2 space-y-1.5">
+        {passwordModeEnabled && (
+          <button
+            onClick={handleLogout}
+            disabled={loggingOut}
+            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors disabled:opacity-60"
+            title={collapsed ? "Logout" : undefined}
+          >
+            <LogOut className="w-4 h-4 shrink-0" />
+            {!collapsed && (
+              <span className="text-xs tracking-wider uppercase">
+                {loggingOut ? "Logging Out..." : "Logout"}
+              </span>
+            )}
+          </button>
+        )}
+
+        {/* Collapse toggle — desktop only */}
         <button
           onClick={() => setCollapsed(!collapsed)}
-          className="w-full flex items-center justify-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors"
+          className="hidden md:flex w-full items-center justify-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors"
         >
           {collapsed ? (
             <ChevronRight className="w-4 h-4" />

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,6 +1,97 @@
-import type { NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
 
-// Auth is intentionally stubbed for now; always allow.
+export const SESSION_COOKIE_NAME = "blackvault_session";
+
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
+
+function getSessionSigningSecret() {
+  return (
+    process.env.BLACKVAULT_SESSION_SECRET ??
+    process.env.VAULT_ENCRYPTION_KEY ??
+    process.env.NEXTAUTH_SECRET ??
+    "blackvault-dev-session-secret"
+  );
+}
+
+function buildSessionSignature(appPassword: string) {
+  return createHmac("sha256", getSessionSigningSecret())
+    .update(appPassword)
+    .digest("hex");
+}
+
+async function getAppPassword() {
+  const settings = await prisma.appSettings.findUnique({
+    where: { id: "singleton" },
+    select: { appPassword: true },
+  });
+
+  return settings?.appPassword ?? null;
+}
+
+export function getSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  };
+}
+
+export function createSessionCookieValue(appPassword: string) {
+  return buildSessionSignature(appPassword);
+}
+
+export function clearSessionCookie(response: NextResponse) {
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    ...getSessionCookieOptions(),
+    maxAge: 0,
+  });
+}
+
+export async function isPasswordModeEnabled() {
+  return Boolean(await getAppPassword());
+}
+
+export async function hasValidSessionCookie() {
+  const appPassword = await getAppPassword();
+  if (!appPassword) return true;
+
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  if (!sessionCookie) return false;
+
+  const expected = createSessionCookieValue(appPassword);
+  const expectedBuffer = Buffer.from(expected);
+  const actualBuffer = Buffer.from(sessionCookie);
+
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+}
+
 export async function requireAuth(): Promise<NextResponse | null> {
-  return null;
+  const appPassword = await getAppPassword();
+  if (!appPassword) {
+    return null;
+  }
+
+  const sessionIsValid = await hasValidSessionCookie();
+  if (sessionIsValid) {
+    return null;
+  }
+
+  const response = NextResponse.json(
+    { error: "Unauthorized" },
+    { status: 401 }
+  );
+  clearSessionCookie(response);
+  return response;
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal session mechanism that lets the app be password-locked via `AppSettings.appPassword` while keeping most of the app and APIs intact when no password is set.
- Allow unlocking the UI and protecting server API endpoints with a simple signed cookie rather than a full auth system.

### Description
- Implemented HMAC-based session helpers in `src/lib/server/auth.ts` including `createSessionCookieValue`, `clearSessionCookie`, `hasValidSessionCookie`, `isPasswordModeEnabled`, and updated `requireAuth()` to only enforce when `AppSettings.appPassword` is present.
- Added `POST /api/session/unlock` and `POST /api/session/logout` routes in `src/app/api/session/unlock/route.ts` and `src/app/api/session/logout/route.ts` to validate the app password, set the signed `blackvault_session` cookie, and clear it on logout.
- Updated the root layout (`src/app/layout.tsx`) to check password-mode and session validity server-side and render a new unlock view when locked.
- Added a client `UnlockScreen` component (`src/components/auth/UnlockScreen.tsx`) for submitting the password, and exposed Logout actions in the desktop `Sidebar` and mobile `MobileHeader` that call the logout API, clear client-side state, and redirect to the unlock gate.

### Testing
- Ran `npx eslint` against the modified files (`src/lib/server/auth.ts`, `src/app/api/session/unlock/route.ts`, `src/app/api/session/logout/route.ts`, `src/app/layout.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/MobileHeader.tsx`, `src/components/auth/UnlockScreen.tsx`) which completed for the changed files.
- Ran `npm run lint` for the repository which failed due to pre-existing lint issues unrelated to this change (existing `no-explicit-any` and React effect warnings); the failures are not caused by the new password-session changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d5ae8ac8326baed4955065086cb)