### PR TITLE
Improve typings and fix ammo summary generation in export and session routes

### DIFF
--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -433,18 +433,16 @@ export async function GET(request: NextRequest) {
           }
           const settingsRecord = appSettings as Record<string, unknown>;
           payload.settings = {
-payload.settings = {
-  id: settingsRecord.id,
-  defaultCurrency: settingsRecord.defaultCurrency,
-  hasAppPassword: !!settingsRecord.appPassword,
-  hasEncryptionKey: !!settingsRecord.encryptionKey,
-  dataStoragePath: settingsRecord.dataStoragePath,
-  createdAt: settingsRecord.createdAt,
-  updatedAt: settingsRecord.updatedAt,
-  includeUploadsInBackup: settingsRecord.includeUploadsInBackup,
-  autoBackupEnabled: settingsRecord.autoBackupEnabled,
-  autoBackupCadence: settingsRecord.autoBackupCadence,
-};
+            id: settingsRecord.id,
+            defaultCurrency: settingsRecord.defaultCurrency,
+            hasAppPassword: !!settingsRecord.appPassword,
+            hasEncryptionKey: !!settingsRecord.encryptionKey,
+            dataStoragePath: settingsRecord.dataStoragePath,
+            createdAt: settingsRecord.createdAt,
+            updatedAt: settingsRecord.updatedAt,
+            includeUploadsInBackup: settingsRecord.includeUploadsInBackup,
+            autoBackupEnabled: settingsRecord.autoBackupEnabled,
+            autoBackupCadence: settingsRecord.autoBackupCadence,
           };
         })
       );

--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -445,19 +445,27 @@ export async function GET(request: NextRequest) {
       }),
     ];
 
-    const attachmentsRows = exportOptions.includeDocuments
-      ? documents.map((doc) => ({
-          documentId: doc.id,
-          type: doc.type,
-          name: doc.name,
-          linkedItemId: doc.firearmId || doc.accessoryId || "",
-          linkedItemType: doc.firearmId ? "FIREARM" : doc.accessoryId ? "ACCESSORY" : "UNATTACHED",
-          linkedItemName: doc.firearm?.name || doc.accessory?.name || "",
-          mimeType: doc.mimeType ?? "",
-          fileSize: doc.fileSize ?? "",
-          fileUrl: doc.fileUrl,
-          uploadedAt: doc.createdAt.toISOString(),
-        }))
+    const attachmentsRows: FullArmoryExportResponse["attachments"] = exportOptions.includeDocuments
+      ? documents.map((doc) => {
+          const linkedItemType: "FIREARM" | "ACCESSORY" | "UNATTACHED" = doc.firearmId
+            ? "FIREARM"
+            : doc.accessoryId
+              ? "ACCESSORY"
+              : "UNATTACHED";
+
+          return {
+            documentId: doc.id,
+            type: doc.type,
+            name: doc.name,
+            linkedItemId: doc.firearmId || doc.accessoryId || "",
+            linkedItemType,
+            linkedItemName: doc.firearm?.name || doc.accessory?.name || "",
+            mimeType: doc.mimeType ?? "",
+            fileSize: doc.fileSize ?? "",
+            fileUrl: doc.fileUrl,
+            uploadedAt: doc.createdAt.toISOString(),
+          };
+        })
       : [];
 
     const ammoRows = exportOptions.includeAmmo

--- a/src/app/api/range/sessions/[id]/finalize/route.ts
+++ b/src/app/api/range/sessions/[id]/finalize/route.ts
@@ -8,7 +8,7 @@ export async function POST(
   try {
     const { id } = await params;
     const body = await request.json();
-    const selectedAccessoryIdsRaw = Array.isArray(body?.selectedAccessoryIds) ? body.selectedAccessoryIds : [];
+    const selectedAccessoryIdsRaw: unknown[] = Array.isArray(body?.selectedAccessoryIds) ? body.selectedAccessoryIds : [];
     const selectedAccessoryIds = selectedAccessoryIdsRaw.filter(
       (value): value is string => typeof value === "string" && value.length > 0
     );

--- a/src/lib/exports/full-armory-pdf.ts
+++ b/src/lib/exports/full-armory-pdf.ts
@@ -266,16 +266,28 @@ export async function generateFullArmoryPdf(
     }
   }
 
-  if (options.includeAmmo && payload.ammoSummary.length > 0) {
+  const ammoSummary = payload.ammo.reduce(
+    (acc, row) => {
+      const key = row.caliber || "Unknown";
+      const current = acc.get(key) ?? { totalRounds: 0, stockEntries: 0 };
+      current.totalRounds += row.quantity;
+      current.stockEntries += 1;
+      acc.set(key, current);
+      return acc;
+    },
+    new Map<string, { totalRounds: number; stockEntries: number }>()
+  );
+
+  if (options.includeAmmo && ammoSummary.size > 0) {
     addLine(10);
     doc.setFont("helvetica", "bold");
     doc.text("Ammo Summary", PAGE_MARGIN, y);
     addLine(12);
 
     doc.setFont("helvetica", "normal");
-    for (const row of payload.ammoSummary) {
+    for (const [caliber, row] of ammoSummary) {
       ensureSpace(12);
-      doc.text(`${row.caliber}: ${row.totalRounds.toLocaleString()} rounds (${row.stockEntries} entries)`, PAGE_MARGIN, y);
+      doc.text(`${caliber}: ${row.totalRounds.toLocaleString()} rounds (${row.stockEntries} entries)`, PAGE_MARGIN, y);
       addLine(10);
     }
   }


### PR DESCRIPTION
### Motivation
- Improve type safety and code clarity in several API routes and export generation logic.
- Remove a duplicated/incorrect assignment when building the settings payload to avoid subtle bugs.
- Ensure the ammo summary in the full-armory PDF is computed from the raw ammo rows so counts are correct and calibers are grouped.

### Description
- Clean up settings payload construction in `src/app/api/exports/data/route.ts` by removing a duplicated assignment and adjusting the structure inside the promise.
- Add an explicit type for `attachmentsRows` and create a typed `linkedItemType` variable in `src/app/api/exports/full-armory/route.ts` to improve typing and readability.
- Tighten the type of `selectedAccessoryIdsRaw` to `unknown[]` and keep a type-safe filter in `src/app/api/range/sessions/[id]/finalize/route.ts` to avoid unsafe `any` propagation.
- Replace use of `payload.ammoSummary` with a computed `Map` built from `payload.ammo` in `src/lib/exports/full-armory-pdf.ts`, grouping by caliber (with a fallback of `"Unknown"`) and rendering the aggregated values in the PDF.

### Testing
- Ran `tsc` type checking locally and verified there are no new type errors.
- Ran the repository linting and unit test suite where available and observed all checks passing.
- Manually exercised the full-armory export path in a development build to confirm ammo summary output appears as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15e2d78cc8326b5fac97baa5c0945)