### PR TITLE
Improve nav discoverability and keep logout visible in password mode

### DIFF
--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -34,10 +34,13 @@ export function MobileHeader({ passwordModeEnabled = false }: MobileHeaderProps)
       <header className="md:hidden flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
         <button
           onClick={() => setOpen(true)}
-          className="p-1.5 text-vault-text-faint hover:text-vault-text-muted transition-colors"
+          className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"
           aria-label="Open navigation"
         >
           <Menu className="w-5 h-5" />
+          <span className="text-[11px] font-medium tracking-wider uppercase">
+            Menu
+          </span>
         </button>
         <div className="flex items-center gap-2">
           <div className="w-6 h-6 rounded bg-[#00C2FF]/10 border border-[#00C2FF]/30 flex items-center justify-center">
@@ -51,10 +54,13 @@ export function MobileHeader({ passwordModeEnabled = false }: MobileHeaderProps)
           <button
             onClick={handleLogout}
             disabled={loggingOut}
-            className="ml-auto p-1.5 text-vault-text-faint hover:text-vault-text-muted transition-colors disabled:opacity-60"
+            className="ml-auto inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60"
             aria-label="Logout"
           >
             <LogOut className="w-4 h-4" />
+            <span className="text-[11px] font-medium tracking-wider uppercase">
+              {loggingOut ? "Exit..." : "Logout"}
+            </span>
           </button>
         )}
       </header>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -139,6 +139,11 @@ export function Sidebar({
 
       {/* Nav */}
       <nav className="flex-1 overflow-y-auto py-3 space-y-0.5 px-2">
+        {!collapsed && (
+          <p className="px-2.5 pb-2 text-[10px] tracking-[0.18em] uppercase text-vault-text-faint">
+            Navigation
+          </p>
+        )}
         {NAV_ITEMS.map((item) => {
           const Icon = item.icon;
           const isActive =
@@ -168,8 +173,13 @@ export function Sidebar({
                 )}
               />
               {!collapsed && (
-                <span className="font-medium tracking-wide truncate">
-                  {item.label}
+                <span className="min-w-0">
+                  <span className="block font-medium tracking-wide truncate">
+                    {item.label}
+                  </span>
+                  <span className="block text-[11px] text-vault-text-faint truncate">
+                    {item.description}
+                  </span>
                 </span>
               )}
             </Link>
@@ -182,7 +192,7 @@ export function Sidebar({
           <button
             onClick={handleLogout}
             disabled={loggingOut}
-            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors disabled:opacity-60"
+            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60"
             title={collapsed ? "Logout" : undefined}
           >
             <LogOut className="w-4 h-4 shrink-0" />


### PR DESCRIPTION
### Motivation
- Make primary navigation easier to scan and understand by surfacing a clear section label and short per-route descriptions in the sidebar.
- Ensure the logout control is obvious and reachable whenever password-protected mode is enabled so users can quickly exit an unlocked session.
- Keep changes minimal and purely presentation-focused so the simple cookie/session-based auth model and flows are unchanged.

### Description
- Added a visible `Navigation` section label to the expanded sidebar and short route descriptions under each item for improved discoverability by editing `src/components/layout/Sidebar.tsx`.
- Show route descriptions below each label when the sidebar is expanded and keep the compact icon-only layout when collapsed to preserve the existing collapse behavior.
- Increased visual prominence of logout controls by applying a higher-contrast, red-tinted button style in the sidebar and a labeled high-contrast button in the mobile header in `src/components/layout/Sidebar.tsx` and `src/components/layout/MobileHeader.tsx`.
- Replaced the mobile navigation trigger from an icon-only button to a labeled `Menu` button to improve discoverability on small screens, and added a small text label to the mobile logout to match the desktop emphasis.

### Testing
- Ran `npm run lint`, which failed due to pre-existing lint errors in unrelated files (for example `src/app/ammo/page.tsx`, `src/components/layout/ThemeProvider.tsx`, and several `src/app/api/**` routes), so lint status remains red.
- Ran `npm run build`, which completed successfully and produced a successful Next.js production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1692ea48083268d071611df1a83db)