### PR TITLE
fix(export-data): remove duplicate payload.settings assignment

### DIFF
--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -433,18 +433,16 @@ export async function GET(request: NextRequest) {
           }
           const settingsRecord = appSettings as Record<string, unknown>;
           payload.settings = {
-payload.settings = {
-  id: settingsRecord.id,
-  defaultCurrency: settingsRecord.defaultCurrency,
-  hasAppPassword: !!settingsRecord.appPassword,
-  hasEncryptionKey: !!settingsRecord.encryptionKey,
-  dataStoragePath: settingsRecord.dataStoragePath,
-  createdAt: settingsRecord.createdAt,
-  updatedAt: settingsRecord.updatedAt,
-  includeUploadsInBackup: settingsRecord.includeUploadsInBackup,
-  autoBackupEnabled: settingsRecord.autoBackupEnabled,
-  autoBackupCadence: settingsRecord.autoBackupCadence,
-};
+            id: settingsRecord.id,
+            defaultCurrency: settingsRecord.defaultCurrency,
+            hasAppPassword: !!settingsRecord.appPassword,
+            hasEncryptionKey: !!settingsRecord.encryptionKey,
+            dataStoragePath: settingsRecord.dataStoragePath,
+            createdAt: settingsRecord.createdAt,
+            updatedAt: settingsRecord.updatedAt,
+            includeUploadsInBackup: settingsRecord.includeUploadsInBackup,
+            autoBackupEnabled: settingsRecord.autoBackupEnabled,
+            autoBackupCadence: settingsRecord.autoBackupCadence,
           };
         })
       );


### PR DESCRIPTION
### Motivation
- The Next.js production build failed due to a malformed duplicate assignment in the export settings block which produced a parser error (`Expected a semicolon`).
- The change is intended to be a minimal syntax-only fix to restore a valid object assignment and unblock the build process.

### Description
- Removed the duplicated `payload.settings = {` / object literal lines and restored a single valid `payload.settings = { ... };` assignment inside `src/app/api/exports/data/route.ts` without changing field names or behavior.
- Normalized indentation of the restored object literal for readability only and checked the surrounding block for merge markers or other duplicated lines; none were found in that area.
- No unrelated code refactors were performed and no runtime behavior was intentionally changed beyond fixing the broken syntax.

### Testing
- Inspected the file around the error with `sed` and confirmed the duplicate assignment was the root cause and was removed.
- Ran `npx eslint src/app/api/exports/data/route.ts`; it reported pre-existing `@typescript-eslint/no-explicit-any` warnings but no syntax errors after the fix.
- Ran `npm run build`, which runs `prisma generate` and `prisma migrate deploy` as part of the build; Prisma steps and migrations applied successfully and Next.js progressed past the original parser error to TypeScript checks.
- Build outcome: the original syntax error is resolved, but the full `npm run build` now fails on an unrelated TypeScript type mismatch in `src/app/api/exports/full-armory/route.ts` (attachment `linkedItemType` value is typed as `string` but expected a union of specific literal types), so the overall build is not yet fully green.

Files changed:
- `src/app/api/exports/data/route.ts`

Diff summary:
- Single-file change; removed duplicate object assignment and adjusted indentation; net ~10 insertions and ~12 deletions limited to the `payload.settings` block.

Commands run:
- `sed -n '380,500p' src/app/api/exports/data/route.ts`
- `rg -n "payload\.settings\s*=\s*\{" src/app/api/exports/data/route.ts`
- `npx eslint src/app/api/exports/data/route.ts`
- `npm run build` (includes `prisma generate` and `prisma migrate deploy`)

Final status:
- The malformed duplicate `payload.settings` assignment was removed and the syntax error is fixed.
- `npm run build` no longer fails at the previous parse error, but the build still fails due to a separate TypeScript typing issue in `src/app/api/exports/full-armory/route.ts` which should be addressed next.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15e2d78cc8326b5fac97baa5c0945)