### PR TITLE
docs: finalize V1 release checklist and README self-hosted messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A self-hosted tactical firearms management application built with Next.js 16, Prisma, and SQLite.
 
+> BlackVault is designed for local/self-managed deployment. No cloud account or external managed service is required for core usage.
+
 ```
 [ screenshot placeholder ]
 ```
@@ -73,9 +75,9 @@ docker-compose down
 
 The container automatically runs `prisma migrate deploy` on startup before serving traffic.
 
-Data is persisted in named Docker volumes:
-- `blackvault-db` — SQLite database at `/app/data/vault.db`
-- `blackvault-uploads` — User-uploaded images at `/app/uploads`
+Data is persisted in host-mounted paths configured by `DATA_DIR`:
+- `${DATA_DIR}/db` — SQLite database at `/app/data/vault.db`
+- `${DATA_DIR}/uploads` — User-uploaded images at `/app/uploads`
 
 ---
 
@@ -131,3 +133,20 @@ ProjectBlackVault/
 ├── docker-compose.yml
 └── .env.example
 ```
+
+---
+
+## V1 Release Readiness
+
+Use the release checklist before tagging a V1 release:
+
+- [docs/release-checklist.md](docs/release-checklist.md)
+
+Minimum validation commands:
+
+```bash
+npm run lint
+npm run build
+docker compose config
+```
+

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,49 @@
+# BlackVault V1 Release Checklist
+
+This checklist is for **self-hosted** V1 release readiness only.
+
+## 1) Product & Messaging
+
+- [ ] README describes BlackVault as self-hosted software.
+- [ ] No cloud/SaaS dependency is required to run core features.
+- [ ] Install paths and Docker-first setup flow are documented.
+
+## 2) Install & Upgrade Paths
+
+- [ ] Linux/macOS setup tested with `./install.sh`.
+- [ ] Windows setup tested with `install.bat`.
+- [ ] Update path documented with `./update.sh` (and `update.bat` on Windows).
+- [ ] Generated `.blackvault.env` includes `DATA_DIR`, `PORT`, and `VAULT_ENCRYPTION_KEY`.
+
+## 3) Containerization
+
+- [ ] `Dockerfile` builds with multi-stage flow (deps → builder → runner).
+- [ ] Runtime runs as non-root user.
+- [ ] Prisma migrations run on container startup.
+- [ ] `docker-compose.yml` mounts persistent DB and uploads directories.
+- [ ] Healthcheck endpoint `/api/health` is configured.
+
+## 4) Release Validation Commands
+
+Run from repository root:
+
+```bash
+npm run lint
+npm run build
+docker compose config
+```
+
+- [ ] `npm run lint` passes.
+- [ ] `npm run build` passes.
+- [ ] `docker compose config` passes.
+
+## 5) Release Blockers
+
+Mark any blocker found during validation:
+
+- [ ] None
+- [ ] Blockers documented below
+
+### Blocker Notes
+
+- _None at this time._


### PR DESCRIPTION
### Motivation
- Prepare final, conservative release-facing documentation for V1 focused on self-hosted deployments and a concise validation checklist. 
- Make it explicit where persistent data lives and surface the minimum validation commands maintainers should run before tagging V1.

### Description
- Add `docs/release-checklist.md` containing the V1 readiness checklist and validation steps. 
- Update `README.md` to add an explicit self-hosted usage note, correct Docker persistence wording to reflect `DATA_DIR` host mounts, and append a `V1 Release Readiness` section that links to the new checklist and lists required validation commands. 
- No feature code was modified and Docker install/update paths in `install.sh` / `install.bat` remain unchanged.

### Testing
- Ran `npm run lint`, which failed due to pre-existing lint errors in application code (examples include `src/app/ammo/page.tsx`, `src/components/layout/ThemeProvider.tsx`, and several `src/app/api/*` files). 
- Ran `npm run build`, which completed successfully (Prisma client generated, migrations applied, and Next.js produced the optimized build). 
- Attempted `docker compose config` but the Docker CLI is unavailable in this execution environment so the check could not be executed here (reported as `docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c169435d60832692fa58bca521f1de)