### PR TITLE
Wave 4: Sidebar logout & Range nav, configurator accessory unification + custom slot

### DIFF
--- a/src/app/api/accessories/route.ts
+++ b/src/app/api/accessories/route.ts
@@ -7,9 +7,13 @@ function normalizeString(value: unknown) {
 }
 
 // GET /api/accessories - List all accessories with current build name
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url);
+    const type = normalizeString(searchParams.get("type"));
+
     const accessories = await prisma.accessory.findMany({
+      where: type ? { type } : undefined,
       include: {
         buildSlots: {
           include: {

--- a/src/app/range/page.tsx
+++ b/src/app/range/page.tsx
@@ -491,7 +491,7 @@ export default function RangeSessionPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form id="log-range-session" onSubmit={handleSubmit} className="space-y-6 scroll-mt-20">
           <fieldset className={SECTION_CARD_CLASS}>
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session Details</legend>
             <p className="text-xs text-vault-text-faint -mt-1">Required fields are marked with <span className="text-[#E53935]">*</span>.</p>
@@ -674,7 +674,7 @@ export default function RangeSessionPage() {
           </div>
         </form>
 
-        <fieldset className={SECTION_CARD_CLASS}>
+        <fieldset id="log-a-drill" className={`${SECTION_CARD_CLASS} scroll-mt-20`}>
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drills</legend>
 
           <div>
@@ -709,7 +709,7 @@ export default function RangeSessionPage() {
               </div>
             </div>
 
-            <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+            <div id="hit-factor-calculator" className="grid sm:grid-cols-2 md:grid-cols-4 gap-4 scroll-mt-20">
               <div>
                 <label className={LABEL_CLASS}>Points <span className="text-[#E53935]">*</span></label>
                 <input type="number" step="0.01" min="0" required value={drillPoints} onChange={(e) => setDrillPoints(e.target.value)} className={INPUT_CLASS} placeholder="90" />
@@ -745,8 +745,9 @@ export default function RangeSessionPage() {
             </div>
           </form>
 
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-widest text-vault-text-muted">Drill History</p>
+          <div id="drill-performance" className="space-y-2 scroll-mt-20">
+            <p className="text-xs uppercase tracking-widest text-vault-text-muted">Drill Performance</p>
+            <p id="drill-library" className="text-[11px] text-vault-text-faint">Drill Library: use your saved drill names below as repeatable templates.</p>
             {loadingDrills ? (
               <div className="flex items-center gap-2 text-sm text-vault-text-muted"><Loader2 className="w-4 h-4 animate-spin" />Loading drills...</div>
             ) : sessionDrills.length === 0 ? (
@@ -773,7 +774,7 @@ export default function RangeSessionPage() {
           </div>
         </fieldset>
 
-        <fieldset className={SECTION_CARD_CLASS}>
+        <fieldset id="range-session-history" className={`${SECTION_CARD_CLASS} scroll-mt-20`}>
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session History</legend>
 
           {loadingSessions ? (

--- a/src/app/vault/[id]/builds/[buildId]/page.tsx
+++ b/src/app/vault/[id]/builds/[buildId]/page.tsx
@@ -18,6 +18,19 @@ import {
 import { SLOTS_BY_FIREARM_TYPE, SLOT_TYPE_LABELS, FirearmType, SlotType } from "@/lib/types";
 import { SLOT_ICONS } from "@/lib/configurator/slot-icons";
 
+const CUSTOM_SLOT_PREFIX = "CUSTOM:";
+
+function getSlotLabel(slotType: string) {
+  if (slotType.startsWith(CUSTOM_SLOT_PREFIX)) {
+    return slotType.slice(CUSTOM_SLOT_PREFIX.length) || "Custom Slot";
+  }
+  return SLOT_TYPE_LABELS[slotType as SlotType] ?? slotType;
+}
+
+function getSlotIconConfig(slotType: string) {
+  return SLOT_ICONS[slotType as SlotType];
+}
+
 // ─── Types ────────────────────────────────────────────────────
 
 interface Accessory {
@@ -59,7 +72,7 @@ interface Build {
 // ─── Accessory Browser Modal ───────────────────────────────────
 
 interface AccessoryBrowserModalProps {
-  slotType: SlotType;
+  slotType: string;
   buildId: string;
   onClose: () => void;
   onAssigned: () => void;
@@ -79,7 +92,17 @@ function AccessoryBrowserModal({
   const [assignError, setAssignError] = useState<string | null>(null);
 
   const [view, setView] = useState<"browse" | "create">("browse");
-  const [form, setForm] = useState({ name: "", manufacturer: "", model: "", caliber: "", purchasePrice: "" });
+  const [form, setForm] = useState({
+    name: "",
+    manufacturer: "",
+    model: "",
+    caliber: "",
+    purchasePrice: "",
+    hasBattery: false,
+    batteryType: "",
+    replacementIntervalDays: "",
+    lastBatteryChangeDate: "",
+  });
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
@@ -151,6 +174,12 @@ function AccessoryBrowserModal({
           type: slotType,
           caliber: form.caliber.trim() || undefined,
           purchasePrice: form.purchasePrice ? parseFloat(form.purchasePrice) : undefined,
+          hasBattery: form.hasBattery,
+          batteryType: form.batteryType.trim() || undefined,
+          replacementIntervalDays: form.replacementIntervalDays
+            ? parseInt(form.replacementIntervalDays, 10)
+            : undefined,
+          lastBatteryChangeDate: form.lastBatteryChangeDate || undefined,
         }),
       });
       const created = await createRes.json();
@@ -178,7 +207,7 @@ function AccessoryBrowserModal({
     }
   }
 
-  const slotIconConfig = SLOT_ICONS[slotType as SlotType];
+  const slotIconConfig = getSlotIconConfig(slotType);
   const SlotIcon = slotIconConfig?.icon ?? Shield;
 
   return (
@@ -204,7 +233,7 @@ function AccessoryBrowserModal({
                 Assign Attachment
               </p>
               <h2 className="text-sm font-semibold text-vault-text">
-                {SLOT_TYPE_LABELS[slotType]}
+                {getSlotLabel(slotType)}
               </h2>
             </div>
           </div>
@@ -249,7 +278,7 @@ function AccessoryBrowserModal({
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder={`Search ${SLOT_TYPE_LABELS[slotType]} accessories...`}
+                placeholder={`Search ${getSlotLabel(slotType)} accessories...`}
                 className="w-full bg-vault-bg border border-vault-border text-vault-text rounded-md pl-9 pr-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint"
                 autoFocus
               />
@@ -285,7 +314,7 @@ function AccessoryBrowserModal({
                 <p className="text-sm text-vault-text-muted">
                   {search
                     ? "No accessories match your search"
-                    : `No ${SLOT_TYPE_LABELS[slotType]} accessories in your collection`}
+                    : `No ${getSlotLabel(slotType)} accessories in your collection`}
                 </p>
                 {!search && (
                   <button
@@ -369,7 +398,7 @@ function AccessoryBrowserModal({
               <div>
                 <label className="block text-[10px] uppercase tracking-widest text-vault-text-faint mb-1.5">Type</label>
                 <div className="bg-vault-bg border border-vault-border rounded-md px-3 py-2 text-sm text-vault-text-muted font-mono">
-                  {SLOT_TYPE_LABELS[slotType]}
+                  {getSlotLabel(slotType)}
                 </div>
               </div>
               {/* Name */}
@@ -406,6 +435,37 @@ function AccessoryBrowserModal({
                 <input type="number" value={form.purchasePrice} onChange={e => setForm(f => ({...f, purchasePrice: e.target.value}))}
                   className="w-full bg-vault-bg border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint"
                   placeholder="0.00" />
+              </div>
+
+              <div className="rounded-md border border-vault-border p-3 space-y-3">
+                <label className="flex items-center gap-2 text-xs text-vault-text-muted">
+                  <input
+                    type="checkbox"
+                    checked={form.hasBattery}
+                    onChange={(e) => setForm((f) => ({ ...f, hasBattery: e.target.checked }))}
+                    className="rounded border-vault-border"
+                  />
+                  This accessory uses a battery
+                </label>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-[10px] uppercase tracking-widest text-vault-text-faint mb-1.5">Battery Type</label>
+                    <input value={form.batteryType} onChange={e => setForm(f => ({...f, batteryType: e.target.value}))}
+                      className="w-full bg-vault-bg border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint"
+                      placeholder="e.g. CR2032" />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] uppercase tracking-widest text-vault-text-faint mb-1.5">Replacement Interval (days)</label>
+                    <input type="number" min="1" step="1" value={form.replacementIntervalDays} onChange={e => setForm(f => ({...f, replacementIntervalDays: e.target.value}))}
+                      className="w-full bg-vault-bg border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint"
+                      placeholder="180" />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-[10px] uppercase tracking-widest text-vault-text-faint mb-1.5">Last Battery Change</label>
+                  <input type="date" value={form.lastBatteryChangeDate} onChange={e => setForm(f => ({...f, lastBatteryChangeDate: e.target.value}))}
+                    className="w-full bg-vault-bg border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint" />
+                </div>
               </div>
             </div>
           </div>
@@ -458,17 +518,21 @@ function AccessoryBrowserModal({
 
 interface WeaponCanvasProps {
   build: Build;
-  onSlotClick: (slotType: SlotType) => void;
-  onRemoveSlot: (slotType: SlotType) => void;
+  onSlotClick: (slotType: string) => void;
+  onRemoveSlot: (slotType: string) => void;
 }
 
 function WeaponCanvas({ build, onSlotClick, onRemoveSlot }: WeaponCanvasProps) {
   const firearmType = build.firearm.type as FirearmType;
-  const availableSlots = SLOTS_BY_FIREARM_TYPE[firearmType] ?? [];
+  const baseSlots = SLOTS_BY_FIREARM_TYPE[firearmType] ?? [];
+  const customSlots = build.slots
+    .map((slot) => slot.slotType)
+    .filter((slotType) => slotType.startsWith(CUSTOM_SLOT_PREFIX));
+  const availableSlots = [...baseSlots, ...customSlots];
 
-  const slotMap: Partial<Record<SlotType, BuildSlot>> = {};
+  const slotMap: Record<string, BuildSlot> = {};
   for (const slot of build.slots) {
-    slotMap[slot.slotType as SlotType] = slot;
+    slotMap[slot.slotType] = slot;
   }
 
   return (
@@ -486,7 +550,7 @@ function WeaponCanvas({ build, onSlotClick, onRemoveSlot }: WeaponCanvasProps) {
           {availableSlots.map((slotType) => {
             const slot = slotMap[slotType];
             const hasAccessory = !!slot?.accessory;
-            const slotIconConfig = SLOT_ICONS[slotType];
+            const slotIconConfig = getSlotIconConfig(slotType);
             const SlotIcon = slotIconConfig?.icon ?? Shield;
 
             return (
@@ -500,9 +564,7 @@ function WeaponCanvas({ build, onSlotClick, onRemoveSlot }: WeaponCanvasProps) {
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <p className="text-[10px] uppercase tracking-widest font-mono text-vault-text-faint">
-                      {SLOT_TYPE_LABELS[slotType]}
-                    </p>
+                    <p className="text-[10px] uppercase tracking-widest font-mono text-vault-text-faint">{getSlotLabel(slotType)}</p>
                     <span
                       className={`inline-flex mt-1 text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded border ${
                         hasAccessory
@@ -569,24 +631,58 @@ interface SlotPanelProps {
   build: Build;
   allBuilds: Build[];
   onSwitchBuild: (buildId: string) => void;
+  onAddCustomSlot: (label: string) => Promise<void>;
 }
 
 function SlotPanel({
   build,
   allBuilds,
   onSwitchBuild,
+  onAddCustomSlot,
 }: SlotPanelProps) {
   const [switchOpen, setSwitchOpen] = useState(false);
+  const [newCustomSlot, setNewCustomSlot] = useState("");
+  const [addingCustomSlot, setAddingCustomSlot] = useState(false);
+  const [customSlotError, setCustomSlotError] = useState<string | null>(null);
   const firearmType = build.firearm.type as FirearmType;
-  const availableSlots = SLOTS_BY_FIREARM_TYPE[firearmType] ?? [];
+  const baseSlots = SLOTS_BY_FIREARM_TYPE[firearmType] ?? [];
+  const customSlots = build.slots
+    .map((slot) => slot.slotType)
+    .filter((slotType) => slotType.startsWith(CUSTOM_SLOT_PREFIX));
+  const availableSlots = [...baseSlots, ...customSlots];
 
-  const slotMap: Partial<Record<SlotType, BuildSlot>> = {};
+  const slotMap: Record<string, BuildSlot> = {};
   for (const slot of build.slots) {
-    slotMap[slot.slotType as SlotType] = slot;
+    slotMap[slot.slotType] = slot;
   }
 
   const otherBuilds = allBuilds.filter((b) => b.id !== build.id);
   const filledCount = build.slots.filter((s) => s.accessoryId).length;
+
+  async function handleAddCustomSlot() {
+    const trimmed = newCustomSlot.trim();
+    if (!trimmed) {
+      setCustomSlotError("Enter a custom slot name first.");
+      return;
+    }
+    const slotType = `${CUSTOM_SLOT_PREFIX}${trimmed}`;
+    if (availableSlots.includes(slotType)) {
+      setCustomSlotError("That custom slot already exists.");
+      return;
+    }
+    setAddingCustomSlot(true);
+    setCustomSlotError(null);
+    try {
+      await onAddCustomSlot(trimmed);
+      setNewCustomSlot("");
+    } catch {
+      setCustomSlotError("Could not create custom slot.");
+    } finally {
+      setAddingCustomSlot(false);
+    }
+  }
+
+  const customSlotCount = customSlots.length;
 
   return (
     <div className="h-full flex flex-col bg-vault-surface border-t md:border-t-0 border-l-0 md:border-l border-vault-border">
@@ -662,6 +758,29 @@ function SlotPanel({
             )}
           </div>
         )}
+
+        <div className="mt-3 p-2.5 border border-vault-border rounded-md bg-vault-bg/50 space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[10px] uppercase tracking-widest text-vault-text-faint">Custom Slot</p>
+            <span className="text-[10px] text-vault-text-faint">{customSlotCount} added</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              value={newCustomSlot}
+              onChange={(e) => setNewCustomSlot(e.target.value)}
+              placeholder="e.g. Data Card"
+              className="flex-1 bg-vault-surface border border-vault-border rounded-md px-2.5 py-1.5 text-xs text-vault-text focus:outline-none focus:border-[#00C2FF]"
+            />
+            <button
+              onClick={handleAddCustomSlot}
+              disabled={addingCustomSlot}
+              className="px-2.5 py-1.5 rounded-md text-xs border border-[#00C2FF]/35 text-[#00C2FF] hover:bg-[#00C2FF]/10 disabled:opacity-60"
+            >
+              {addingCustomSlot ? "Adding..." : "Add"}
+            </button>
+          </div>
+          {customSlotError && <p className="text-[10px] text-[#E53935]">{customSlotError}</p>}
+        </div>
       </div>
 
       {/* Slot list */}
@@ -669,7 +788,7 @@ function SlotPanel({
         {availableSlots.map((slotType) => {
           const slot = slotMap[slotType];
           const hasAccessory = !!slot?.accessory;
-          const slotIconConfig = SLOT_ICONS[slotType];
+          const slotIconConfig = getSlotIconConfig(slotType);
           const SlotIcon = slotIconConfig?.icon ?? Shield;
 
           return (
@@ -703,7 +822,7 @@ function SlotPanel({
                     hasAccessory ? "text-vault-text-faint" : "text-vault-border"
                   }`}
                 >
-                  {SLOT_TYPE_LABELS[slotType]}
+                  {getSlotLabel(slotType)}
                 </p>
                 {hasAccessory && slot?.accessory ? (
                   <div className="flex items-center gap-2 mt-0.5">
@@ -752,7 +871,7 @@ export default function BuildConfiguratorPage() {
   const [activatingBuild, setActivatingBuild] = useState(false);
 
   // Modal state
-  const [browserSlot, setBrowserSlot] = useState<SlotType | null>(null);
+  const [browserSlot, setBrowserSlot] = useState<string | null>(null);
 
   const fetchBuild = useCallback(async () => {
     try {
@@ -782,7 +901,7 @@ export default function BuildConfiguratorPage() {
     fetchBuild();
   }, [fetchBuild]);
 
-  async function handleRemoveSlot(slotType: SlotType) {
+  async function handleRemoveSlot(slotType: string) {
     if (!build) return;
     try {
       await fetch(`/api/builds/${buildId}/slots`, {
@@ -815,6 +934,18 @@ export default function BuildConfiguratorPage() {
 
   function handleSwitchBuild(newBuildId: string) {
     router.push(`/vault/${firearmId}/builds/${newBuildId}`);
+  }
+
+  async function handleAddCustomSlot(label: string) {
+    await fetch(`/api/builds/${buildId}/slots`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slotType: `${CUSTOM_SLOT_PREFIX}${label.trim()}`,
+        accessoryId: null,
+      }),
+    });
+    await fetchBuild();
   }
 
   // ── Loading/error screens ──────────────────────────────────
@@ -910,6 +1041,7 @@ export default function BuildConfiguratorPage() {
             build={build}
             allBuilds={allBuilds}
             onSwitchBuild={handleSwitchBuild}
+            onAddCustomSlot={handleAddCustomSlot}
           />
         </div>
       </div>

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Shield, Menu, LogOut } from "lucide-react";
+import { Shield, Menu } from "lucide-react";
 import { Sidebar } from "./Sidebar";
 
 interface MobileHeaderProps {
@@ -10,24 +10,6 @@ interface MobileHeaderProps {
 
 export function MobileHeader({ passwordModeEnabled = false }: MobileHeaderProps) {
   const [open, setOpen] = useState(false);
-  const [loggingOut, setLoggingOut] = useState(false);
-
-  async function handleLogout() {
-    if (loggingOut) return;
-    setLoggingOut(true);
-
-    try {
-      await fetch("/api/session/logout", {
-        method: "POST",
-        cache: "no-store",
-      });
-    } finally {
-      sessionStorage.clear();
-      sessionStorage.removeItem("blackvault-unlocked");
-      localStorage.removeItem("blackvault-unlocked");
-      window.location.href = "/";
-    }
-  }
 
   return (
     <>
@@ -50,19 +32,6 @@ export function MobileHeader({ passwordModeEnabled = false }: MobileHeaderProps)
             BlackVault
           </p>
         </div>
-        {passwordModeEnabled && (
-          <button
-            onClick={handleLogout}
-            disabled={loggingOut}
-            className="ml-auto inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60"
-            aria-label="Logout"
-          >
-            <LogOut className="w-4 h-4" />
-            <span className="text-[11px] font-medium tracking-wider uppercase">
-              {loggingOut ? "Exit..." : "Logout"}
-            </span>
-          </button>
-        )}
       </header>
       <Sidebar
         mobileOnly

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import {
   Shield,
   Crosshair,
-  Package,
   Layers,
   Target,
   Settings,
@@ -15,60 +14,36 @@ import {
   X,
   LogOut,
   FileText,
+  ChevronDown,
+  Timer,
+  History,
+  Calculator,
+  Library,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useEffect } from "react";
 
-const NAV_ITEMS = [
-  {
-    label: "Command",
-    href: "/",
-    icon: Zap,
-    description: "Overview & stats",
-  },
-  {
-    label: "Vault",
-    href: "/vault",
-    icon: Shield,
-    description: "Firearms inventory",
-  },
-  {
-    label: "Documents",
-    href: "/documents",
-    icon: FileText,
-    description: "Document library",
-  },
-  {
-    label: "Loadouts",
-    href: "/builds",
-    icon: Layers,
-    description: "Build configurations",
-  },
-  {
-    label: "Accessories",
-    href: "/accessories",
-    icon: Crosshair,
-    description: "Parts & attachments",
-  },
-  {
-    label: "Ammo",
-    href: "/ammo",
-    icon: Target,
-    description: "Ammunition storage",
-  },
-  {
-    label: "Range",
-    href: "/range",
-    icon: Package,
-    description: "Log range sessions",
-  },
-  {
-    label: "Settings",
-    href: "/settings",
-    icon: Settings,
-    description: "Configuration",
-  },
-];
+const PRIMARY_NAV_ITEMS = [
+  { label: "Command", href: "/", icon: Zap, description: "Overview & stats" },
+  { label: "Vault", href: "/vault", icon: Shield, description: "Firearms inventory" },
+  { label: "Loadouts", href: "/builds", icon: Layers, description: "Build configurations" },
+  { label: "Accessories", href: "/accessories", icon: Crosshair, description: "Parts & attachments" },
+  { label: "Ammo", href: "/ammo", icon: Target, description: "Ammunition storage" },
+] as const;
+
+const RANGE_CHILD_ITEMS = [
+  { label: "Log Range Session", href: "/range#log-range-session", icon: Target },
+  { label: "Range Session History", href: "/range#range-session-history", icon: History },
+  { label: "Log a Drill", href: "/range#log-a-drill", icon: Timer },
+  { label: "Drill Performance", href: "/range#drill-performance", icon: Timer },
+  { label: "Drill Library", href: "/range#drill-library", icon: Library },
+  { label: "Hit Factor Calculator", href: "/range#hit-factor-calculator", icon: Calculator },
+] as const;
+
+const BOTTOM_NAV_ITEMS = [
+  { label: "Documents", href: "/documents", icon: FileText, description: "Document library" },
+  { label: "Settings", href: "/settings", icon: Settings, description: "Configuration" },
+] as const;
 
 interface SidebarProps {
   mobileOnly?: boolean;
@@ -77,30 +52,27 @@ interface SidebarProps {
   passwordModeEnabled?: boolean;
 }
 
-export function Sidebar({
-  mobileOnly = false,
-  mobileOpen = false,
-  onMobileClose,
-  passwordModeEnabled = false,
-}: SidebarProps) {
+export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose, passwordModeEnabled = false }: SidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
+  const [rangeOpen, setRangeOpen] = useState(pathname.startsWith("/range"));
 
-  // Close mobile menu on route change
   useEffect(() => {
     onMobileClose?.();
   }, [pathname, onMobileClose]);
 
+  useEffect(() => {
+    if (pathname.startsWith("/range")) {
+      setRangeOpen(true);
+    }
+  }, [pathname]);
+
   async function handleLogout() {
     if (loggingOut) return;
     setLoggingOut(true);
-
     try {
-      await fetch("/api/session/logout", {
-        method: "POST",
-        cache: "no-store",
-      });
+      await fetch("/api/session/logout", { method: "POST", cache: "no-store" });
     } finally {
       sessionStorage.clear();
       sessionStorage.removeItem("blackvault-unlocked");
@@ -111,112 +83,110 @@ export function Sidebar({
 
   const navContent = (
     <>
-      {/* Logo */}
       <div className="flex items-center gap-3 px-4 h-14 border-b border-vault-border shrink-0">
         <div className="w-7 h-7 rounded bg-[#00C2FF]/10 border border-[#00C2FF]/30 flex items-center justify-center shrink-0">
           <Shield className="w-4 h-4 text-[#00C2FF]" />
         </div>
         {!collapsed && (
           <div className="overflow-hidden flex-1 min-w-0">
-            <p className="text-xs font-bold text-vault-text tracking-widest uppercase leading-none">
-              BlackVault
-            </p>
-            <p className="text-[10px] text-vault-text-faint tracking-wider uppercase mt-0.5">
-              Armory Platform
-            </p>
+            <p className="text-xs font-bold text-vault-text tracking-widest uppercase leading-none">BlackVault</p>
+            <p className="text-[10px] text-vault-text-faint tracking-wider uppercase mt-0.5">Armory Platform</p>
           </div>
         )}
-        {/* Mobile close button */}
         {onMobileClose && (
-          <button
-            onClick={onMobileClose}
-            className="md:hidden ml-auto p-1 text-vault-text-faint hover:text-vault-text-muted transition-colors"
-          >
+          <button onClick={onMobileClose} className="md:hidden ml-auto p-1 text-vault-text-faint hover:text-vault-text-muted transition-colors">
             <X className="w-4 h-4" />
           </button>
         )}
       </div>
 
-      {/* Nav */}
       <nav className="flex-1 overflow-y-auto py-3 space-y-0.5 px-2">
-        {!collapsed && (
-          <p className="px-2.5 pb-2 text-[10px] tracking-[0.18em] uppercase text-vault-text-faint">
-            Navigation
-          </p>
-        )}
-        {NAV_ITEMS.map((item) => {
+        {!collapsed && <p className="px-2.5 pb-2 text-[10px] tracking-[0.18em] uppercase text-vault-text-faint">Navigation</p>}
+
+        {PRIMARY_NAV_ITEMS.map((item) => {
           const Icon = item.icon;
-          const isActive =
-            item.href === "/"
-              ? pathname === "/"
-              : pathname.startsWith(item.href);
+          const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
           return (
-            <Link
-              key={item.href}
-              href={item.href}
-              title={collapsed ? item.label : undefined}
-              className={cn(
-                "flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative",
-                isActive
-                  ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20"
-                  : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border"
-              )}
-            >
-              {isActive && (
-                <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />
-              )}
-              <Icon
-                className={cn(
-                  "shrink-0 transition-colors",
-                  collapsed ? "w-5 h-5" : "w-4 h-4",
-                  isActive ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted"
-                )}
-              />
+            <Link key={item.href} href={item.href} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
+              {isActive && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
+              <Icon className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", isActive ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
               {!collapsed && (
                 <span className="min-w-0">
-                  <span className="block font-medium tracking-wide truncate">
-                    {item.label}
-                  </span>
-                  <span className="block text-[11px] text-vault-text-faint truncate">
-                    {item.description}
-                  </span>
+                  <span className="block font-medium tracking-wide truncate">{item.label}</span>
+                  <span className="block text-[11px] text-vault-text-faint truncate">{item.description}</span>
                 </span>
               )}
             </Link>
           );
         })}
+
+        <div>
+          <button
+            onClick={() => setRangeOpen((prev) => !prev)}
+            className={cn(
+              "w-full flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative",
+              pathname.startsWith("/range") ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border"
+            )}
+            title={collapsed ? "Range" : undefined}
+          >
+            {pathname.startsWith("/range") && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
+            <Target className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", pathname.startsWith("/range") ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
+            {!collapsed && (
+              <>
+                <span className="min-w-0 text-left">
+                  <span className="block font-medium tracking-wide truncate">Range</span>
+                  <span className="block text-[11px] text-vault-text-faint truncate">Sessions & drills</span>
+                </span>
+                <ChevronDown className={cn("w-4 h-4 ml-auto transition-transform", rangeOpen ? "rotate-180" : "rotate-0")} />
+              </>
+            )}
+          </button>
+
+          {!collapsed && rangeOpen && (
+            <div className="mt-1 ml-4 border-l border-vault-border pl-2 space-y-0.5">
+              {RANGE_CHILD_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <Link key={item.href} href={item.href} className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-vault-text-muted hover:text-vault-text hover:bg-vault-border transition-colors">
+                    <Icon className="w-3.5 h-3.5 text-vault-text-faint" />
+                    <span>{item.label}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="pt-2 mt-2 border-t border-vault-border/70">
+          {BOTTOM_NAV_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const isActive = pathname.startsWith(item.href);
+            return (
+              <Link key={item.href} href={item.href} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
+                {isActive && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
+                <Icon className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", isActive ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
+                {!collapsed && (
+                  <span className="min-w-0">
+                    <span className="block font-medium tracking-wide truncate">{item.label}</span>
+                    <span className="block text-[11px] text-vault-text-faint truncate">{item.description}</span>
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
       </nav>
 
       <div className="px-2 pb-3 shrink-0 border-t border-vault-border pt-2 space-y-1.5">
         {passwordModeEnabled && (
-          <button
-            onClick={handleLogout}
-            disabled={loggingOut}
-            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60"
-            title={collapsed ? "Logout" : undefined}
-          >
+          <button onClick={handleLogout} disabled={loggingOut} className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60" title={collapsed ? "Logout" : undefined}>
             <LogOut className="w-4 h-4 shrink-0" />
-            {!collapsed && (
-              <span className="text-xs tracking-wider uppercase">
-                {loggingOut ? "Logging Out..." : "Logout"}
-              </span>
-            )}
+            {!collapsed && <span className="text-xs tracking-wider uppercase">{loggingOut ? "Logging Out..." : "Logout"}</span>}
           </button>
         )}
 
-        {/* Collapse toggle — desktop only */}
-        <button
-          onClick={() => setCollapsed(!collapsed)}
-          className="hidden md:flex w-full items-center justify-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors"
-        >
-          {collapsed ? (
-            <ChevronRight className="w-4 h-4" />
-          ) : (
-            <>
-              <ChevronLeft className="w-4 h-4" />
-              <span className="text-xs tracking-wider uppercase">Collapse</span>
-            </>
-          )}
+        <button onClick={() => setCollapsed(!collapsed)} className="hidden md:flex w-full items-center justify-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors">
+          {collapsed ? <ChevronRight className="w-4 h-4" /> : <><ChevronLeft className="w-4 h-4" /><span className="text-xs tracking-wider uppercase">Collapse</span></>}
         </button>
       </div>
     </>
@@ -224,27 +194,15 @@ export function Sidebar({
 
   return (
     <>
-      {/* Desktop sidebar */}
       {!mobileOnly && (
-        <aside
-          className={cn(
-            "hidden md:flex flex-col h-screen border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0",
-            collapsed ? "w-16" : "w-56"
-          )}
-        >
+        <aside className={cn("hidden md:flex flex-col h-screen border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0", collapsed ? "w-16" : "w-56")}>
           {navContent}
         </aside>
       )}
 
-      {/* Mobile overlay */}
       {mobileOpen && (
         <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 z-40 bg-black/60 md:hidden"
-            onClick={onMobileClose}
-          />
-          {/* Drawer */}
+          <div className="fixed inset-0 z-40 bg-black/60 md:hidden" onClick={onMobileClose} />
           <aside className="fixed inset-y-0 left-0 z-50 flex flex-col w-64 bg-vault-surface border-r border-vault-border md:hidden animate-slide-up">
             {navContent}
           </aside>


### PR DESCRIPTION
### Motivation
- Address fresh-user feedback to restore a visible logout control and improve sidebar navigation discoverability and structure. 
- Surface Range features in the sidebar as a compact, discoverable section rather than main-page tiles. 
- Ensure accessories created in the configurator are unified with the main accessory model and support battery-tracking fields. 
- Provide a minimal, V1-safe custom slot mechanism in the configurator to let users add a named slot without schema changes.

### Description
- Sidebar/navigation: Added a footer `Logout` button (shown when password mode is enabled) placed above the collapse control and shared between desktop and mobile drawer, moved `Documents` to sit directly above `Settings`, and replaced the flat Range item with a collapsible parent that reveals submenu links for Log Range Session, Range Session History, Log a Drill, Drill Performance, Drill Library, and Hit Factor Calculator (`src/components/layout/Sidebar.tsx`, `src/components/layout/MobileHeader.tsx`).
- Range page anchors: Added in-page anchor targets (`id`s) so Range submenu links navigate to real sections on the range page (log session, drills, performance/library, hit factor, session history) to avoid dead links (`src/app/range/page.tsx`).
- Configurator → Accessories unification: The configurator accessory browser now queries the shared API (`/api/accessories`) with an optional `type` filter and creates accessories via the same endpoint so configurator-created accessories are normal `Accessory` records (`src/app/api/accessories/route.ts`, `src/app/vault/[id]/builds/[buildId]/page.tsx`).
- Battery fields: The accessor-creation form in the configurator includes `hasBattery`, `batteryType`, `lastBatteryChangeDate`, and `replacementIntervalDays`, and those fields are passed to the shared `POST /api/accessories` payload so configurator-created entries support the same battery UI as regular accessories (`src/app/vault/[id]/builds/[buildId]/page.tsx`).
- Custom slot support: Added a simple UI to add one or more named custom slots stored in the existing `BuildSlot.slotType` string using the prefix `CUSTOM:` and persisted via the existing `PUT /api/builds/[id]/slots` API; custom slots render in both the canvas and slot panel and behave like normal slots for assignment (`src/app/vault/[id]/builds/[buildId]/page.tsx`).
- Minor TS-safe helpers: Introduced helper functions to map slot strings to labels/icons and to safely call the slot icon lookup for custom slot keys (`src/app/vault/[id]/builds/[buildId]/page.tsx`).
- Files changed: `src/components/layout/Sidebar.tsx`, `src/components/layout/MobileHeader.tsx`, `src/app/range/page.tsx`, `src/app/api/accessories/route.ts`, and `src/app/vault/[id]/builds/[buildId]/page.tsx`.
- Schema/migrations: No schema or migration changes were required; custom slots reuse the existing `BuildSlot.slotType` string and accessory battery fields already exist in the model.

### Testing
- Built the app with `npm run build` and the production build completed successfully (migrations applied and Next build passed). ✅
- Ran `npm run lint` and it reported pre-existing repository lint issues unrelated to these changes (lint errors exist in other parts of the codebase), so lint did not fully pass in this run. ⚠️
- No automated unit tests were added; manual validation checklist prepared for UI/behavior verification (logout visibility/function, navigation order and collapse behavior, Range submenu navigation, accessories created in configurator visible in `Accessories`, battery fields persisted, and custom slot add/save/load behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c173b684108326817de63dc5ba4c93)