### PR TITLE
Harden backup export and settings validation

### DIFF
--- a/src/app/api/exports/data/route.backup.test.ts
+++ b/src/app/api/exports/data/route.backup.test.ts
@@ -136,4 +136,58 @@ describe("/api/exports/data backup metadata", () => {
     expect(response.status).toBe(400);
     expect(json.error).toMatch(/Supported values: csv, pdf/);
   });
+
+  it("filters unsafe upload URLs and deduplicates references", async () => {
+    mocks.appSettingsFindUnique.mockResolvedValue({
+      id: "singleton",
+      includeUploadsInBackup: true,
+    });
+    mocks.firearmFindMany.mockResolvedValue([
+      {
+        id: "f1",
+        name: "Duty Rifle",
+        imageUrl: " /api/files/images/firearms/f1_1.webp ",
+        serialNumber: "SER123",
+      },
+      {
+        id: "f1",
+        name: "Duty Rifle Copy",
+        imageUrl: "/api/files/images/firearms/f1_1.webp",
+        serialNumber: "SER123",
+      },
+      {
+        id: "f2",
+        name: "Unsafe Rifle",
+        imageUrl: "/api/files/../../etc/passwd",
+      },
+    ]);
+
+    const response = await GET(new NextRequest(`http://localhost/api/exports/data?${BASE_QUERY}`));
+    const csv = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(csv).toContain("uploadedAssetReferences");
+    expect(csv).toContain("/api/files/images/firearms/f1_1.webp");
+    const uploadedReferenceLines = csv
+      .split("\n")
+      .filter((line) => line.startsWith("uploadedAssetReferences,"));
+    expect(uploadedReferenceLines.some((line) => line.includes("../../etc/passwd"))).toBe(false);
+    const firearmReferenceMatches = csv.match(/firearmImage/g) ?? [];
+    expect(firearmReferenceMatches.length).toBe(1);
+  });
+
+  it("defaults includeUploadReferences to true when settings value is malformed", async () => {
+    mocks.appSettingsFindUnique.mockResolvedValue({
+      id: "singleton",
+      includeUploadsInBackup: "nope",
+    });
+
+    const response = await GET(new NextRequest(`http://localhost/api/exports/data?${BASE_QUERY}`));
+    const csv = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(csv).toContain("includeUploadReferences");
+    expect(csv).toContain("true");
+    expect(csv).toContain("uploadedAssetReferences");
+  });
 });

--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
 type ExportFormat = "csv" | "pdf";
+type UploadReferenceKind = "firearmImage" | "accessoryImage" | "document";
 
 type SectionFlags = {
   firearms: boolean;
@@ -40,6 +41,16 @@ function parseFormat(searchParams: URLSearchParams): ExportFormat {
   const format = (searchParams.get("format") ?? "csv").trim().toLowerCase();
   if (format === "csv" || format === "pdf") return format;
   throw new Error("INVALID_FORMAT");
+}
+
+function normalizeIncludeUploadReferences(value: unknown): boolean {
+  return typeof value === "boolean" ? value : true;
+}
+
+function isLocalUploadUrl(url: string): boolean {
+  if (!url.startsWith("/api/files/")) return false;
+  if (url.includes("..")) return false;
+  return true;
 }
 
 function toSerializable(value: unknown): string {
@@ -329,7 +340,7 @@ export async function GET(request: NextRequest) {
     const format = parseFormat(searchParams);
     const includeSerialNumbers = parseBool(searchParams.get("includeSerialNumbers"), false);
     const appSettings = await prisma.appSettings.findUnique({ where: { id: "singleton" } });
-    const includeUploadReferences = appSettings?.includeUploadsInBackup ?? true;
+    const includeUploadReferences = normalizeIncludeUploadReferences(appSettings?.includeUploadsInBackup);
 
     const payload: Record<string, unknown> = {
       meta: {
@@ -452,13 +463,21 @@ export async function GET(request: NextRequest) {
 
     if (includeUploadReferences) {
       const uploadReferences: Array<Record<string, string>> = [];
-      const addReference = (kind: string, sourceId: string, url: string) => {
-        if (!url.startsWith("/api/files/")) return;
+      const seenReferenceKeys = new Set<string>();
+
+      const addReference = (kind: UploadReferenceKind, sourceId: string, url: string) => {
+        const normalizedSourceId = sourceId.trim();
+        const normalizedUrl = url.trim();
+        if (!normalizedSourceId) return;
+        if (!isLocalUploadUrl(normalizedUrl)) return;
+        const dedupeKey = `${kind}:${normalizedSourceId}:${normalizedUrl}`;
+        if (seenReferenceKeys.has(dedupeKey)) return;
+        seenReferenceKeys.add(dedupeKey);
         uploadReferences.push({
           kind,
-          sourceId,
-          url,
-          storagePath: url.replace("/api/files/", "storage/uploads/"),
+          sourceId: normalizedSourceId,
+          url: normalizedUrl,
+          storagePath: normalizedUrl.replace("/api/files/", "storage/uploads/"),
         });
       };
 

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -136,4 +136,65 @@ describe("/api/settings backup fields", () => {
     expect(json.error).toMatch(/Invalid auto backup cadence/i);
     expect(mocks.upsert).not.toHaveBeenCalled();
   });
+
+  it("rejects string booleans for backup flags", async () => {
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      body: JSON.stringify({
+        includeUploadsInBackup: "yes",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await PUT(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toMatch(/includeUploadsInBackup must be a boolean/i);
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("normalizes and validates defaultCurrency", async () => {
+    mocks.upsert.mockResolvedValue({
+      id: "singleton",
+      defaultCurrency: "EUR",
+      googleCseApiKey: null,
+      enableImageSearch: false,
+    });
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      body: JSON.stringify({
+        defaultCurrency: " eur ",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(200);
+    const upsertArgs = mocks.upsert.mock.calls[0][0];
+    expect(upsertArgs.update.defaultCurrency).toBe("EUR");
+  });
+
+  it("rejects empty update payloads", async () => {
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      body: JSON.stringify({}),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await PUT(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toMatch(/No valid settings fields provided/i);
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,6 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+const ALLOWED_AUTO_BACKUP_CADENCE = new Set(["daily", "weekly", "monthly"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBooleanField(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return null;
+}
+
+function normalizeCurrency(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(normalized)) return null;
+  return normalized;
+}
+
 // GET /api/settings - Get the singleton AppSettings
 export async function GET() {
   try {
@@ -39,7 +62,13 @@ export async function GET() {
 // PUT /api/settings - Update the singleton AppSettings
 export async function PUT(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { error: "Invalid JSON body. Expected an object payload." },
+        { status: 400 }
+      );
+    }
 
     const {
       includeUploadsInBackup,
@@ -52,17 +81,36 @@ export async function PUT(request: NextRequest) {
     const updateData: Record<string, unknown> = {};
 
     if (includeUploadsInBackup !== undefined) {
-      updateData.includeUploadsInBackup = Boolean(includeUploadsInBackup);
+      const parsed = parseBooleanField(includeUploadsInBackup);
+      if (parsed == null) {
+        return NextResponse.json(
+          { error: "includeUploadsInBackup must be a boolean." },
+          { status: 400 }
+        );
+      }
+      updateData.includeUploadsInBackup = parsed;
     }
 
     if (autoBackupEnabled !== undefined) {
-      updateData.autoBackupEnabled = Boolean(autoBackupEnabled);
+      const parsed = parseBooleanField(autoBackupEnabled);
+      if (parsed == null) {
+        return NextResponse.json(
+          { error: "autoBackupEnabled must be a boolean." },
+          { status: 400 }
+        );
+      }
+      updateData.autoBackupEnabled = parsed;
     }
 
     if (autoBackupCadence !== undefined) {
+      if (typeof autoBackupCadence !== "string") {
+        return NextResponse.json(
+          { error: "autoBackupCadence must be a string value." },
+          { status: 400 }
+        );
+      }
       const cadence = String(autoBackupCadence).trim().toLowerCase();
-      const allowed = new Set(["daily", "weekly", "monthly"]);
-      if (!allowed.has(cadence)) {
+      if (!ALLOWED_AUTO_BACKUP_CADENCE.has(cadence)) {
         return NextResponse.json(
           { error: "Invalid auto backup cadence. Use daily, weekly, or monthly." },
           { status: 400 }
@@ -72,11 +120,31 @@ export async function PUT(request: NextRequest) {
     }
 
     if (defaultCurrency !== undefined) {
-      updateData.defaultCurrency = defaultCurrency;
+      const normalized = normalizeCurrency(defaultCurrency);
+      if (normalized == null) {
+        return NextResponse.json(
+          { error: "defaultCurrency must be a 3-letter currency code." },
+          { status: 400 }
+        );
+      }
+      updateData.defaultCurrency = normalized;
     }
 
     if (appPassword !== undefined) {
+      if (appPassword !== null && typeof appPassword !== "string") {
+        return NextResponse.json(
+          { error: "appPassword must be a string or null." },
+          { status: 400 }
+        );
+      }
       updateData.appPassword = appPassword === "" ? null : appPassword;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: "No valid settings fields provided." },
+        { status: 400 }
+      );
     }
 
     const settings = await prisma.appSettings.upsert({


### PR DESCRIPTION
### Motivation
- Prevent accidental or malformed settings writes and reduce backup export surface for unsafe asset references by adding targeted validation and sanitization in the backup/settings APIs.
- Improve reliability of backup metadata generation so consumers get consistent, deduplicated, and safe references for uploaded assets.

### Description
- Tightened `PUT /api/settings` input handling by rejecting non-object JSON bodies and enforcing field-level types and formats for `includeUploadsInBackup`, `autoBackupEnabled`, `autoBackupCadence`, `defaultCurrency`, and `appPassword`.
- Added small helper functions: `isRecord`, `parseBooleanField`, `normalizeCurrency`, and `ALLOWED_AUTO_BACKUP_CADENCE` to centralize validation logic.
- Hardened `GET /api/exports/data` backup metadata by normalizing malformed DB values for `includeUploadsInBackup`, trimming inputs, filtering out non-local or path-traversal upload URLs (rejecting values containing `..` or not starting with `/api/files/`), and deduplicating uploaded asset references via a `Set` keying strategy.
- Added/updated unit tests that cover the new validation and sanitization behaviors and edge cases.
- Files changed: `src/app/api/settings/route.ts`, `src/app/api/settings/route.test.ts`, `src/app/api/exports/data/route.ts`, `src/app/api/exports/data/route.backup.test.ts`.

### Testing
- Ran `npx vitest run src/app/api/exports/data/route.backup.test.ts src/app/api/settings/route.test.ts` and all tests passed (`13/13` tests passed).
- Ran `npm run lint` which failed due to pre-existing, unrelated repository lint issues outside the modified files (examples: `src/app/ammo/page.tsx` and `src/components/layout/ThemeProvider.tsx`).
- Ran `npm run build` which failed in this environment due to a Prisma engine checksum fetch error (external artifact fetch returned `403 Forbidden`).
- Attempting `node --test` on the TypeScript test files is not supported in this environment and fails on unknown `.ts` file extension; `vitest` was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c168cc31bc8326a4c3287dd11f2332)