### PR TITLE
Add Range Sessions & Drills: schema, APIs, UI, migration, and .gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ prisma/dev.db-journal
 
 # User uploads
 /uploads/
+
+# PR hygiene for runtime/binary artifacts
+uploads/
+prisma/*.db
+prisma/prisma/*.db
+prisma/prisma/*.db-journal
+*.db
+.next/
+node_modules/

--- a/prisma/migrations/20260323005101_add_range_sessions_and_drills/migration.sql
+++ b/prisma/migrations/20260323005101_add_range_sessions_and_drills/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "RangeSession" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sessionDate" DATETIME NOT NULL,
+    "location" TEXT NOT NULL,
+    "firearmId" TEXT NOT NULL,
+    "buildId" TEXT,
+    "roundsFired" INTEGER NOT NULL,
+    "notes" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "RangeSession_firearmId_fkey" FOREIGN KEY ("firearmId") REFERENCES "Firearm" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "RangeSession_buildId_fkey" FOREIGN KEY ("buildId") REFERENCES "Build" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "RangeSessionAmmoLink" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "rangeSessionId" TEXT NOT NULL,
+    "ammoStockId" TEXT NOT NULL,
+    "roundsUsed" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RangeSessionAmmoLink_rangeSessionId_fkey" FOREIGN KEY ("rangeSessionId") REFERENCES "RangeSession" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "RangeSessionAmmoLink_ammoStockId_fkey" FOREIGN KEY ("ammoStockId") REFERENCES "AmmoStock" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "SessionDrill" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "rangeSessionId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "timeSeconds" REAL NOT NULL,
+    "points" REAL NOT NULL,
+    "penalties" REAL,
+    "hits" INTEGER,
+    "hitFactor" REAL NOT NULL,
+    "notes" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SessionDrill_rangeSessionId_fkey" FOREIGN KEY ("rangeSessionId") REFERENCES "RangeSession" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "RangeSession_sessionDate_idx" ON "RangeSession"("sessionDate");
+
+-- CreateIndex
+CREATE INDEX "RangeSession_firearmId_idx" ON "RangeSession"("firearmId");
+
+-- CreateIndex
+CREATE INDEX "RangeSession_buildId_idx" ON "RangeSession"("buildId");
+
+-- CreateIndex
+CREATE INDEX "RangeSessionAmmoLink_rangeSessionId_idx" ON "RangeSessionAmmoLink"("rangeSessionId");
+
+-- CreateIndex
+CREATE INDEX "RangeSessionAmmoLink_ammoStockId_idx" ON "RangeSessionAmmoLink"("ammoStockId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RangeSessionAmmoLink_rangeSessionId_ammoStockId_key" ON "RangeSessionAmmoLink"("rangeSessionId", "ammoStockId");
+
+-- CreateIndex
+CREATE INDEX "SessionDrill_rangeSessionId_idx" ON "SessionDrill"("rangeSessionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Firearm {
   maintenanceIntervalDays Int?
 
   builds          Build[]
+  rangeSessions   RangeSession[]
 
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
@@ -52,6 +53,7 @@ model Build {
   firearm     Firearm     @relation(fields: [firearmId], references: [id], onDelete: Cascade)
 
   slots       BuildSlot[]
+  rangeSessions RangeSession[]
 
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
@@ -153,11 +155,67 @@ model AmmoStock {
   notes           String?
 
   transactions    AmmoTransaction[]
+  rangeSessionLinks RangeSessionAmmoLink[]
 
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
 
   @@index([caliber])
+}
+
+// ─── RANGE SESSIONS ──────────────────────────────────────────
+
+model RangeSession {
+  id            String                 @id @default(cuid())
+  sessionDate   DateTime
+  location      String
+  firearmId     String
+  firearm       Firearm                @relation(fields: [firearmId], references: [id], onDelete: Cascade)
+  buildId       String?
+  build         Build?                 @relation(fields: [buildId], references: [id], onDelete: SetNull)
+  roundsFired   Int
+  notes         String?
+
+  ammoLinks     RangeSessionAmmoLink[]
+  sessionDrills SessionDrill[]
+
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+
+  @@index([sessionDate])
+  @@index([firearmId])
+  @@index([buildId])
+}
+
+model RangeSessionAmmoLink {
+  id             String       @id @default(cuid())
+  rangeSessionId String
+  rangeSession   RangeSession @relation(fields: [rangeSessionId], references: [id], onDelete: Cascade)
+  ammoStockId    String
+  ammoStock      AmmoStock    @relation(fields: [ammoStockId], references: [id], onDelete: Cascade)
+  roundsUsed     Int
+  createdAt      DateTime     @default(now())
+
+  @@unique([rangeSessionId, ammoStockId])
+  @@index([rangeSessionId])
+  @@index([ammoStockId])
+}
+
+model SessionDrill {
+  id             String       @id @default(cuid())
+  rangeSessionId String
+  rangeSession   RangeSession @relation(fields: [rangeSessionId], references: [id], onDelete: Cascade)
+  name           String
+  timeSeconds    Float
+  points         Float
+  penalties      Float?
+  hits           Int?
+  hitFactor      Float
+  notes          String?
+  sortOrder      Int          @default(0)
+  createdAt      DateTime     @default(now())
+
+  @@index([rangeSessionId])
 }
 
 model AmmoTransaction {

--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -395,13 +395,13 @@ export async function GET(request: NextRequest) {
 
     if (flags.rangeSessions) {
       queries.push(
-        (prisma as any).rangeSession.findMany({
+        prisma.rangeSession.findMany({
           include: {
             sessionDrills: { orderBy: { sortOrder: "asc" } },
             ammoLinks: true,
           },
-          orderBy: { date: "desc" },
-        }).then((rows: any) => {
+          orderBy: { sessionDate: "desc" },
+        }).then((rows) => {
           payload.rangeSessions = rows;
         })
       );

--- a/src/app/api/range/sessions/[id]/drills/route.ts
+++ b/src/app/api/range/sessions/[id]/drills/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+function calculateHitFactor(points: number, timeSeconds: number): number {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= 0) {
+    return 0;
+  }
+
+  if (!Number.isFinite(points) || points < 0) {
+    return 0;
+  }
+
+  return Number((points / timeSeconds).toFixed(4));
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const session = await prisma.rangeSession.findUnique({ where: { id }, select: { id: true } });
+    if (!session) {
+      return NextResponse.json({ error: "Range session not found" }, { status: 404 });
+    }
+
+    const drills = await prisma.sessionDrill.findMany({
+      where: { rangeSessionId: id },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+    });
+
+    return NextResponse.json(drills);
+  } catch (error) {
+    console.error("GET /api/range/sessions/[id]/drills error:", error);
+    return NextResponse.json({ error: "Failed to fetch drills" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const { name, timeSeconds, points, penalties, hits, notes, sortOrder } = body;
+
+    if (!name || timeSeconds === undefined || points === undefined) {
+      return NextResponse.json(
+        { error: "Missing required fields: name, timeSeconds, points" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json({ error: "name must be a non-empty string" }, { status: 400 });
+    }
+
+    if (typeof timeSeconds !== "number" || !Number.isFinite(timeSeconds) || timeSeconds <= 0) {
+      return NextResponse.json({ error: "timeSeconds must be a positive number" }, { status: 400 });
+    }
+
+    if (typeof points !== "number" || !Number.isFinite(points) || points < 0) {
+      return NextResponse.json({ error: "points must be a non-negative number" }, { status: 400 });
+    }
+
+    if (
+      penalties !== undefined &&
+      penalties !== null &&
+      (typeof penalties !== "number" || !Number.isFinite(penalties) || penalties < 0)
+    ) {
+      return NextResponse.json({ error: "penalties must be a non-negative number" }, { status: 400 });
+    }
+
+    if (hits !== undefined && hits !== null && (typeof hits !== "number" || !Number.isInteger(hits) || hits < 0)) {
+      return NextResponse.json({ error: "hits must be a non-negative integer" }, { status: 400 });
+    }
+
+    const session = await prisma.rangeSession.findUnique({ where: { id }, select: { id: true } });
+    if (!session) {
+      return NextResponse.json({ error: "Range session not found" }, { status: 404 });
+    }
+
+    const adjustedPoints = Math.max(0, points - (typeof penalties === "number" ? penalties : 0));
+    const hitFactor = calculateHitFactor(adjustedPoints, timeSeconds);
+
+    const drill = await prisma.sessionDrill.create({
+      data: {
+        rangeSessionId: id,
+        name: name.trim(),
+        timeSeconds,
+        points,
+        penalties: typeof penalties === "number" ? penalties : null,
+        hits: typeof hits === "number" ? hits : null,
+        hitFactor,
+        notes: typeof notes === "string" ? notes.trim() || null : null,
+        sortOrder: typeof sortOrder === "number" && Number.isInteger(sortOrder) ? sortOrder : 0,
+      },
+    });
+
+    return NextResponse.json(drill, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/range/sessions/[id]/drills error:", error);
+    return NextResponse.json({ error: "Failed to create drill" }, { status: 500 });
+  }
+}

--- a/src/app/api/range/sessions/[id]/finalize/route.ts
+++ b/src/app/api/range/sessions/[id]/finalize/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const selectedAccessoryIdsRaw = Array.isArray(body?.selectedAccessoryIds) ? body.selectedAccessoryIds : [];
+    const selectedAccessoryIds = selectedAccessoryIdsRaw.filter(
+      (value): value is string => typeof value === "string" && value.length > 0
+    );
+
+    const result = await prisma.$transaction(async (tx) => {
+      const session = await tx.rangeSession.findUnique({
+        where: { id },
+        include: {
+          ammoLinks: true,
+          build: {
+            include: {
+              slots: {
+                include: {
+                  accessory: {
+                    select: {
+                      id: true,
+                      roundCount: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!session) {
+        throw new Error("Range session not found");
+      }
+
+      const sessionNote = `Range session ${session.id}`;
+
+      for (const ammoLink of session.ammoLinks) {
+        const existing = await tx.ammoTransaction.findFirst({
+          where: {
+            stockId: ammoLink.ammoStockId,
+            type: "RANGE_USE",
+            note: sessionNote,
+          },
+          select: { id: true },
+        });
+
+        if (existing) continue;
+
+        const stock = await tx.ammoStock.findUnique({ where: { id: ammoLink.ammoStockId } });
+        if (!stock) {
+          throw new Error("Ammo stock no longer exists for this session");
+        }
+
+        if (stock.quantity < ammoLink.roundsUsed) {
+          throw new Error(`Insufficient ammo stock for ${stock.brand} (${stock.caliber})`);
+        }
+
+        const previousQty = stock.quantity;
+        const newQty = previousQty - ammoLink.roundsUsed;
+
+        await tx.ammoStock.update({
+          where: { id: stock.id },
+          data: { quantity: newQty },
+        });
+
+        await tx.ammoTransaction.create({
+          data: {
+            stockId: stock.id,
+            type: "RANGE_USE",
+            quantity: ammoLink.roundsUsed,
+            previousQty,
+            newQty,
+            note: sessionNote,
+          },
+        });
+      }
+
+      const allowedAccessoryIds = new Set(
+        (session.build?.slots ?? [])
+          .map((slot) => slot.accessory?.id)
+          .filter((accessoryId): accessoryId is string => Boolean(accessoryId))
+      );
+
+      const accessoryIdsToProcess = selectedAccessoryIds.filter((accessoryId) => allowedAccessoryIds.has(accessoryId));
+
+      for (const accessoryId of accessoryIdsToProcess) {
+        const alreadyLogged = await tx.roundCountLog.findFirst({
+          where: {
+            accessoryId,
+            sessionNote,
+          },
+          select: { id: true },
+        });
+
+        if (alreadyLogged) continue;
+
+        const accessory = await tx.accessory.findUnique({ where: { id: accessoryId } });
+        if (!accessory) {
+          continue;
+        }
+
+        const previousCount = accessory.roundCount;
+        const newCount = previousCount + session.roundsFired;
+
+        await tx.accessory.update({
+          where: { id: accessoryId },
+          data: { roundCount: newCount },
+        });
+
+        await tx.roundCountLog.create({
+          data: {
+            accessoryId,
+            roundsAdded: session.roundsFired,
+            previousCount,
+            newCount,
+            sessionNote,
+          },
+        });
+      }
+
+      return {
+        sessionId: session.id,
+        accessoriesProcessed: accessoryIdsToProcess.length,
+        ammoLinksProcessed: session.ammoLinks.length,
+      };
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Range session not found") {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    console.error("POST /api/range/sessions/[id]/finalize error:", error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to finalize session" }, { status: 400 });
+  }
+}

--- a/src/app/api/range/sessions/route.ts
+++ b/src/app/api/range/sessions/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const sessions = await prisma.rangeSession.findMany({
+      include: {
+        firearm: {
+          select: {
+            id: true,
+            name: true,
+            caliber: true,
+          },
+        },
+        build: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        ammoLinks: {
+          include: {
+            ammoStock: {
+              select: {
+                id: true,
+                caliber: true,
+                brand: true,
+                grainWeight: true,
+                bulletType: true,
+              },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+        sessionDrills: {
+          orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+        },
+      },
+      orderBy: [{ sessionDate: "desc" }, { createdAt: "desc" }],
+    });
+
+    return NextResponse.json(sessions);
+  } catch (error) {
+    console.error("GET /api/range/sessions error:", error);
+    return NextResponse.json({ error: "Failed to fetch range sessions" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { sessionDate, location, firearmId, buildId, roundsFired, notes, ammoLinks } = body;
+
+    if (!sessionDate || !location || !firearmId || roundsFired === undefined || roundsFired === null) {
+      return NextResponse.json(
+        { error: "Missing required fields: sessionDate, location, firearmId, roundsFired" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof location !== "string" || location.trim().length === 0) {
+      return NextResponse.json({ error: "location must be a non-empty string" }, { status: 400 });
+    }
+
+    if (typeof roundsFired !== "number" || !Number.isInteger(roundsFired) || roundsFired <= 0) {
+      return NextResponse.json({ error: "roundsFired must be a positive integer" }, { status: 400 });
+    }
+
+    const parsedDate = new Date(sessionDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return NextResponse.json({ error: "sessionDate must be a valid date" }, { status: 400 });
+    }
+
+    if (!Array.isArray(ammoLinks) || ammoLinks.length === 0) {
+      return NextResponse.json(
+        { error: "At least one ammo selection is required" },
+        { status: 400 }
+      );
+    }
+
+    const normalizedAmmoLinks = ammoLinks
+      .map((link) => ({
+        ammoStockId: typeof link?.ammoStockId === "string" ? link.ammoStockId : "",
+        roundsUsed: link?.roundsUsed,
+      }))
+      .filter((link) => link.ammoStockId);
+
+    if (normalizedAmmoLinks.length === 0) {
+      return NextResponse.json({ error: "ammoLinks contain no valid ammoStockId values" }, { status: 400 });
+    }
+
+    for (const link of normalizedAmmoLinks) {
+      if (typeof link.roundsUsed !== "number" || !Number.isInteger(link.roundsUsed) || link.roundsUsed <= 0) {
+        return NextResponse.json(
+          { error: "Each ammo link must include a positive integer roundsUsed value" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const uniqueAmmoStockIds = new Set(normalizedAmmoLinks.map((item) => item.ammoStockId));
+    if (uniqueAmmoStockIds.size !== normalizedAmmoLinks.length) {
+      return NextResponse.json(
+        { error: "Duplicate ammo selections are not allowed in a single session" },
+        { status: 400 }
+      );
+    }
+
+    const totalAmmoRounds = normalizedAmmoLinks.reduce((sum, item) => sum + item.roundsUsed, 0);
+    if (totalAmmoRounds !== roundsFired) {
+      return NextResponse.json(
+        { error: "Ammo rounds selected must match rounds fired" },
+        { status: 400 }
+      );
+    }
+
+    const firearm = await prisma.firearm.findUnique({
+      where: { id: firearmId },
+      select: { id: true, caliber: true },
+    });
+    const build = buildId
+      ? await prisma.build.findUnique({ where: { id: buildId }, select: { id: true, firearmId: true } })
+      : null;
+    const ammoStocks = await prisma.ammoStock.findMany({
+      where: {
+        id: { in: normalizedAmmoLinks.map((item) => item.ammoStockId) },
+      },
+      select: { id: true, caliber: true, quantity: true, brand: true },
+    });
+
+    if (!firearm) {
+      return NextResponse.json({ error: "Firearm not found" }, { status: 404 });
+    }
+
+    if (buildId && !build) {
+      return NextResponse.json({ error: "Build not found" }, { status: 404 });
+    }
+
+    if (build && build.firearmId !== firearmId) {
+      return NextResponse.json(
+        { error: "Selected build does not belong to the selected firearm" },
+        { status: 400 }
+      );
+    }
+
+    if (ammoStocks.length !== normalizedAmmoLinks.length) {
+      return NextResponse.json({ error: "One or more ammo selections are invalid" }, { status: 400 });
+    }
+
+    for (const ammoLink of normalizedAmmoLinks) {
+      const stock = ammoStocks.find((item) => item.id === ammoLink.ammoStockId);
+      if (!stock) {
+        return NextResponse.json({ error: "One or more ammo selections are invalid" }, { status: 400 });
+      }
+
+      if (stock.caliber !== firearm.caliber) {
+        return NextResponse.json(
+          { error: `Selected ammo must match firearm caliber (${firearm.caliber})` },
+          { status: 400 }
+        );
+      }
+
+      if (stock.quantity < ammoLink.roundsUsed) {
+        return NextResponse.json(
+          { error: `Insufficient ammo stock for ${stock.brand}. Available: ${stock.quantity}` },
+          { status: 400 }
+        );
+      }
+    }
+
+    const created = await prisma.rangeSession.create({
+      data: {
+        sessionDate: parsedDate,
+        location: location.trim(),
+        firearmId,
+        buildId: buildId ?? null,
+        roundsFired,
+        notes: typeof notes === "string" ? notes.trim() || null : null,
+        ammoLinks: {
+          create: normalizedAmmoLinks,
+        },
+      },
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+        build: { select: { id: true, name: true } },
+        ammoLinks: {
+          include: {
+            ammoStock: {
+              select: {
+                id: true,
+                caliber: true,
+                brand: true,
+                grainWeight: true,
+                bulletType: true,
+              },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/range/sessions error:", error);
+    return NextResponse.json({ error: "Failed to create range session" }, { status: 500 });
+  }
+}

--- a/src/app/range/page.tsx
+++ b/src/app/range/page.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatNumber } from "@/lib/utils";
-import {
-  Target,
-  ChevronDown,
-  Loader2,
-  AlertCircle,
-  CheckCircle2,
-  Shield,
-} from "lucide-react";
+import { Target, ChevronDown, Loader2, AlertCircle, CheckCircle2, Shield, Timer } from "lucide-react";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
@@ -51,6 +44,40 @@ interface AmmoStock {
   quantity: number;
 }
 
+interface SessionDrill {
+  id: string;
+  name: string;
+  timeSeconds: number;
+  points: number;
+  penalties: number | null;
+  hits: number | null;
+  hitFactor: number;
+  notes: string | null;
+  createdAt: string;
+}
+
+interface RangeSession {
+  id: string;
+  sessionDate: string;
+  location: string;
+  roundsFired: number;
+  notes: string | null;
+  firearm: { id: string; name: string; caliber: string };
+  build: { id: string; name: string } | null;
+  ammoLinks: Array<{
+    id: string;
+    roundsUsed: number;
+    ammoStock: {
+      id: string;
+      caliber: string;
+      brand: string;
+      grainWeight: number | null;
+      bulletType: string | null;
+    };
+  }>;
+  sessionDrills: SessionDrill[];
+}
+
 const SLOT_TYPE_LABELS: Record<string, string> = {
   BARREL: "Barrel",
   SUPPRESSOR: "Suppressor",
@@ -62,34 +89,68 @@ const SLOT_TYPE_LABELS: Record<string, string> = {
   GRIP: "Grip",
 };
 
-// Slots that typically accumulate rounds
 const ROUND_COUNT_SLOTS = new Set(["BARREL", "SUPPRESSOR", "MUZZLE", "TRIGGER", "SLIDE", "FRAME"]);
+
+function calculateHitFactor(points: number, timeSeconds: number) {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= 0) return 0;
+  if (!Number.isFinite(points) || points < 0) return 0;
+  return Number((points / timeSeconds).toFixed(4));
+}
 
 export default function RangeSessionPage() {
   const [firearms, setFirearms] = useState<Firearm[]>([]);
   const [builds, setBuilds] = useState<Build[]>([]);
   const [ammoStocks, setAmmoStocks] = useState<AmmoStock[]>([]);
+  const [sessions, setSessions] = useState<RangeSession[]>([]);
+  const [sessionDrills, setSessionDrills] = useState<SessionDrill[]>([]);
 
   const [selectedFirearm, setSelectedFirearm] = useState<string>("");
   const [selectedBuild, setSelectedBuild] = useState<string>("");
   const [roundsFired, setRoundsFired] = useState<string>("");
   const [selectedAmmoStock, setSelectedAmmoStock] = useState<string>("");
+  const [sessionDate, setSessionDate] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [sessionLocation, setSessionLocation] = useState<string>("");
   const [sessionNote, setSessionNote] = useState<string>("");
   const [selectedAccessories, setSelectedAccessories] = useState<Set<string>>(new Set());
+
+  const [selectedSessionId, setSelectedSessionId] = useState<string>("");
+  const [drillName, setDrillName] = useState<string>("");
+  const [drillTime, setDrillTime] = useState<string>("");
+  const [drillPoints, setDrillPoints] = useState<string>("");
+  const [drillPenalties, setDrillPenalties] = useState<string>("");
+  const [drillHits, setDrillHits] = useState<string>("");
+  const [drillNotes, setDrillNotes] = useState<string>("");
 
   const [loadingFirearms, setLoadingFirearms] = useState(true);
   const [loadingBuilds, setLoadingBuilds] = useState(false);
   const [loadingAmmo, setLoadingAmmo] = useState(true);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [loadingDrills, setLoadingDrills] = useState(false);
 
   const [submitting, setSubmitting] = useState(false);
+  const [submittingDrill, setSubmittingDrill] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [successDetails, setSuccessDetails] = useState<{ accessories: string[]; ammoLeft: number | null }>({
-    accessories: [],
-    ammoLeft: null,
-  });
+  const [success, setSuccess] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [finalizeState, setFinalizeState] = useState<"idle" | "success" | "failed_after_save">("idle");
+  const [savedSessionId, setSavedSessionId] = useState<string | null>(null);
 
-  // Load firearms
+  const loadSessions = useCallback(async () => {
+    setLoadingSessions(true);
+    try {
+      const res = await fetch("/api/range/sessions");
+      const data = (await res.json()) as RangeSession[];
+      if (res.ok) {
+        setSessions(data);
+        if (!selectedSessionId && data.length > 0) {
+          setSelectedSessionId(data[0].id);
+        }
+      }
+    } finally {
+      setLoadingSessions(false);
+    }
+  }, [selectedSessionId]);
+
   useEffect(() => {
     fetch("/api/firearms")
       .then((r) => r.json())
@@ -98,10 +159,7 @@ export default function RangeSessionPage() {
         setLoadingFirearms(false);
       })
       .catch(() => setLoadingFirearms(false));
-  }, []);
 
-  // Load ammo stocks
-  useEffect(() => {
     fetch("/api/ammo")
       .then((r) => r.json())
       .then((data) => {
@@ -109,25 +167,25 @@ export default function RangeSessionPage() {
         setLoadingAmmo(false);
       })
       .catch(() => setLoadingAmmo(false));
-  }, []);
 
-  // Load builds when firearm changes
+    void loadSessions();
+  }, [loadSessions]);
+
   const loadBuilds = useCallback(async (firearmId: string) => {
     if (!firearmId) {
       setBuilds([]);
       return;
     }
+
     setLoadingBuilds(true);
     try {
       const res = await fetch(`/api/builds?firearmId=${firearmId}`);
-      const data = await res.json();
+      const data = (await res.json()) as Build[];
       setBuilds(data);
 
-      // Auto-select active build
-      const active = data.find((b: Build) => b.isActive);
+      const active = data.find((b) => b.isActive);
       if (active) {
         setSelectedBuild(active.id);
-        // Auto-select barrel and suppressor
         const autoSelect = new Set<string>();
         for (const slot of active.slots) {
           if (slot.accessory && ROUND_COUNT_SLOTS.has(slot.slotType)) {
@@ -147,14 +205,13 @@ export default function RangeSessionPage() {
 
   useEffect(() => {
     if (selectedFirearm) {
-      loadBuilds(selectedFirearm);
+      void loadBuilds(selectedFirearm);
     } else {
       setBuilds([]);
       setSelectedBuild("");
     }
   }, [selectedFirearm, loadBuilds]);
 
-  // Update accessory defaults when build changes
   useEffect(() => {
     const build = builds.find((b) => b.id === selectedBuild);
     if (!build) return;
@@ -167,23 +224,56 @@ export default function RangeSessionPage() {
     setSelectedAccessories(autoSelect);
   }, [selectedBuild, builds]);
 
+  useEffect(() => {
+    if (!selectedSessionId) {
+      setSessionDrills([]);
+      return;
+    }
+
+    setLoadingDrills(true);
+    fetch(`/api/range/sessions/${selectedSessionId}/drills`)
+      .then((r) => r.json())
+      .then((data) => {
+        setSessionDrills(Array.isArray(data) ? data : []);
+      })
+      .finally(() => setLoadingDrills(false));
+  }, [selectedSessionId]);
+
+  useEffect(() => {
+    if (sessions.length === 0) {
+      if (selectedSessionId) setSelectedSessionId("");
+      return;
+    }
+
+    const stillExists = sessions.some((session) => session.id === selectedSessionId);
+    if (!stillExists) {
+      setSelectedSessionId(sessions[0].id);
+    }
+  }, [sessions, selectedSessionId]);
+
   const selectedFirearmData = firearms.find((f) => f.id === selectedFirearm);
   const selectedBuildData = builds.find((b) => b.id === selectedBuild);
   const buildAccessories = selectedBuildData?.slots.filter((s) => s.accessory) ?? [];
 
-  // Filter ammo by firearm caliber
   const compatibleAmmo = selectedFirearmData
     ? ammoStocks.filter((a) => a.caliber === selectedFirearmData.caliber)
     : ammoStocks;
 
+  const selectedSession = sessions.find((session) => session.id === selectedSessionId) ?? null;
+
+  const drillHitFactorPreview = useMemo(() => {
+    const time = Number.parseFloat(drillTime);
+    const points = Number.parseFloat(drillPoints);
+    const penalties = Number.parseFloat(drillPenalties || "0");
+    const adjustedPoints = Number.isFinite(points) ? Math.max(0, points - (Number.isFinite(penalties) ? penalties : 0)) : 0;
+    return calculateHitFactor(adjustedPoints, time);
+  }, [drillTime, drillPoints, drillPenalties]);
+
   function toggleAccessory(accessoryId: string) {
     setSelectedAccessories((prev) => {
       const next = new Set(prev);
-      if (next.has(accessoryId)) {
-        next.delete(accessoryId);
-      } else {
-        next.add(accessoryId);
-      }
+      if (next.has(accessoryId)) next.delete(accessoryId);
+      else next.add(accessoryId);
       return next;
     });
   }
@@ -191,161 +281,232 @@ export default function RangeSessionPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
+    setSuccess(null);
+    setWarning(null);
+    setFinalizeState("idle");
+    setSavedSessionId(null);
     setSubmitting(true);
 
-    const rounds = parseInt(roundsFired);
+    const rounds = Number.parseInt(roundsFired, 10);
     if (!rounds || rounds <= 0) {
       setError("Please enter a valid number of rounds fired.");
       setSubmitting(false);
       return;
     }
 
+    if (!sessionDate || !sessionLocation.trim()) {
+      setError("Session date and location are required.");
+      setSubmitting(false);
+      return;
+    }
+
+    if (!selectedAmmoStock) {
+      setError("Please select ammo for this session.");
+      setSubmitting(false);
+      return;
+    }
+
+    const selectedAmmoData = ammoStocks.find((stock) => stock.id === selectedAmmoStock);
+    if (!selectedAmmoData) {
+      setError("Selected ammo stock is invalid.");
+      setSubmitting(false);
+      return;
+    }
+
+    if (selectedAmmoData.quantity < rounds) {
+      setError(`Insufficient ammo in selected stock. Available: ${formatNumber(selectedAmmoData.quantity)} rounds.`);
+      setSubmitting(false);
+      return;
+    }
+
     try {
-      const results: string[] = [];
-      let ammoLeft: number | null = null;
+      const sessionRes = await fetch("/api/range/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionDate,
+          location: sessionLocation,
+          firearmId: selectedFirearm,
+          buildId: selectedBuild || null,
+          roundsFired: rounds,
+          notes: sessionNote,
+          ammoLinks: [{ ammoStockId: selectedAmmoStock, roundsUsed: rounds }],
+        }),
+      });
 
-      // Log rounds to each selected accessory
-      for (const accessoryId of selectedAccessories) {
-        const slot = buildAccessories.find((s) => s.accessory?.id === accessoryId);
-        const name = slot?.accessory?.name ?? accessoryId;
-        const res = await fetch(`/api/accessories/${accessoryId}/rounds`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            rounds,
-            note: sessionNote || `Range session`,
-          }),
-        });
-        if (!res.ok) {
-          const json = await res.json();
-          throw new Error(`Failed for ${name}: ${json.error}`);
-        }
-        results.push(name);
+      const sessionJson = await sessionRes.json();
+      if (!sessionRes.ok) {
+        throw new Error(sessionJson.error ?? "Failed to create range session");
       }
 
-      // Deduct ammo if stock selected
-      if (selectedAmmoStock) {
-        const res = await fetch(`/api/ammo/${selectedAmmoStock}/transactions`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            type: "RANGE_USE",
-            quantity: rounds,
-            note: sessionNote || "Range session",
-          }),
-        });
-        const json = await res.json();
-        if (!res.ok) {
-          throw new Error(json.error ?? "Failed to deduct ammo");
-        }
-        ammoLeft = json.stock.quantity;
+      setSavedSessionId(sessionJson.id);
+
+      const finalizeRes = await fetch(`/api/range/sessions/${sessionJson.id}/finalize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          selectedAccessoryIds: Array.from(selectedAccessories),
+        }),
+      });
+
+      const finalizeJson = await finalizeRes.json();
+      if (!finalizeRes.ok) {
+        setFinalizeState("failed_after_save");
+        setSuccess("Session saved.");
+        setWarning("Finalize failed. Retry save to safely re-run updates.");
+        setError(finalizeJson.error ?? "Finalize failed");
+        await loadSessions();
+        setSelectedSessionId(sessionJson.id);
+        setSubmitting(false);
+        return;
       }
 
-      setSuccessDetails({ accessories: results, ammoLeft });
-      setSuccess(true);
+      await loadSessions();
+      setSelectedSessionId(sessionJson.id);
+      setFinalizeState("success");
+      setSuccess("Session saved and finalized.");
+      setWarning(null);
+      setRoundsFired("");
+      setSessionNote("");
+      setSelectedAmmoStock("");
     } catch (err) {
+      setFinalizeState("idle");
       setError(err instanceof Error ? err.message : "Session log failed");
+      setWarning(null);
     } finally {
       setSubmitting(false);
     }
   }
 
-  function resetForm() {
-    setSelectedFirearm("");
-    setSelectedBuild("");
-    setRoundsFired("");
-    setSelectedAmmoStock("");
-    setSessionNote("");
-    setSelectedAccessories(new Set());
-    setSuccess(false);
-    setError(null);
-    setBuilds([]);
-  }
+  async function handleAddDrill(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedSessionId) return;
 
-  if (success) {
-    return (
-      <div className="min-h-full">
-        <PageHeader title="RANGE SESSION" subtitle="Log your range session rounds and usage" />
-        <div className="flex flex-col items-center justify-center py-24 text-center px-6">
-          <div className="w-20 h-20 rounded-full bg-[#00C853]/10 border border-[#00C853]/30 flex items-center justify-center mb-6">
-            <CheckCircle2 className="w-10 h-10 text-[#00C853]" />
-          </div>
-          <h2 className="text-2xl font-bold text-vault-text mb-2">Session Logged</h2>
-          <p className="text-vault-text-muted mb-6 max-w-sm">
-            Range session recorded successfully.
-          </p>
-          <div className="bg-vault-surface border border-vault-border rounded-lg p-5 text-left max-w-sm w-full mb-8">
-            <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-3">Session Summary</p>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm text-vault-text-muted">Rounds fired</span>
-                <span className="text-sm font-mono font-bold text-[#00C2FF]">
-                  {formatNumber(parseInt(roundsFired))}
-                </span>
-              </div>
-              {successDetails.accessories.length > 0 && (
-                <div>
-                  <p className="text-sm text-vault-text-muted mb-1">Logged to accessories:</p>
-                  {successDetails.accessories.map((name) => (
-                    <p key={name} className="text-xs text-[#00C853] flex items-center gap-1.5 ml-2">
-                      <CheckCircle2 className="w-3 h-3" />
-                      {name}
-                    </p>
-                  ))}
-                </div>
-              )}
-              {successDetails.ammoLeft != null && (
-                <div className="flex justify-between">
-                  <span className="text-sm text-vault-text-muted">Ammo remaining</span>
-                  <span className="text-sm font-mono text-[#F5A623]">
-                    {formatNumber(successDetails.ammoLeft)} rds
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
-          <button
-            onClick={resetForm}
-            className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 px-5 py-2 rounded-md text-sm font-medium transition-colors"
-          >
-            Log Another Session
-          </button>
-        </div>
-      </div>
-    );
+    setError(null);
+    setSuccess(null);
+    setWarning(null);
+    setSubmittingDrill(true);
+
+    try {
+      const payload = {
+        name: drillName,
+        timeSeconds: Number.parseFloat(drillTime),
+        points: Number.parseFloat(drillPoints),
+        penalties: drillPenalties ? Number.parseFloat(drillPenalties) : undefined,
+        hits: drillHits ? Number.parseInt(drillHits, 10) : undefined,
+        notes: drillNotes,
+      };
+
+      const res = await fetch(`/api/range/sessions/${selectedSessionId}/drills`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error ?? "Failed to add drill");
+      }
+
+      const drillsRes = await fetch(`/api/range/sessions/${selectedSessionId}/drills`);
+      const drillsJson = await drillsRes.json();
+      setSessionDrills(Array.isArray(drillsJson) ? drillsJson : []);
+      await loadSessions();
+
+      setDrillName("");
+      setDrillTime("");
+      setDrillPoints("");
+      setDrillPenalties("");
+      setDrillHits("");
+      setDrillNotes("");
+      setSuccess("Drill logged successfully.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Drill log failed");
+    } finally {
+      setSubmittingDrill(false);
+    }
   }
 
   return (
     <div className="min-h-full">
       <PageHeader
         title="RANGE SESSION"
-        subtitle="Log rounds fired, deduct ammo, and update accessory round counts"
+        subtitle="Log rounds, persist sessions, and track drill performance history"
       />
 
-      <div className="max-w-2xl mx-auto px-6 py-8">
+      <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
         {error && (
-          <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3 mb-6">
+          <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3">
             <AlertCircle className="w-4 h-4 text-[#E53935] shrink-0" />
             <p className="text-sm text-[#E53935]">{error}</p>
           </div>
         )}
 
+        {success && (
+          <div className="flex items-center gap-3 bg-[#00C853]/10 border border-[#00C853]/30 rounded-lg px-4 py-3">
+            <CheckCircle2 className="w-4 h-4 text-[#00C853] shrink-0" />
+            <p className="text-sm text-[#00C853]">{success}</p>
+          </div>
+        )}
+
+        {warning && (
+          <div className="flex items-center gap-3 bg-[#F5A623]/10 border border-[#F5A623]/30 rounded-lg px-4 py-3">
+            <AlertCircle className="w-4 h-4 text-[#F5A623] shrink-0" />
+            <p className="text-sm text-[#F5A623]">{warning}</p>
+          </div>
+        )}
+
+        {finalizeState === "failed_after_save" && savedSessionId && (
+          <div className="bg-vault-surface border border-vault-border rounded-lg px-4 py-3">
+            <p className="text-xs text-vault-text-faint uppercase tracking-widest mb-1">Finalize status</p>
+            <p className="text-sm text-vault-text-muted">
+              Session <span className="font-mono text-vault-text">{savedSessionId.slice(0, 12)}</span> saved, but finalize did not complete.
+            </p>
+          </div>
+        )}
+
+        {finalizeState === "success" && savedSessionId && (
+          <div className="bg-vault-surface border border-[#00C853]/30 rounded-lg px-4 py-3">
+            <p className="text-xs text-vault-text-faint uppercase tracking-widest mb-1">Finalize status</p>
+            <p className="text-sm text-[#00C853]">
+              Finalize complete for session <span className="font-mono">{savedSessionId.slice(0, 12)}</span>.
+            </p>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Firearm & Build */}
           <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
-            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
-              Firearm & Build
-            </legend>
+            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session Details</legend>
+
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <label className={LABEL_CLASS}>Session Date <span className="text-[#E53935]">*</span></label>
+                <input
+                  type="date"
+                  required
+                  value={sessionDate}
+                  onChange={(e) => setSessionDate(e.target.value)}
+                  className={INPUT_CLASS}
+                />
+              </div>
+
+              <div>
+                <label className={LABEL_CLASS}>Location <span className="text-[#E53935]">*</span></label>
+                <input
+                  type="text"
+                  required
+                  value={sessionLocation}
+                  onChange={(e) => setSessionLocation(e.target.value)}
+                  placeholder="e.g. Oak Ridge Sportsmen Club"
+                  className={INPUT_CLASS}
+                />
+              </div>
+            </div>
 
             <div>
-              <label className={LABEL_CLASS}>
-                Firearm <span className="text-[#E53935]">*</span>
-              </label>
+              <label className={LABEL_CLASS}>Firearm <span className="text-[#E53935]">*</span></label>
               {loadingFirearms ? (
-                <div className="flex items-center gap-2 h-10">
-                  <Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" />
-                  <span className="text-sm text-vault-text-muted">Loading...</span>
-                </div>
+                <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" /></div>
               ) : (
                 <div className="relative">
                   <select
@@ -360,9 +521,7 @@ export default function RangeSessionPage() {
                   >
                     <option value="">Select firearm...</option>
                     {firearms.map((f) => (
-                      <option key={f.id} value={f.id}>
-                        {f.name} ({f.caliber})
-                      </option>
+                      <option key={f.id} value={f.id}>{f.name} ({f.caliber})</option>
                     ))}
                   </select>
                   <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
@@ -374,24 +533,15 @@ export default function RangeSessionPage() {
               <div>
                 <label className={LABEL_CLASS}>Build</label>
                 {loadingBuilds ? (
-                  <div className="flex items-center gap-2 h-10">
-                    <Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" />
-                    <span className="text-sm text-vault-text-muted">Loading builds...</span>
-                  </div>
+                  <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" /></div>
                 ) : builds.length === 0 ? (
                   <p className="text-sm text-vault-text-faint py-2">No builds for this firearm.</p>
                 ) : (
                   <div className="relative">
-                    <select
-                      value={selectedBuild}
-                      onChange={(e) => setSelectedBuild(e.target.value)}
-                      className={INPUT_CLASS}
-                    >
+                    <select value={selectedBuild} onChange={(e) => setSelectedBuild(e.target.value)} className={INPUT_CLASS}>
                       <option value="">No build selected</option>
                       {builds.map((b) => (
-                        <option key={b.id} value={b.id}>
-                          {b.name}{b.isActive ? " (Active)" : ""}
-                        </option>
+                        <option key={b.id} value={b.id}>{b.name}{b.isActive ? " (Active)" : ""}</option>
                       ))}
                     </select>
                     <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
@@ -399,78 +549,57 @@ export default function RangeSessionPage() {
                 )}
               </div>
             )}
-          </fieldset>
 
-          {/* Rounds & Ammo */}
-          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
-            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
-              Rounds Fired
-            </legend>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <label className={LABEL_CLASS}>Rounds Fired <span className="text-[#E53935]">*</span></label>
+                <input
+                  type="number"
+                  min={1}
+                  required
+                  value={roundsFired}
+                  onChange={(e) => setRoundsFired(e.target.value)}
+                  placeholder="e.g. 200"
+                  className={INPUT_CLASS}
+                />
+              </div>
+
+              <div>
+                <label className={LABEL_CLASS}>Ammo Stock <span className="text-[#E53935]">*</span></label>
+                {loadingAmmo ? (
+                  <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#F5A623] animate-spin" /></div>
+                ) : (
+                  <div className="relative">
+                    <select required value={selectedAmmoStock} onChange={(e) => setSelectedAmmoStock(e.target.value)} className={INPUT_CLASS}>
+                      <option value="">Select ammo...</option>
+                      {compatibleAmmo.map((a) => (
+                        <option key={a.id} value={a.id}>
+                          {a.caliber} · {a.brand}{a.grainWeight ? ` ${a.grainWeight}gr` : ""}{a.bulletType ? ` ${a.bulletType}` : ""} — {formatNumber(a.quantity)} rds
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+                  </div>
+                )}
+                <p className="text-xs text-vault-text-faint mt-1">Selected ammo must match firearm caliber and have enough quantity for rounds fired.</p>
+              </div>
+            </div>
 
             <div>
-              <label className={LABEL_CLASS}>
-                Rounds Fired <span className="text-[#E53935]">*</span>
-              </label>
-              <input
-                type="number"
-                min={1}
-                required
-                value={roundsFired}
-                onChange={(e) => setRoundsFired(e.target.value)}
-                placeholder="e.g. 200"
-                className={INPUT_CLASS}
+              <label className={LABEL_CLASS}>Notes</label>
+              <textarea
+                rows={3}
+                value={sessionNote}
+                onChange={(e) => setSessionNote(e.target.value)}
+                placeholder="e.g. Match prep and transition work"
+                className={`${INPUT_CLASS} resize-none`}
               />
             </div>
-
-            <div>
-              <label className={LABEL_CLASS}>Ammo Stock to Deduct From</label>
-              {loadingAmmo ? (
-                <div className="flex items-center gap-2 h-10">
-                  <Loader2 className="w-4 h-4 text-[#F5A623] animate-spin" />
-                </div>
-              ) : compatibleAmmo.length === 0 ? (
-                <p className="text-sm text-vault-text-faint py-2">
-                  {selectedFirearmData
-                    ? `No ${selectedFirearmData.caliber} stocks found.`
-                    : "Select a firearm to filter compatible ammo."}
-                </p>
-              ) : (
-                <div className="relative">
-                  <select
-                    value={selectedAmmoStock}
-                    onChange={(e) => setSelectedAmmoStock(e.target.value)}
-                    className={INPUT_CLASS}
-                  >
-                    <option value="">No deduction</option>
-                    {compatibleAmmo.map((a) => (
-                      <option key={a.id} value={a.id}>
-                        {a.caliber} · {a.brand}
-                        {a.grainWeight ? ` ${a.grainWeight}gr` : ""}
-                        {a.bulletType ? ` ${a.bulletType}` : ""}
-                        {" "}— {formatNumber(a.quantity)} rds
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
-                </div>
-              )}
-              <p className="text-xs text-vault-text-faint mt-1">
-                This will deduct rounds from the selected stock.
-              </p>
-            </div>
           </fieldset>
 
-          {/* Accessories Round Attribution */}
           {selectedBuildData && buildAccessories.length > 0 && (
             <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-3">
-              <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
-                Attribute Rounds To Accessories
-              </legend>
-              <p className="text-xs text-vault-text-muted">
-                Select which accessories should have their round count incremented.
-                Barrel and suppressor are pre-selected.
-              </p>
-
+              <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Attribute Rounds To Accessories</legend>
               <div className="space-y-2">
                 {buildAccessories.map((slot) => {
                   if (!slot.accessory) return null;
@@ -478,59 +607,24 @@ export default function RangeSessionPage() {
                   const isRoundCountPart = ROUND_COUNT_SLOTS.has(slot.slotType);
 
                   return (
-                    <label
-                      key={slot.id}
-                      className={`flex items-center gap-3 p-3 rounded-md border cursor-pointer transition-all ${
-                        isSelected
-                          ? "bg-[#00C2FF]/10 border-[#00C2FF]/30"
-                          : "bg-vault-bg border-vault-border hover:border-vault-text-muted/30"
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        onChange={() => toggleAccessory(slot.accessory!.id)}
-                        className="sr-only"
-                      />
-                      <div
-                        className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
-                          isSelected
-                            ? "bg-[#00C2FF] border-[#00C2FF]"
-                            : "border-vault-border"
-                        }`}
-                      >
-                        {isSelected && (
-                          <svg className="w-2.5 h-2.5 text-vault-bg" fill="currentColor" viewBox="0 0 20 20">
-                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                          </svg>
-                        )}
+                    <label key={slot.id} className={`flex items-center gap-3 p-3 rounded-md border cursor-pointer transition-all ${
+                      isSelected ? "bg-[#00C2FF]/10 border-[#00C2FF]/30" : "bg-vault-bg border-vault-border hover:border-vault-text-muted/30"
+                    }`}>
+                      <input type="checkbox" checked={isSelected} onChange={() => toggleAccessory(slot.accessory!.id)} className="sr-only" />
+                      <div className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${isSelected ? "bg-[#00C2FF] border-[#00C2FF]" : "border-vault-border"}`}>
+                        {isSelected && <CheckCircle2 className="w-3 h-3 text-vault-bg" />}
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <p className="text-sm font-medium text-vault-text truncate">
-                            {slot.accessory.name}
-                          </p>
-                          {isRoundCountPart && (
-                            <span className="text-[10px] text-[#F5A623] border border-[#F5A623]/30 px-1.5 py-0.5 rounded font-mono">
-                              wear part
-                            </span>
-                          )}
+                          <p className="text-sm font-medium text-vault-text truncate">{slot.accessory.name}</p>
+                          {isRoundCountPart && <span className="text-[10px] text-[#F5A623] border border-[#F5A623]/30 px-1.5 py-0.5 rounded font-mono">wear part</span>}
                         </div>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <span className="text-[10px] text-vault-text-faint">
-                            {SLOT_TYPE_LABELS[slot.slotType] ?? slot.slotType}
-                          </span>
-                          <span className="text-[10px] text-vault-text-faint">·</span>
-                          <span className="text-[10px] font-mono text-vault-text-muted">
-                            {formatNumber(slot.accessory.roundCount)} rds total
-                          </span>
+                        <div className="flex items-center gap-2 mt-0.5 text-[10px] text-vault-text-faint">
+                          <span>{SLOT_TYPE_LABELS[slot.slotType] ?? slot.slotType}</span>
+                          <span>·</span>
+                          <span className="font-mono text-vault-text-muted">{formatNumber(slot.accessory.roundCount)} rds total</span>
                         </div>
                       </div>
-                      {isSelected && roundsFired && (
-                        <span className="text-xs font-mono text-[#00C2FF] shrink-0">
-                          +{formatNumber(parseInt(roundsFired) || 0)}
-                        </span>
-                      )}
                     </label>
                   );
                 })}
@@ -542,54 +636,155 @@ export default function RangeSessionPage() {
             <div className="bg-vault-surface border border-vault-border rounded-lg p-5">
               <div className="flex items-center gap-3">
                 <Shield className="w-4 h-4 text-vault-text-faint" />
-                <p className="text-sm text-vault-text-muted">
-                  This build has no accessories installed. Rounds fired won&apos;t be attributed to any parts.
-                </p>
+                <p className="text-sm text-vault-text-muted">This build has no accessories installed.</p>
               </div>
             </div>
           )}
 
-          {/* Session Note */}
-          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
-            <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">
-              Session Note
-            </legend>
-            <div>
-              <label className={LABEL_CLASS}>Notes</label>
-              <textarea
-                rows={3}
-                value={sessionNote}
-                onChange={(e) => setSessionNote(e.target.value)}
-                placeholder="e.g. Sunday range trip, competition practice, zeroing optic..."
-                className={`${INPUT_CLASS} resize-none`}
-              />
-            </div>
-          </fieldset>
-
-          {/* Submit */}
-          <div className="flex items-center justify-end gap-3 pt-2">
-            <div className="flex-1 text-xs text-vault-text-faint">
-              {selectedAccessories.size > 0 && (
-                <p>Will log rounds to {selectedAccessories.size} accessor{selectedAccessories.size !== 1 ? "ies" : "y"}</p>
-              )}
-              {selectedAmmoStock && roundsFired && (
-                <p>Will deduct {formatNumber(parseInt(roundsFired) || 0)} rounds from stock</p>
-              )}
-            </div>
+          <div className="flex items-center justify-end gap-3">
             <button
               type="submit"
-              disabled={submitting || !selectedFirearm || !roundsFired}
+              disabled={submitting || !selectedFirearm || !roundsFired || !selectedAmmoStock || !sessionDate || !sessionLocation}
               className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-6 py-2 rounded-md text-sm font-medium transition-colors"
             >
-              {submitting ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Target className="w-4 h-4" />
-              )}
+              {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Target className="w-4 h-4" />}
               {submitting ? "Logging..." : "Log Session"}
             </button>
           </div>
         </form>
+
+        <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drills</legend>
+
+          <div>
+            <label className={LABEL_CLASS}>Session</label>
+            <div className="relative">
+              <select
+                value={selectedSessionId}
+                onChange={(e) => setSelectedSessionId(e.target.value)}
+                className={INPUT_CLASS}
+                disabled={loadingSessions || sessions.length === 0}
+              >
+                <option value="">Select session...</option>
+                {sessions.map((session) => (
+                  <option key={session.id} value={session.id}>
+                    {new Date(session.sessionDate).toLocaleDateString()} · {session.location} · {session.firearm.name}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+            </div>
+          </div>
+
+          <form onSubmit={handleAddDrill} className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <label className={LABEL_CLASS}>Drill Name <span className="text-[#E53935]">*</span></label>
+                <input required value={drillName} onChange={(e) => setDrillName(e.target.value)} className={INPUT_CLASS} placeholder="e.g. Bill Drill" />
+              </div>
+              <div>
+                <label className={LABEL_CLASS}>Time (seconds) <span className="text-[#E53935]">*</span></label>
+                <input type="number" step="0.01" min="0.01" required value={drillTime} onChange={(e) => setDrillTime(e.target.value)} className={INPUT_CLASS} placeholder="2.45" />
+              </div>
+            </div>
+
+            <div className="grid md:grid-cols-4 gap-4">
+              <div>
+                <label className={LABEL_CLASS}>Points <span className="text-[#E53935]">*</span></label>
+                <input type="number" step="0.01" min="0" required value={drillPoints} onChange={(e) => setDrillPoints(e.target.value)} className={INPUT_CLASS} placeholder="90" />
+              </div>
+              <div>
+                <label className={LABEL_CLASS}>Penalties</label>
+                <input type="number" step="0.01" min="0" value={drillPenalties} onChange={(e) => setDrillPenalties(e.target.value)} className={INPUT_CLASS} placeholder="10" />
+              </div>
+              <div>
+                <label className={LABEL_CLASS}>Hits</label>
+                <input type="number" min="0" value={drillHits} onChange={(e) => setDrillHits(e.target.value)} className={INPUT_CLASS} placeholder="6" />
+              </div>
+              <div className="bg-vault-bg border border-vault-border rounded-md px-3 py-2">
+                <p className="text-[11px] text-vault-text-faint uppercase tracking-widest">Hit Factor</p>
+                <p className="text-lg font-mono text-[#00C2FF]">{drillHitFactorPreview.toFixed(4)}</p>
+              </div>
+            </div>
+
+            <div>
+              <label className={LABEL_CLASS}>Drill Notes</label>
+              <textarea rows={2} value={drillNotes} onChange={(e) => setDrillNotes(e.target.value)} className={`${INPUT_CLASS} resize-none`} />
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={submittingDrill || !selectedSessionId}
+                className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              >
+                {submittingDrill ? <Loader2 className="w-4 h-4 animate-spin" /> : <Timer className="w-4 h-4" />}
+                {submittingDrill ? "Saving..." : "Add Drill"}
+              </button>
+            </div>
+          </form>
+
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-widest text-vault-text-muted">Drill History</p>
+            {loadingDrills ? (
+              <div className="flex items-center gap-2 text-sm text-vault-text-muted"><Loader2 className="w-4 h-4 animate-spin" />Loading drills...</div>
+            ) : sessionDrills.length === 0 ? (
+              <p className="text-sm text-vault-text-faint">No drills logged yet for this session. Add your first drill above.</p>
+            ) : (
+              <div className="space-y-2">
+                {sessionDrills.map((drill) => (
+                  <div key={drill.id} className="bg-vault-bg border border-vault-border rounded-md p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-semibold text-vault-text">{drill.name}</p>
+                      <p className="text-xs font-mono text-[#00C2FF]">HF {drill.hitFactor.toFixed(4)}</p>
+                    </div>
+                    <div className="mt-1 text-xs text-vault-text-muted flex flex-wrap gap-3">
+                      <span>{drill.points} pts</span>
+                      <span>{drill.timeSeconds}s</span>
+                      {drill.penalties != null && <span>{drill.penalties} pen</span>}
+                      {drill.hits != null && <span>{drill.hits} hits</span>}
+                    </div>
+                    {drill.notes && <p className="text-xs text-vault-text-faint mt-1">{drill.notes}</p>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </fieldset>
+
+        <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+          <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session History</legend>
+
+          {loadingSessions ? (
+            <div className="flex items-center gap-2 text-sm text-vault-text-muted"><Loader2 className="w-4 h-4 animate-spin" />Loading sessions...</div>
+          ) : sessions.length === 0 ? (
+            <p className="text-sm text-vault-text-faint">No sessions logged yet. Save a range session to start drill history.</p>
+          ) : (
+            <div className="space-y-2">
+              {sessions.slice(0, 8).map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => setSelectedSessionId(session.id)}
+                  className={`w-full text-left p-3 rounded-md border transition-colors ${
+                    session.id === selectedSessionId ? "border-[#00C2FF]/50 bg-[#00C2FF]/10" : "border-vault-border bg-vault-bg hover:border-vault-text-muted/30"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-medium text-vault-text">{new Date(session.sessionDate).toLocaleDateString()} · {session.location}</p>
+                    <p className="text-xs font-mono text-[#F5A623]">{formatNumber(session.roundsFired)} rds</p>
+                  </div>
+                  <p className="text-xs text-vault-text-muted mt-1">
+                    {session.firearm.name}{session.build ? ` · ${session.build.name}` : ""} · {session.ammoLinks.map((link) => `${link.ammoStock.brand} (${link.roundsUsed})`).join(", ")}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {selectedSession?.sessionDrills?.length ? (
+            <p className="text-xs text-vault-text-faint">Session has {selectedSession.sessionDrills.length} drill entr{selectedSession.sessionDrills.length === 1 ? "y" : "ies"}.</p>
+          ) : null}
+        </fieldset>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Introduce first-class tracking for range sessions to persist session metadata, ammo usage, and drill performance history.
- Provide an atomic finalize flow to deduct ammo and increment accessory round counts tied to a saved session.
- Surface range session and drill data in exports and the existing UI to enable drill logging and session history.

### Description
- Add Prisma models `RangeSession`, `RangeSessionAmmoLink`, and `SessionDrill` to `schema.prisma` and include a SQL migration file `prisma/migrations/.../migration.sql` to create tables and indexes.
- Add new API endpoints: `GET/POST /api/range/sessions`, `POST /api/range/sessions/[id]/finalize`, and `GET/POST /api/range/sessions/[id]/drills` implementing validation, creation, finalize transaction logic, and drill hit-factor calculation.
- Update data export route to include `rangeSessions` with correct `sessionDate` ordering and include related drills and ammo links.
- Update the frontend range page `src/app/range/page.tsx` to support session creation, finalize flow, session & drill listing, drill creation UI, hit factor preview, and handling of finalize failure state.
- Update `.gitignore` to ignore runtime/binary artifacts and local DB files (`*.db`, `.next/`, `node_modules/`, `prisma/*.db`, `uploads/`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d65a54083269086c4ab5e4615fa)