### PR TITLE
Add item document panel and secure upload handling; extend full-armory export with ammo and backup manifest

### DIFF
--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
+import { ItemDocumentPanel } from "@/components/shared/ItemDocumentPanel";
 import {
   ArrowLeft,
   Shield,
@@ -363,6 +364,12 @@ export default function AccessoryDetailPage() {
             </p>
           </div>
         )}
+
+        <ItemDocumentPanel
+          entityType="accessory"
+          entityId={accessory.id}
+          title="Accessory Documents"
+        />
 
         {/* Round Count History */}
         <div>

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,9 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/server/auth";
+import { resolveDocumentStoragePath } from "@/lib/upload-security";
 
 function isNotFoundError(error: unknown): boolean {
   return typeof error === "object" && error !== null && (error as { code?: string }).code === "P2025";
+}
+
+async function deleteFileIfSafe(fileUrl: string | null | undefined) {
+  if (!fileUrl) return;
+
+  const filePath = resolveDocumentStoragePath(fileUrl);
+  if (!filePath) {
+    console.warn("Skipping unsafe document file deletion:", fileUrl);
+    return;
+  }
+
+  try {
+    const stat = await fs.lstat(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return;
+    }
+    await fs.unlink(filePath);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
 }
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -65,7 +89,18 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
 
   try {
     const { id } = await params;
+    const doc = await (prisma as any).document.findUnique({
+      where: { id },
+      select: { id: true, fileUrl: true },
+    });
+
+    if (!doc) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await deleteFileIfSafe(doc.fileUrl);
     await (prisma as any).document.delete({ where: { id } });
+
     return NextResponse.json({ success: true });
   } catch (error) {
     if (isNotFoundError(error)) return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -6,6 +6,7 @@ import { detectFileSignature } from "@/lib/server/file-signatures";
 import { enforceRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/server/client-ip";
 import { requireAuth } from "@/lib/server/auth";
+import { getCanonicalUploadsRoot } from "@/lib/upload-security";
 
 const ALLOWED_EXTENSIONS = new Set(["pdf", "jpg", "png", "webp"]);
 
@@ -67,8 +68,7 @@ export async function POST(request: NextRequest) {
     const fileName = `${fileId}.${detected.extension}`;
     const relativeUrl = `/api/files/documents/${fileName}`;
 
-    const projectRoot = process.cwd();
-    const uploadDir = path.join(projectRoot, "storage", "uploads", "documents");
+    const uploadDir = path.join(getCanonicalUploadsRoot(), "documents");
     const filePath = path.join(uploadDir, fileName);
 
     await fs.mkdir(uploadDir, { recursive: true });

--- a/src/app/api/exports/full-armory/route.test.ts
+++ b/src/app/api/exports/full-armory/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   findFirearms: vi.fn(),
   findAccessories: vi.fn(),
   findDocuments: vi.fn(),
+  findAmmoStocks: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -17,6 +18,9 @@ vi.mock("@/lib/prisma", () => ({
     },
     accessory: {
       findMany: mocks.findAccessories,
+    },
+    ammoStock: {
+      findMany: mocks.findAmmoStocks,
     },
     document: {
       findMany: mocks.findDocuments,
@@ -43,7 +47,7 @@ describe("GET /api/exports/full-armory", () => {
         purchasePrice: 1200,
         currentValue: 1450,
         notes: "Primary",
-        imageUrl: "/api/files/documents/firearm-photo.jpg",
+        imageUrl: "/api/files/images/firearms/firearm-1.jpg",
       },
     ]);
 
@@ -90,9 +94,15 @@ describe("GET /api/exports/full-armory", () => {
         createdAt: new Date("2025-02-03T10:00:00.000Z"),
       },
     ]);
+
+    mocks.findAmmoStocks.mockResolvedValue([
+      { id: "ammo-1", caliber: "5.56", quantity: 300 },
+      { id: "ammo-2", caliber: "5.56", quantity: 200 },
+      { id: "ammo-3", caliber: "9mm", quantity: 120 },
+    ]);
   });
 
-  it("keeps claims semantics and includes image URLs in item rows", async () => {
+  it("keeps claims semantics and includes image/doc rows", async () => {
     const request = new NextRequest("http://localhost/api/exports/full-armory?preset=CLAIMS");
     const response = await GET(request);
     const json = await response.json();
@@ -100,16 +110,20 @@ describe("GET /api/exports/full-armory", () => {
     expect(response.status).toBe(200);
     expect(json.meta.preset).toBe("CLAIMS");
     expect(json.items[0].serialNumber).toBe("ABC123456");
-    expect(json.items[0].imageUrl).toBe("/api/files/documents/firearm-photo.jpg");
+    expect(json.items[0].imageUrl).toBe("/api/files/images/firearms/firearm-1.jpg");
     expect(json.summary.totalItems).toBe(2);
     expect(json.summary.totalReceipts).toBe(2);
     expect(json.csv.inventoryItems).toContain("imageUrl");
     expect(json.csv.attachmentsIndex).toContain("Accessory Receipt PDF");
+    expect(json.ammoSummary).toEqual([
+      { caliber: "5.56", totalRounds: 500, stockEntries: 2 },
+      { caliber: "9mm", totalRounds: 120, stockEntries: 1 },
+    ]);
   });
 
-  it("parses export options and masks serials for backup preset", async () => {
+  it("parses include options and creates backup file references", async () => {
     const request = new NextRequest(
-      "http://localhost/api/exports/full-armory?preset=BACKUP&includePhotos=false&includeReceipts=0&imageMode=ALL_IMAGES"
+      "http://localhost/api/exports/full-armory?preset=BACKUP&includeSerialNumbers=false&includeDocuments=false&includeImages=false&includeAmmo=false&includeValue=false&imageMode=ALL_IMAGES"
     );
     const response = await GET(request);
     const json = await response.json();
@@ -118,10 +132,31 @@ describe("GET /api/exports/full-armory", () => {
     expect(json.meta.preset).toBe("BACKUP");
     expect(json.meta.exportOptions).toEqual({
       preset: "BACKUP",
+      includeSerialNumbers: false,
+      includeAmmo: false,
+      includeValue: false,
+      includeImages: false,
+      includeDocuments: false,
       includePhotos: false,
       includeReceipts: false,
       imageMode: "ALL_IMAGES",
     });
-    expect(json.items[0].serialNumber).toMatch(/\*+3456$/);
+    expect(json.items[0].serialNumber).toBe("");
+    expect(json.items[0].purchasePrice).toBeNull();
+    expect(json.items[0].imageUrl).toBe("");
+    expect(json.attachments).toEqual([]);
+    expect(json.ammoSummary).toEqual([]);
+    expect(json.backupFiles).toEqual([]);
+  });
+
+  it("includes backup manifest rows for safe file URLs", async () => {
+    const request = new NextRequest("http://localhost/api/exports/full-armory?preset=BACKUP");
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.backupFiles.length).toBe(3);
+    expect(json.backupFiles[0].storagePath).toContain("storage/uploads/documents/");
+    expect(json.backupFiles.some((row: { category: string; storagePath: string }) => row.category === "IMAGE" && row.storagePath.includes("storage/uploads/images/firearms"))).toBe(true);
   });
 });

--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import path from "path";
 import { prisma } from "@/lib/prisma";
 import {
   type ExportPreset,
   parseExportOptionsFromSearchParams,
 } from "@/lib/exports/full-armory";
+import { getCanonicalUploadsRoot, resolveDocumentStoragePath } from "@/lib/upload-security";
 import { requireAuth } from "@/lib/server/auth";
 
 function csvEscape(value: unknown): string {
@@ -36,6 +38,19 @@ function maskSerial(serialNumber: string | null | undefined): string {
   return `${"*".repeat(Math.max(serialNumber.length - 4, 3))}${serialNumber.slice(-4)}`;
 }
 
+function toSafeBasename(fileUrl: string): string | null {
+  const value = fileUrl.trim();
+  const prefix = "/api/files/images/";
+  if (!value.startsWith(prefix)) return null;
+
+  const rest = value.slice(prefix.length);
+  const segments = rest.split("/").filter(Boolean);
+  if (segments.length < 2) return null;
+  if (!segments.every((seg) => /^[a-zA-Z0-9._-]+$/.test(seg))) return null;
+
+  return path.join("images", ...segments);
+}
+
 export async function GET(request: NextRequest) {
   const auth = await requireAuth();
   if (auth) return auth;
@@ -44,17 +59,24 @@ export async function GET(request: NextRequest) {
     const exportOptions = parseExportOptionsFromSearchParams(request.nextUrl.searchParams);
     const preset: ExportPreset = exportOptions.preset;
 
-    const [firearms, accessories, documents] = await Promise.all([
+    const [firearms, accessories, documents, ammoStocks] = await Promise.all([
       prisma.firearm.findMany({ orderBy: [{ manufacturer: "asc" }, { model: "asc" }, { name: "asc" }] }),
       prisma.accessory.findMany({ orderBy: [{ manufacturer: "asc" }, { name: "asc" }] }),
-      (prisma as any).document.findMany({
-        orderBy: [{ createdAt: "asc" }],
-        include: {
-          firearm: { select: { id: true, name: true } },
-          accessory: { select: { id: true, name: true } },
-        },
-      }),
-    ]) as [any[], any[], any[]];
+      exportOptions.includeDocuments
+        ? (prisma as any).document.findMany({
+            orderBy: [{ createdAt: "asc" }],
+            include: {
+              firearm: { select: { id: true, name: true } },
+              accessory: { select: { id: true, name: true } },
+            },
+          })
+        : Promise.resolve([]),
+      exportOptions.includeAmmo
+        ? prisma.ammoStock.findMany({
+            orderBy: [{ caliber: "asc" }, { brand: "asc" }],
+          })
+        : Promise.resolve([]),
+    ]) as [any[], any[], any[], any[]];
 
     const receiptDocuments = documents.filter((doc: any) => doc.type === "RECEIPT");
 
@@ -62,7 +84,12 @@ export async function GET(request: NextRequest) {
       ...firearms.map((firearm: any) => {
         const itemDocs = documents.filter((doc: any) => doc.firearmId === firearm.id);
         const receiptCount = itemDocs.filter((doc: any) => doc.type === "RECEIPT").length;
-        const hasPhoto = !!firearm.imageUrl;
+        const hasPhoto = exportOptions.includeImages ? !!firearm.imageUrl : false;
+        const serialValue = !exportOptions.includeSerialNumbers
+          ? ""
+          : preset === "BACKUP"
+          ? maskSerial(firearm.serialNumber)
+          : (firearm.serialNumber ?? "");
 
         return {
           itemId: firearm.id,
@@ -71,26 +98,26 @@ export async function GET(request: NextRequest) {
           manufacturer: firearm.manufacturer || "",
           model: firearm.model || firearm.name,
           caliber: firearm.caliber || "",
-          serialNumber: preset === "BACKUP" ? maskSerial(firearm.serialNumber) : (firearm.serialNumber ?? ""),
+          serialNumber: serialValue,
           hasSerial: !!firearm.serialNumber,
           purchaseDate: formatDate(firearm.acquisitionDate),
-          purchasePrice: firearm.purchasePrice ?? null,
-          replacementValue: firearm.currentValue ?? null,
-          receiptCount,
-          documentCount: itemDocs.length,
+          purchasePrice: exportOptions.includeValue ? firearm.purchasePrice ?? null : null,
+          replacementValue: exportOptions.includeValue ? firearm.currentValue ?? null : null,
+          receiptCount: exportOptions.includeDocuments ? receiptCount : 0,
+          documentCount: exportOptions.includeDocuments ? itemDocs.length : 0,
           hasPhoto,
-          imageUrl: firearm.imageUrl ?? "",
-          missingSerial: !firearm.serialNumber,
-          missingReceipt: receiptCount === 0,
-          missingPhoto: !hasPhoto,
-          missingValue: firearm.currentValue == null && firearm.purchasePrice == null,
+          imageUrl: exportOptions.includeImages ? firearm.imageUrl ?? "" : "",
+          missingSerial: exportOptions.includeSerialNumbers ? !firearm.serialNumber : false,
+          missingReceipt: exportOptions.includeDocuments ? receiptCount === 0 : false,
+          missingPhoto: exportOptions.includeImages ? !hasPhoto : false,
+          missingValue: exportOptions.includeValue ? firearm.currentValue == null && firearm.purchasePrice == null : false,
           notes: firearm.notes ?? "",
         };
       }),
       ...accessories.map((accessory: any) => {
         const itemDocs = documents.filter((doc: any) => doc.accessoryId === accessory.id);
         const receiptCount = itemDocs.filter((doc: any) => doc.type === "RECEIPT").length;
-        const hasPhoto = !!accessory.imageUrl;
+        const hasPhoto = exportOptions.includeImages ? !!accessory.imageUrl : false;
 
         return {
           itemId: accessory.id,
@@ -102,33 +129,84 @@ export async function GET(request: NextRequest) {
           serialNumber: "",
           hasSerial: false,
           purchaseDate: formatDate(accessory.acquisitionDate),
-          purchasePrice: accessory.purchasePrice ?? null,
+          purchasePrice: exportOptions.includeValue ? accessory.purchasePrice ?? null : null,
           replacementValue: null,
-          receiptCount,
-          documentCount: itemDocs.length,
+          receiptCount: exportOptions.includeDocuments ? receiptCount : 0,
+          documentCount: exportOptions.includeDocuments ? itemDocs.length : 0,
           hasPhoto,
-          imageUrl: accessory.imageUrl ?? "",
-          missingSerial: true,
-          missingReceipt: receiptCount === 0,
-          missingPhoto: !hasPhoto,
-          missingValue: accessory.purchasePrice == null,
+          imageUrl: exportOptions.includeImages ? accessory.imageUrl ?? "" : "",
+          missingSerial: false,
+          missingReceipt: exportOptions.includeDocuments ? receiptCount === 0 : false,
+          missingPhoto: exportOptions.includeImages ? !hasPhoto : false,
+          missingValue: exportOptions.includeValue ? accessory.purchasePrice == null : false,
           notes: accessory.notes ?? "",
         };
       }),
     ];
 
-    const attachmentsRows = documents.map((doc: any) => ({
-      documentId: doc.id,
-      type: doc.type,
-      name: doc.name,
-      linkedItemId: doc.firearmId || doc.accessoryId || "",
-      linkedItemType: doc.firearmId ? "FIREARM" : doc.accessoryId ? "ACCESSORY" : "UNATTACHED",
-      linkedItemName: doc.firearm?.name || doc.accessory?.name || "",
-      mimeType: doc.mimeType ?? "",
-      fileSize: doc.fileSize ?? "",
-      fileUrl: doc.fileUrl,
-      uploadedAt: doc.createdAt.toISOString(),
+    const attachmentsRows = exportOptions.includeDocuments
+      ? documents.map((doc: any) => ({
+          documentId: doc.id,
+          type: doc.type,
+          name: doc.name,
+          linkedItemId: doc.firearmId || doc.accessoryId || "",
+          linkedItemType: doc.firearmId ? "FIREARM" : doc.accessoryId ? "ACCESSORY" : "UNATTACHED",
+          linkedItemName: doc.firearm?.name || doc.accessory?.name || "",
+          mimeType: doc.mimeType ?? "",
+          fileSize: doc.fileSize ?? "",
+          fileUrl: doc.fileUrl,
+          uploadedAt: doc.createdAt.toISOString(),
+        }))
+      : [];
+
+    const ammoByCaliber = new Map<string, { totalRounds: number; stockEntries: number }>();
+    for (const stock of ammoStocks) {
+      const caliber = stock.caliber || "Unknown";
+      const entry = ammoByCaliber.get(caliber) ?? { totalRounds: 0, stockEntries: 0 };
+      entry.totalRounds += Number(stock.quantity ?? 0);
+      entry.stockEntries += 1;
+      ammoByCaliber.set(caliber, entry);
+    }
+
+    const ammoSummary = Array.from(ammoByCaliber.entries()).map(([caliber, value]) => ({
+      caliber,
+      totalRounds: value.totalRounds,
+      stockEntries: value.stockEntries,
     }));
+
+    const uploadsRoot = getCanonicalUploadsRoot();
+    const backupFiles = preset === "BACKUP"
+      ? [
+          ...attachmentsRows.map((row) => {
+            const resolved = resolveDocumentStoragePath(row.fileUrl);
+            if (!resolved) return null;
+            return {
+              category: "DOCUMENT",
+              fileUrl: row.fileUrl,
+              storagePath: resolved,
+              fileName: path.basename(resolved),
+              linkedItemId: row.linkedItemId,
+              linkedItemType: row.linkedItemType,
+              linkedItemName: row.linkedItemName,
+            };
+          }),
+          ...itemRows.map((item) => {
+            if (!item.imageUrl) return null;
+            const relativeImagePath = toSafeBasename(item.imageUrl);
+            if (!relativeImagePath) return null;
+            const resolved = path.resolve(uploadsRoot, relativeImagePath);
+            return {
+              category: "IMAGE",
+              fileUrl: item.imageUrl,
+              storagePath: resolved,
+              fileName: path.basename(resolved),
+              linkedItemId: item.itemId,
+              linkedItemType: item.entityType,
+              linkedItemName: `${item.manufacturer} ${item.model}`.trim(),
+            };
+          }),
+        ].filter(Boolean)
+      : [];
 
     const totalPurchaseValue = itemRows.reduce((sum, item) => sum + (typeof item.purchasePrice === "number" ? item.purchasePrice : 0), 0);
     const totalReplacementValue = itemRows.reduce((sum, item) => sum + (typeof item.replacementValue === "number" ? item.replacementValue : 0), 0);
@@ -156,11 +234,11 @@ export async function GET(request: NextRequest) {
       },
       {
         metric: "Total Documents",
-        value: documents.length,
+        value: attachmentsRows.length,
       },
       {
         metric: "Total Receipts",
-        value: receiptDocuments.length,
+        value: exportOptions.includeDocuments ? receiptDocuments.length : 0,
       },
       {
         metric: "Total Purchase Value",
@@ -186,21 +264,29 @@ export async function GET(request: NextRequest) {
         metric: "Items Missing Serial",
         value: itemRows.filter((i) => i.missingSerial).length,
       },
+      {
+        metric: "Total Ammo Rounds",
+        value: ammoSummary.reduce((sum, row) => sum + row.totalRounds, 0),
+      },
+      {
+        metric: "Backup File References",
+        value: backupFiles.length,
+      },
     ];
 
     return NextResponse.json({
       meta: {
         generatedAt: new Date().toISOString(),
         preset,
-        includesAllUploadedReceipts: true,
+        includesAllUploadedReceipts: exportOptions.includeDocuments,
         exportOptions,
       },
       summary: {
         totalItems: itemRows.length,
         totalFirearms: firearms.length,
         totalAccessories: accessories.length,
-        totalDocuments: documents.length,
-        totalReceipts: receiptDocuments.length,
+        totalDocuments: attachmentsRows.length,
+        totalReceipts: exportOptions.includeDocuments ? receiptDocuments.length : 0,
         totalPurchaseValue,
         totalReplacementValue,
         missingEvidence: {
@@ -212,10 +298,14 @@ export async function GET(request: NextRequest) {
       },
       items: itemRows,
       attachments: attachmentsRows,
+      ammoSummary,
+      backupFiles,
       csv: {
         inventoryItems: rowsToCsv(itemRows),
         attachmentsIndex: rowsToCsv(attachmentsRows),
         valuationSummary: rowsToCsv(summaryRows),
+        ammoSummary: rowsToCsv(ammoSummary),
+        backupFiles: rowsToCsv(backupFiles),
       },
     });
   } catch (error) {

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { DocumentUploader, type UploadedDocument } from "@/components/shared/DocumentUploader";
 
-type DocTypeFilter = "ALL" | "RECEIPT" | "NFA_TAX_STAMP" | "OTHER";
+type DocTypeFilter = "ALL" | "RECEIPT" | "PHOTO" | "NFA_TAX_STAMP" | "OTHER";
 type EntityFilter = "ALL" | "FIREARM" | "ACCESSORY" | "UNATTACHED";
 
 function formatBytes(bytes: number | null) {
@@ -107,7 +107,7 @@ export default function DocumentLibraryPage() {
 
           {/* Type filter */}
           <div className="flex gap-1.5 flex-wrap">
-            {(["ALL", "RECEIPT", "NFA_TAX_STAMP", "OTHER"] as DocTypeFilter[]).map((t) => (
+            {(["ALL", "RECEIPT", "PHOTO", "NFA_TAX_STAMP", "OTHER"] as DocTypeFilter[]).map((t) => (
               <button
                 key={t}
                 onClick={() => setTypeFilter(t)}
@@ -117,7 +117,7 @@ export default function DocumentLibraryPage() {
                     : "border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border"
                 }`}
               >
-                {t === "ALL" ? "All Types" : t === "NFA_TAX_STAMP" ? "NFA Stamps" : t === "RECEIPT" ? "Receipts" : "Other"}
+                {t === "ALL" ? "All Types" : t === "NFA_TAX_STAMP" ? "NFA Stamps" : t === "RECEIPT" ? "Receipts" : t === "PHOTO" ? "Photos" : "Other"}
               </button>
             ))}
           </div>
@@ -195,9 +195,11 @@ export default function DocumentLibraryPage() {
                           ? "border-[#F5A623]/30 text-[#F5A623]"
                           : doc.type === "RECEIPT"
                           ? "border-[#00C2FF]/30 text-[#00C2FF]"
+                          : doc.type === "PHOTO" || doc.mimeType?.startsWith("image/")
+                          ? "border-[#00C853]/30 text-[#00C853]"
                           : "border-vault-border text-vault-text-faint"
                       }`}>
-                        {doc.type === "NFA_TAX_STAMP" ? "NFA Tax Stamp" : doc.type === "RECEIPT" ? "Receipt" : "Other"}
+                        {doc.type === "NFA_TAX_STAMP" ? "NFA Tax Stamp" : doc.type === "RECEIPT" ? "Receipt" : doc.type === "PHOTO" || doc.mimeType?.startsWith("image/") ? "Photo" : "Other"}
                       </span>
                     </div>
                     <div className="flex items-center gap-3 mt-0.5 flex-wrap">

--- a/src/app/exports/full-armory/page.tsx
+++ b/src/app/exports/full-armory/page.tsx
@@ -1,31 +1,96 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { Download, Eye, FileText, Loader2 } from "lucide-react";
 import { PageHeader } from "@/components/shared/PageHeader";
-import { DEFAULT_EXPORT_FIELDS } from "@/lib/exports/full-armory-fields";
+import {
+  buildExportQueryString,
+  type FullArmoryExportOptions,
+  type FullArmoryExportResponse,
+} from "@/lib/exports/full-armory";
+import { generateFullArmoryPdf } from "@/lib/exports/full-armory-pdf";
+
+const DEFAULT_OPTIONS: FullArmoryExportOptions = {
+  preset: "CLAIMS",
+  includeSerialNumbers: true,
+  includeAmmo: true,
+  includeValue: true,
+  includeImages: true,
+  includeDocuments: true,
+  includePhotos: true,
+  includeReceipts: true,
+  imageMode: "PRIMARY_ONLY",
+};
+
+function downloadText(name: string, content: string, type = "text/plain;charset=utf-8") {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+  link.click();
+  URL.revokeObjectURL(url);
+}
 
 export default function FullArmoryExportPage() {
-  const [format, setFormat] = useState<"csv" | "json">("csv");
-  const [fields, setFields] = useState<string[]>([...DEFAULT_EXPORT_FIELDS]);
+  const [options, setOptions] = useState<FullArmoryExportOptions>(DEFAULT_OPTIONS);
   const [loading, setLoading] = useState(false);
 
-  async function runExport() {
+  const queryString = useMemo(() => buildExportQueryString(options), [options]);
+
+  function toggle<K extends keyof FullArmoryExportOptions>(key: K, value: FullArmoryExportOptions[K]) {
+    setOptions((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function fetchPacket(): Promise<FullArmoryExportResponse> {
+    const response = await fetch(`/api/exports/full-armory?${queryString}`);
+    const json = await response.json();
+    if (!response.ok) {
+      throw new Error(json.error ?? "Failed to generate export");
+    }
+    return json;
+  }
+
+  async function handleJsonDownload() {
     setLoading(true);
     try {
-      const res = await fetch("/api/exports/full-armory", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ format, fields }),
-      });
-      if (!res.ok) return;
+      const packet = await fetchPacket();
+      downloadText(
+        `full-armory-export-${packet.meta.generatedAt.replace(/[:.]/g, "-")}.json`,
+        JSON.stringify(packet, null, 2),
+        "application/json;charset=utf-8"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
 
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = format === "csv" ? "full-armory-export.csv" : "full-armory-export.json";
-      link.click();
-      URL.revokeObjectURL(url);
+  async function handleCsvDownload() {
+    setLoading(true);
+    try {
+      const packet = await fetchPacket();
+      const stamp = packet.meta.generatedAt.replace(/[:.]/g, "-");
+      downloadText(`full-armory-inventory-${stamp}.csv`, packet.csv.inventoryItems, "text/csv;charset=utf-8");
+      if (options.includeDocuments) {
+        downloadText(`full-armory-attachments-${stamp}.csv`, packet.csv.attachmentsIndex, "text/csv;charset=utf-8");
+      }
+      if (options.includeAmmo) {
+        downloadText(`full-armory-ammo-${stamp}.csv`, packet.csv.ammoSummary, "text/csv;charset=utf-8");
+      }
+      if (options.preset === "BACKUP") {
+        downloadText(`full-armory-backup-files-${stamp}.csv`, packet.csv.backupFiles, "text/csv;charset=utf-8");
+      }
+      downloadText(`full-armory-summary-${stamp}.csv`, packet.csv.valuationSummary, "text/csv;charset=utf-8");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handlePdfDownload() {
+    setLoading(true);
+    try {
+      const packet = await fetchPacket();
+      await generateFullArmoryPdf(packet, options);
     } finally {
       setLoading(false);
     }
@@ -33,48 +98,107 @@ export default function FullArmoryExportPage() {
 
   return (
     <div className="min-h-full">
-      <PageHeader title="FULL ARMORY EXPORT" subtitle="Choose fields and file format" />
-      <div className="p-6 space-y-6">
-        <div className="bg-vault-surface border border-vault-border rounded-lg p-4 space-y-4">
-          <div>
-            <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-2">File type</p>
-            <select value={format} onChange={(e) => setFormat(e.target.value as "csv" | "json")} className="bg-vault-bg border border-vault-border rounded px-3 py-2 text-sm text-vault-text">
-              <option value="csv">CSV</option>
-              <option value="json">JSON</option>
-            </select>
-          </div>
+      <PageHeader title="Full Armory Export" subtitle="V1 export packet with evidence and backup references." />
 
-          <div>
-            <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-2">Fields</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-              {DEFAULT_EXPORT_FIELDS.map((field) => {
-                const checked = fields.includes(field);
-                return (
-                  <label key={field} className="text-sm text-vault-text flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => {
-                        setFields((prev) =>
-                          e.target.checked ? [...prev, field] : prev.filter((f) => f !== field)
-                        );
-                      }}
-                    />
-                    {field}
-                  </label>
-                );
-              })}
+      <div className="p-6 max-w-4xl mx-auto space-y-5">
+        <div className="rounded-xl border border-vault-border bg-vault-surface p-5 space-y-5">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <label className="text-xs text-vault-text-muted space-y-1">
+              <span className="uppercase tracking-widest">Preset</span>
+              <select
+                value={options.preset}
+                onChange={(e) => toggle("preset", e.target.value === "BACKUP" ? "BACKUP" : "CLAIMS")}
+                className="w-full bg-vault-bg border border-vault-border rounded px-3 py-2 text-sm text-vault-text"
+              >
+                <option value="CLAIMS">Claims</option>
+                <option value="BACKUP">Backup</option>
+              </select>
+            </label>
+
+            <label className="text-xs text-vault-text-muted space-y-1">
+              <span className="uppercase tracking-widest">Image Appendix Mode</span>
+              <select
+                value={options.imageMode}
+                onChange={(e) => toggle("imageMode", e.target.value === "ALL_IMAGES" ? "ALL_IMAGES" : "PRIMARY_ONLY")}
+                className="w-full bg-vault-bg border border-vault-border rounded px-3 py-2 text-sm text-vault-text"
+                disabled={!options.includeImages}
+              >
+                <option value="PRIMARY_ONLY">Primary Only</option>
+                <option value="ALL_IMAGES">All Images</option>
+              </select>
+            </label>
+
+            <div className="text-xs text-vault-text-faint rounded-md border border-vault-border bg-vault-bg p-3">
+              <p className="uppercase tracking-widest mb-1">Preview Link</p>
+              <a href={`/exports/full-armory/preview?${queryString}`} className="text-[#00C2FF] hover:underline break-all">
+                /exports/full-armory/preview?{queryString}
+              </a>
             </div>
           </div>
 
-          <button
-            type="button"
-            onClick={runExport}
-            disabled={loading || fields.length === 0}
-            className="bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-60 px-4 py-2 rounded text-sm"
-          >
-            {loading ? "Exporting..." : "Export"}
-          </button>
+          <div>
+            <p className="text-xs uppercase tracking-widest text-vault-text-muted mb-2">Include In Export</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm">
+              {([
+                ["includeSerialNumbers", "Serial Numbers"],
+                ["includeAmmo", "Ammo"],
+                ["includeValue", "Value"],
+                ["includeImages", "Images"],
+                ["includeDocuments", "Documents"],
+                ["includePhotos", "Item Photos"],
+                ["includeReceipts", "Receipt Images"],
+              ] as Array<[
+                "includeSerialNumbers" | "includeAmmo" | "includeValue" | "includeImages" | "includeDocuments" | "includePhotos" | "includeReceipts",
+                string
+              ]>).map(([key, label]) => (
+                <label key={key} className="flex items-center gap-2 text-vault-text">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(options[key])}
+                    onChange={(e) => setOptions((prev) => ({ ...prev, [key]: e.target.checked }))}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <a
+              href={`/exports/full-armory/preview?${queryString}`}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-vault-border text-vault-text-muted hover:text-vault-text hover:bg-vault-bg text-sm"
+            >
+              <Eye className="w-4 h-4" />
+              Open Preview
+            </a>
+            <button
+              type="button"
+              onClick={handleJsonDownload}
+              disabled={loading}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] text-sm hover:bg-[#00C2FF]/20 disabled:opacity-50"
+            >
+              {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+              Download JSON
+            </button>
+            <button
+              type="button"
+              onClick={handleCsvDownload}
+              disabled={loading}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-[#00C853]/10 border border-[#00C853]/30 text-[#00C853] text-sm hover:bg-[#00C853]/20 disabled:opacity-50"
+            >
+              {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <FileText className="w-4 h-4" />}
+              Download CSV
+            </button>
+            <button
+              type="button"
+              onClick={handlePdfDownload}
+              disabled={loading}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-[#F5A623]/10 border border-[#F5A623]/30 text-[#F5A623] text-sm hover:bg-[#F5A623]/20 disabled:opacity-50"
+            >
+              {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <FileText className="w-4 h-4" />}
+              Generate PDF
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/exports/full-armory/preview/page.tsx
+++ b/src/app/exports/full-armory/preview/page.tsx
@@ -126,6 +126,13 @@ export default function FullArmoryPreviewPage() {
               <p className="font-semibold text-vault-text">{formatCurrency(data.summary.totalReplacementValue)}</p>
             </div>
           </div>
+          <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+            <span className="px-2 py-1 rounded border border-vault-border">Serials: {options.includeSerialNumbers ? "Included" : "Hidden"}</span>
+            <span className="px-2 py-1 rounded border border-vault-border">Ammo: {options.includeAmmo ? "Included" : "Excluded"}</span>
+            <span className="px-2 py-1 rounded border border-vault-border">Value: {options.includeValue ? "Included" : "Excluded"}</span>
+            <span className="px-2 py-1 rounded border border-vault-border">Images: {options.includeImages ? "Included" : "Excluded"}</span>
+            <span className="px-2 py-1 rounded border border-vault-border">Documents: {options.includeDocuments ? "Included" : "Excluded"}</span>
+          </div>
         </section>
 
         <section className="rounded-lg border border-vault-border bg-vault-surface p-5">
@@ -182,33 +189,61 @@ export default function FullArmoryPreviewPage() {
           </div>
         </section>
 
-        <section className="rounded-lg border border-vault-border bg-vault-surface p-5">
-          <h2 className="text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Document Index</h2>
-          <div className="mt-3 overflow-x-auto">
-            <table className="w-full text-xs border-collapse">
-              <thead>
-                <tr className="border-b border-vault-border text-vault-text-faint">
-                  <th className="py-2 text-left">Type</th>
-                  <th className="py-2 text-left">Name</th>
-                  <th className="py-2 text-left">Linked Item</th>
-                  <th className="py-2 text-left">Mime</th>
-                  <th className="py-2 text-left">Uploaded</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.attachments.map((row) => (
-                  <tr key={row.documentId} className="border-b border-vault-border/60">
-                    <td className="py-2">{row.type}</td>
-                    <td className="py-2">{row.name}</td>
-                    <td className="py-2">{row.linkedItemName || row.linkedItemType}</td>
-                    <td className="py-2">{row.mimeType || "—"}</td>
-                    <td className="py-2">{formatDate(row.uploadedAt)}</td>
+        {options.includeDocuments && (
+          <section className="rounded-lg border border-vault-border bg-vault-surface p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Document Index</h2>
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full text-xs border-collapse">
+                <thead>
+                  <tr className="border-b border-vault-border text-vault-text-faint">
+                    <th className="py-2 text-left">Type</th>
+                    <th className="py-2 text-left">Name</th>
+                    <th className="py-2 text-left">Linked Item</th>
+                    <th className="py-2 text-left">Mime</th>
+                    <th className="py-2 text-left">Uploaded</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
+                </thead>
+                <tbody>
+                  {data.attachments.map((row) => (
+                    <tr key={row.documentId} className="border-b border-vault-border/60">
+                      <td className="py-2">{row.type}</td>
+                      <td className="py-2">{row.name}</td>
+                      <td className="py-2">{row.linkedItemName || row.linkedItemType}</td>
+                      <td className="py-2">{row.mimeType || "—"}</td>
+                      <td className="py-2">{formatDate(row.uploadedAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {options.includeAmmo && data.ammoSummary.length > 0 && (
+          <section className="rounded-lg border border-vault-border bg-vault-surface p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-vault-text-muted">Ammo Summary</h2>
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full text-xs border-collapse">
+                <thead>
+                  <tr className="border-b border-vault-border text-vault-text-faint">
+                    <th className="py-2 text-left">Caliber</th>
+                    <th className="py-2 text-right">Rounds</th>
+                    <th className="py-2 text-right">Entries</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.ammoSummary.map((row) => (
+                    <tr key={row.caliber} className="border-b border-vault-border/60">
+                      <td className="py-2">{row.caliber}</td>
+                      <td className="py-2 text-right">{row.totalRounds.toLocaleString()}</td>
+                      <td className="py-2 text-right">{row.stockEntries}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
         {visuals.length > 0 && (
           <section className="rounded-lg border border-vault-border bg-vault-surface p-5 armory-page-break">

--- a/src/app/vault/[id]/page.tsx
+++ b/src/app/vault/[id]/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import { ItemDocumentPanel } from "@/components/shared/ItemDocumentPanel";
 import {
   ArrowLeft,
   Edit,
@@ -93,7 +94,6 @@ export default async function FirearmDetailPage({
     notFound();
   }
 
-  const activeBuild = firearm.builds.find((b) => b.isActive) ?? null;
   const typeBadge = TYPE_BADGE_COLORS[firearm.type] ?? "border-vault-border text-vault-text-muted";
   const typeLabel = FIREARM_TYPE_LABELS[firearm.type] ?? firearm.type;
 
@@ -224,6 +224,12 @@ export default async function FirearmDetailPage({
             <p className="text-sm text-vault-text leading-relaxed whitespace-pre-wrap">{firearm.notes}</p>
           </div>
         )}
+
+        <ItemDocumentPanel
+          entityType="firearm"
+          entityId={firearm.id}
+          title="Firearm Documents"
+        />
 
         {/* Builds Section */}
         <div>

--- a/src/components/shared/DocumentUploader.tsx
+++ b/src/components/shared/DocumentUploader.tsx
@@ -21,13 +21,14 @@ export interface UploadedDocument {
 interface DocumentUploaderProps {
   entityType?: "firearm" | "accessory" | null;
   entityId?: string | null;
-  defaultDocType?: "RECEIPT" | "NFA_TAX_STAMP" | "OTHER";
+  defaultDocType?: "RECEIPT" | "PHOTO" | "NFA_TAX_STAMP" | "OTHER";
   onUploadComplete: (doc: UploadedDocument) => void;
   onCancel?: () => void;
 }
 
 const DOC_TYPES = [
   { value: "RECEIPT", label: "Receipt" },
+  { value: "PHOTO", label: "Photo" },
   { value: "NFA_TAX_STAMP", label: "NFA Tax Stamp" },
   { value: "OTHER", label: "Other" },
 ] as const;
@@ -51,7 +52,7 @@ export function DocumentUploader({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [docName, setDocName] = useState("");
-  const [docType, setDocType] = useState<"RECEIPT" | "NFA_TAX_STAMP" | "OTHER">(defaultDocType);
+  const [docType, setDocType] = useState<"RECEIPT" | "PHOTO" | "NFA_TAX_STAMP" | "OTHER">(defaultDocType);
   const [notes, setNotes] = useState("");
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/shared/ItemDocumentPanel.tsx
+++ b/src/components/shared/ItemDocumentPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, FileText, Trash2, Upload, X } from "lucide-react";
+import { DocumentUploader, type UploadedDocument } from "@/components/shared/DocumentUploader";
+
+interface ItemDocumentPanelProps {
+  entityType: "firearm" | "accessory";
+  entityId: string;
+  title?: string;
+}
+
+type DisplayTag = {
+  label: string;
+  className: string;
+};
+
+function formatBytes(bytes: number | null) {
+  if (!bytes) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function tagForDocument(doc: UploadedDocument): DisplayTag {
+  if (doc.type === "RECEIPT") {
+    return { label: "Receipt", className: "border-[#00C2FF]/30 text-[#00C2FF]" };
+  }
+  if (doc.type === "NFA_TAX_STAMP") {
+    return { label: "Tax Stamp", className: "border-[#F5A623]/30 text-[#F5A623]" };
+  }
+  if (doc.type === "PHOTO" || doc.mimeType?.startsWith("image/")) {
+    return { label: "Photo", className: "border-[#00C853]/30 text-[#00C853]" };
+  }
+  return { label: "Other", className: "border-vault-border text-vault-text-faint" };
+}
+
+export function ItemDocumentPanel({ entityType, entityId, title = "Documents" }: ItemDocumentPanelProps) {
+  const [documents, setDocuments] = useState<UploadedDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showUploader, setShowUploader] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const query = entityType === "firearm" ? `firearmId=${entityId}` : `accessoryId=${entityId}`;
+    fetch(`/api/documents?${query}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setDocuments(data);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [entityId, entityType]);
+
+  async function handleDelete(id: string) {
+    if (!confirm("Delete this document?")) return;
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/documents/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        alert(json?.error ?? "Failed to delete document");
+        return;
+      }
+      setDocuments((prev) => prev.filter((d) => d.id !== id));
+    } catch {
+      alert("Network error — could not delete document");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const emptyText = useMemo(() => {
+    if (entityType === "firearm") {
+      return "No docs attached yet. Upload receipts, photos, and tax stamps directly on this firearm.";
+    }
+    return "No docs attached yet. Upload receipts, photos, and tax stamps directly on this accessory.";
+  }, [entityType]);
+
+  return (
+    <div className="rounded-xl border border-vault-border bg-vault-surface overflow-hidden">
+      <div className="px-4 py-3 border-b border-vault-border flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-vault-text">{title}</h3>
+          <p className="text-xs text-vault-text-faint">{documents.length} attached</p>
+        </div>
+        <button
+          onClick={() => setShowUploader((v) => !v)}
+          className="flex items-center gap-1.5 text-xs bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-2.5 py-1.5 rounded transition-colors"
+        >
+          {showUploader ? <X className="w-3.5 h-3.5" /> : <Upload className="w-3.5 h-3.5" />}
+          {showUploader ? "Close" : "Upload"}
+        </button>
+      </div>
+
+      {showUploader && (
+        <div className="p-4 border-b border-vault-border bg-vault-bg/50">
+          <DocumentUploader
+            entityType={entityType}
+            entityId={entityId}
+            defaultDocType="RECEIPT"
+            onUploadComplete={(doc) => {
+              setDocuments((prev) => [doc, ...prev]);
+              setShowUploader(false);
+            }}
+            onCancel={() => setShowUploader(false)}
+          />
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-8 flex justify-center">
+          <div className="w-5 h-5 border-2 border-[#00C2FF]/30 border-t-[#00C2FF] rounded-full animate-spin" />
+        </div>
+      ) : documents.length === 0 ? (
+        <div className="p-6 text-center">
+          <FileText className="w-8 h-8 text-vault-border mx-auto mb-2" />
+          <p className="text-xs text-vault-text-faint">{emptyText}</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-vault-border">
+          {documents.map((doc) => {
+            const tag = tagForDocument(doc);
+            return (
+              <div key={doc.id} className="px-4 py-3 flex items-start gap-3 group hover:bg-vault-border/20 transition-colors">
+                <div className="w-9 h-9 rounded-md border border-vault-border bg-vault-bg flex items-center justify-center shrink-0">
+                  <FileText className="w-4 h-4 text-vault-text-muted" />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm text-vault-text font-medium truncate">{doc.name}</p>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono ${tag.className}`}>
+                      {tag.label}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 text-xs text-vault-text-faint flex-wrap">
+                    <span>{new Date(doc.createdAt).toLocaleDateString()}</span>
+                    {doc.fileSize ? <span>{formatBytes(doc.fileSize)}</span> : null}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <a
+                    href={doc.fileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 px-2 py-1 rounded border border-vault-border text-xs text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 transition-colors"
+                  >
+                    <ExternalLink className="w-3.5 h-3.5" />
+                    Open
+                  </a>
+                  <button
+                    onClick={() => handleDelete(doc.id)}
+                    disabled={deletingId === doc.id}
+                    className="p-1.5 rounded text-vault-text-faint hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/exports/full-armory-pdf.ts
+++ b/src/lib/exports/full-armory-pdf.ts
@@ -192,10 +192,12 @@ export async function generateFullArmoryPdf(
     addLine(10);
   }
 
-  addLine(12);
-  doc.setFont("helvetica", "bold");
-  doc.text("Document Index", PAGE_MARGIN, y);
-  addLine(12);
+  if (options.includeDocuments) {
+    addLine(12);
+    doc.setFont("helvetica", "bold");
+    doc.text("Document Index", PAGE_MARGIN, y);
+    addLine(12);
+  }
 
   const docColumns = [
     { label: "Type", width: 52, maxChars: 8 },
@@ -220,46 +222,62 @@ export async function generateFullArmoryPdf(
     addLine(6);
   };
 
-  drawDocHeader();
-  doc.setFont("helvetica", "normal");
-  for (const row of payload.attachments) {
-    ensureSpace(14);
-    if (y === PAGE_MARGIN) {
-      drawDocHeader();
+  if (options.includeDocuments) {
+    drawDocHeader();
+    doc.setFont("helvetica", "normal");
+    for (const row of payload.attachments) {
+      ensureSpace(14);
+      if (y === PAGE_MARGIN) {
+        drawDocHeader();
+        doc.setFont("helvetica", "normal");
+      }
+
+      const values = [
+        row.type,
+        row.name,
+        row.linkedItemName || row.linkedItemType,
+        row.mimeType || "—",
+        formatDate(row.uploadedAt),
+      ];
+
+      let x = PAGE_MARGIN;
+      for (let index = 0; index < docColumns.length; index += 1) {
+        const column = docColumns[index];
+        doc.text(truncate(values[index], column.maxChars), x + 2, y);
+        x += column.width;
+      }
+      addLine(10);
+    }
+
+    const pdfReceiptCount = payload.attachments.filter((row) => isPdfReceipt(row)).length;
+    if (pdfReceiptCount > 0) {
+      ensureSpace(24);
+      addLine(8);
+      doc.setFont("helvetica", "italic");
+      doc.setFontSize(FONT_SIZE_SMALL);
+      doc.text(
+        `${pdfReceiptCount} receipt PDF file(s) are referenced in the index and not embedded as page images.`,
+        PAGE_MARGIN,
+        y
+      );
       doc.setFont("helvetica", "normal");
+      doc.setFontSize(FONT_SIZE_BODY);
+      addLine(14);
     }
-
-    const values = [
-      row.type,
-      row.name,
-      row.linkedItemName || row.linkedItemType,
-      row.mimeType || "—",
-      formatDate(row.uploadedAt),
-    ];
-
-    let x = PAGE_MARGIN;
-    for (let index = 0; index < docColumns.length; index += 1) {
-      const column = docColumns[index];
-      doc.text(truncate(values[index], column.maxChars), x + 2, y);
-      x += column.width;
-    }
-    addLine(10);
   }
 
-  const pdfReceiptCount = payload.attachments.filter((row) => isPdfReceipt(row)).length;
-  if (pdfReceiptCount > 0) {
-    ensureSpace(24);
-    addLine(8);
-    doc.setFont("helvetica", "italic");
-    doc.setFontSize(FONT_SIZE_SMALL);
-    doc.text(
-      `${pdfReceiptCount} receipt PDF file(s) are referenced in the index and not embedded as page images.`,
-      PAGE_MARGIN,
-      y
-    );
+  if (options.includeAmmo && payload.ammoSummary.length > 0) {
+    addLine(10);
+    doc.setFont("helvetica", "bold");
+    doc.text("Ammo Summary", PAGE_MARGIN, y);
+    addLine(12);
+
     doc.setFont("helvetica", "normal");
-    doc.setFontSize(FONT_SIZE_BODY);
-    addLine(14);
+    for (const row of payload.ammoSummary) {
+      ensureSpace(12);
+      doc.text(`${row.caliber}: ${row.totalRounds.toLocaleString()} rounds (${row.stockEntries} entries)`, PAGE_MARGIN, y);
+      addLine(10);
+    }
   }
 
   const evidence = selectVisualEvidence(payload, options);

--- a/src/lib/exports/full-armory.ts
+++ b/src/lib/exports/full-armory.ts
@@ -3,6 +3,11 @@ export type ExportImageMode = "PRIMARY_ONLY" | "ALL_IMAGES";
 
 export interface FullArmoryExportOptions {
   preset: ExportPreset;
+  includeSerialNumbers: boolean;
+  includeAmmo: boolean;
+  includeValue: boolean;
+  includeImages: boolean;
+  includeDocuments: boolean;
   includePhotos: boolean;
   includeReceipts: boolean;
   imageMode: ExportImageMode;
@@ -44,6 +49,22 @@ export interface FullArmoryAttachmentRow {
   uploadedAt: string;
 }
 
+export interface FullArmoryBackupFileRow {
+  category: "DOCUMENT" | "IMAGE";
+  fileUrl: string;
+  storagePath: string;
+  fileName: string;
+  linkedItemId: string;
+  linkedItemType: "FIREARM" | "ACCESSORY" | "UNATTACHED";
+  linkedItemName: string;
+}
+
+export interface FullArmoryAmmoSummaryRow {
+  caliber: string;
+  totalRounds: number;
+  stockEntries: number;
+}
+
 export interface FullArmoryExportResponse {
   meta: {
     generatedAt: string;
@@ -68,10 +89,14 @@ export interface FullArmoryExportResponse {
   };
   items: FullArmoryItemRow[];
   attachments: FullArmoryAttachmentRow[];
+  ammoSummary: FullArmoryAmmoSummaryRow[];
+  backupFiles: FullArmoryBackupFileRow[];
   csv: {
     inventoryItems: string;
     attachmentsIndex: string;
     valuationSummary: string;
+    ammoSummary: string;
+    backupFiles: string;
   };
 }
 
@@ -101,10 +126,21 @@ export function parseExportOptionsFromSearchParams(searchParams: URLSearchParams
   const presetRaw = searchParams.get("preset");
   const imageModeRaw = searchParams.get("imageMode");
 
+  const includeImages = parseBool(searchParams.get("includeImages"), true);
+  const includeDocuments = parseBool(searchParams.get("includeDocuments"), true);
+
+  const includePhotos = parseBool(searchParams.get("includePhotos"), includeImages) && includeImages;
+  const includeReceipts = parseBool(searchParams.get("includeReceipts"), includeDocuments) && includeDocuments;
+
   return {
     preset: presetRaw === "BACKUP" ? "BACKUP" : "CLAIMS",
-    includePhotos: parseBool(searchParams.get("includePhotos"), true),
-    includeReceipts: parseBool(searchParams.get("includeReceipts"), true),
+    includeSerialNumbers: parseBool(searchParams.get("includeSerialNumbers"), true),
+    includeAmmo: parseBool(searchParams.get("includeAmmo"), true),
+    includeValue: parseBool(searchParams.get("includeValue"), true),
+    includeImages,
+    includeDocuments,
+    includePhotos,
+    includeReceipts,
     imageMode: imageModeRaw === "ALL_IMAGES" ? "ALL_IMAGES" : "PRIMARY_ONLY",
   };
 }
@@ -112,6 +148,11 @@ export function parseExportOptionsFromSearchParams(searchParams: URLSearchParams
 export function buildExportQueryString(options: FullArmoryExportOptions): string {
   const query = new URLSearchParams();
   query.set("preset", options.preset);
+  query.set("includeSerialNumbers", String(options.includeSerialNumbers));
+  query.set("includeAmmo", String(options.includeAmmo));
+  query.set("includeValue", String(options.includeValue));
+  query.set("includeImages", String(options.includeImages));
+  query.set("includeDocuments", String(options.includeDocuments));
   query.set("includePhotos", String(options.includePhotos));
   query.set("includeReceipts", String(options.includeReceipts));
   query.set("imageMode", options.imageMode);
@@ -131,6 +172,10 @@ export function selectVisualEvidence(
   options: FullArmoryExportOptions
 ): VisualEvidenceImage[] {
   const images: VisualEvidenceImage[] = [];
+
+  if (!options.includeImages) {
+    return images;
+  }
 
   if (options.includePhotos) {
     for (const item of payload.items) {

--- a/src/lib/upload-security.ts
+++ b/src/lib/upload-security.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 type SupportedSignature = "pdf" | "jpg" | "png" | "gif" | "webp" | "avif";
 
 function asciiSlice(buffer: Buffer, start: number, end: number): string {
@@ -81,8 +83,40 @@ export function validateUploadBuffer(
   return detected;
 }
 
+const SAFE_FILE_NAME = /^[a-zA-Z0-9._-]+$/;
+
+export function getCanonicalUploadsRoot(): string {
+  return path.resolve(process.cwd(), "storage", "uploads");
+}
+
 export function isSafeDocumentUrl(fileUrl: string): boolean {
-  if (!fileUrl.startsWith("/uploads/documents/")) return false;
-  const fileName = fileUrl.slice("/uploads/documents/".length);
-  return /^[a-zA-Z0-9._-]+$/.test(fileName);
+  if (!fileUrl.startsWith("/api/files/documents/") && !fileUrl.startsWith("/uploads/documents/")) {
+    return false;
+  }
+
+  const fileName = fileUrl.startsWith("/api/files/documents/")
+    ? fileUrl.slice("/api/files/documents/".length)
+    : fileUrl.slice("/uploads/documents/".length);
+
+  return SAFE_FILE_NAME.test(fileName);
+}
+
+export function resolveDocumentStoragePath(fileUrl: string): string | null {
+  if (!isSafeDocumentUrl(fileUrl)) {
+    return null;
+  }
+
+  const fileName = fileUrl.startsWith("/api/files/documents/")
+    ? fileUrl.slice("/api/files/documents/".length)
+    : fileUrl.slice("/uploads/documents/".length);
+
+  const uploadsRoot = getCanonicalUploadsRoot();
+  const documentRoot = path.resolve(uploadsRoot, "documents");
+  const resolvedPath = path.resolve(documentRoot, fileName);
+
+  if (!resolvedPath.startsWith(`${documentRoot}${path.sep}`)) {
+    return null;
+  }
+
+  return resolvedPath;
 }


### PR DESCRIPTION
### Motivation
- Provide an inline UI for viewing/uploading/deleting documents on item pages and ensure uploaded/linked files are stored and removed safely on disk. 
- Expand the full-armory export to include ammo summary, configurable include/exclude options for images/documents/values/serials, and produce backup manifest rows that reference safe storage paths. 
- Support classifying image uploads as `PHOTO` and expose richer export/download controls and PDF generation options.

### Description
- Added a reusable `ItemDocumentPanel` React component and embedded it on firearm and accessory detail pages to list, upload (via `DocumentUploader`), open, and delete documents. 
- Extended `DocumentUploader` to accept a `PHOTO` doc type and update UI/filters in `/documents` to surface photos. 
- Introduced `upload-security` utilities: `getCanonicalUploadsRoot`, `isSafeDocumentUrl`, and `resolveDocumentStoragePath` to validate and map public file URLs to safe storage paths. 
- Updated document upload and delete APIs to use the canonical uploads root and to safely resolve and remove files from disk (`/api/documents/upload/route.ts` and `/api/documents/[id]/route.ts`). 
- Enhanced full-armory export backend and frontend: added `FullArmoryExportOptions` flags (`includeSerialNumbers`, `includeAmmo`, `includeValue`, `includeImages`, `includeDocuments`), ammo stock aggregation (`ammoSummary`), backup file manifest generation (`backupFiles`) with safe path resolution, and CSV fields for ammo and backup files. 
- Updated export UI at `/exports/full-armory` including query builder (`buildExportQueryString`), JSON/CSV/PDF download flows, preview page filters, and incorporated the new export fields into the generated PDF (`generateFullArmoryPdf`) and preview. 
- Adjusted tests and mocks in `route.test.ts` to include ammo stocks and new expectations around images, documents, and backup files. 

### Testing
- Ran unit tests with `vitest`, including the modified `app/api/exports/full-armory/route.test.ts`, and the suite completed successfully. 
- Exercised export endpoints via the updated UI flows to validate JSON/CSV generation and preview behavior in automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d6d27b0832680f21f63cdb7f722)