### PR TITLE
Add Exports panel to Settings and Documents nav item in sidebar

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
   Save,
@@ -13,6 +14,7 @@ import {
   ShieldCheck,
   Archive,
   Database,
+  Download,
 } from "lucide-react";
 
 const INPUT_CLASS =
@@ -307,6 +309,27 @@ export default function SettingsPage() {
                 Use this with a cron job, compose schedule, or host script that calls the export endpoint.
               </p>
             </div>
+          </fieldset>
+
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+                <Download className="w-3.5 h-3.5" />
+                Exports
+              </legend>
+            </div>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              Generate full armory exports for backups, insurance records, or offline sharing.
+            </p>
+
+            <Link
+              href="/exports/full-armory"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/10 transition-colors text-sm font-medium"
+            >
+              <Download className="w-4 h-4" />
+              Open Full Armory Exports
+            </Link>
           </fieldset>
 
           <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Zap,
   X,
   LogOut,
+  FileText,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useEffect } from "react";
@@ -30,6 +31,12 @@ const NAV_ITEMS = [
     href: "/vault",
     icon: Shield,
     description: "Firearms inventory",
+  },
+  {
+    label: "Documents",
+    href: "/documents",
+    icon: FileText,
+    description: "Document library",
   },
   {
     label: "Loadouts",


### PR DESCRIPTION
### Motivation
- Surface a dedicated Exports entry in the Settings UI so users can generate full-armory exports for backups and offline sharing.
- Expose a top-level "Documents" route in the main navigation to make the document library discoverable.

### Description
- Imported `Link` and the `Download` icon into `src/app/settings/page.tsx` and added a new Exports `fieldset` with explanatory text and a link to `/exports/full-armory`.
- Added `FileText` import and appended a new `Documents` item to the `NAV_ITEMS` array in `src/components/layout/Sidebar.tsx` with `href: "/documents"` and the `FileText` icon.
- Kept UI styling consistent with existing components and reused existing design tokens and classes for buttons and fieldsets.

### Testing
- Ran the TypeScript build (`pnpm build` / `next build`) and the typechecker, and the build completed successfully.
- Ran the project's automated test suite (`pnpm test`) and linting (`pnpm lint`), and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c164a73ae48326b247ad3b4175068a)