### PR TITLE
Disable V1 vault password/lock gating (always-unlocked self-hosted mode)

### DIFF
--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -450,7 +450,6 @@ export async function GET(request: NextRequest) {
           payload.settings = {
             id: settingsRecord.id,
             defaultCurrency: settingsRecord.defaultCurrency,
-            hasAppPassword: !!settingsRecord.appPassword,
             hasEncryptionKey: !!settingsRecord.encryptionKey,
             dataStoragePath: settingsRecord.dataStoragePath,
             createdAt: settingsRecord.createdAt,

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -85,7 +85,7 @@ describe("/api/settings backup fields", () => {
     expect(json.autoBackupCadence).toBe("weekly");
   });
 
-  it("does not clear app password when backup-only settings are saved", async () => {
+  it("returns appPassword as null in responses for v1", async () => {
     mocks.upsert.mockResolvedValue({
       id: "singleton",
       includeUploadsInBackup: false,
@@ -115,7 +115,7 @@ describe("/api/settings backup fields", () => {
     expect(upsertArgs.update.autoBackupEnabled).toBe(true);
     expect(upsertArgs.update.autoBackupCadence).toBe("daily");
     expect("appPassword" in upsertArgs.update).toBe(false);
-    expect(json.appPassword).toBe("existing-secret");
+    expect(json.appPassword).toBeNull();
   });
 
   it("rejects invalid cadence values", async () => {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -48,6 +48,7 @@ export async function GET() {
 
     return NextResponse.json({
       ...v1Settings,
+      appPassword: null,
       encryptionEnabled: !!process.env.VAULT_ENCRYPTION_KEY,
     });
   } catch (error) {
@@ -75,7 +76,6 @@ export async function PUT(request: NextRequest) {
       autoBackupEnabled,
       autoBackupCadence,
       defaultCurrency,
-      appPassword,
     } = body;
 
     const updateData: Record<string, unknown> = {};
@@ -130,16 +130,6 @@ export async function PUT(request: NextRequest) {
       updateData.defaultCurrency = normalized;
     }
 
-    if (appPassword !== undefined) {
-      if (appPassword !== null && typeof appPassword !== "string") {
-        return NextResponse.json(
-          { error: "appPassword must be a string or null." },
-          { status: 400 }
-        );
-      }
-      updateData.appPassword = appPassword === "" ? null : appPassword;
-    }
-
     if (Object.keys(updateData).length === 0) {
       return NextResponse.json(
         { error: "No valid settings fields provided." },
@@ -163,7 +153,10 @@ export async function PUT(request: NextRequest) {
       ...v1Settings
     } = settings;
 
-    return NextResponse.json(v1Settings);
+    return NextResponse.json({
+      ...v1Settings,
+      appPassword: null,
+    });
   } catch (error) {
     console.error("PUT /api/settings error:", error);
     return NextResponse.json(

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -29,12 +29,10 @@ export default function DocumentLibraryPage() {
   useEffect(() => {
     fetch("/api/documents", { credentials: "include", cache: "no-store" })
       .then(async (r) => ({ ok: r.ok, status: r.status, data: await r.json().catch(() => null) }))
-      .then(({ ok, status, data }) => {
+      .then(({ ok, data }) => {
         if (ok && Array.isArray(data)) {
           setDocuments(data);
           setLoadError(null);
-        } else if (status === 401) {
-          setLoadError("Document library is locked. Unlock the vault to view and upload documents.");
         } else {
           setLoadError((data as { error?: string } | null)?.error ?? "Failed to load documents.");
         }

--- a/src/app/exports/full-armory/page.tsx
+++ b/src/app/exports/full-armory/page.tsx
@@ -51,10 +51,6 @@ export default function FullArmoryExportPage() {
           if (text) errorMessage = text.slice(0, 240);
         }
 
-        if (response.status === 401) {
-          errorMessage = "Export is locked. Please unlock the vault and try again.";
-        }
-
         throw new Error(errorMessage);
       }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,25 +4,17 @@ import { Sidebar } from "@/components/layout/Sidebar";
 import { MobileHeader } from "@/components/layout/MobileHeader";
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
-import { UnlockScreen } from "@/components/auth/UnlockScreen";
-import { hasValidSessionCookie, isPasswordModeEnabled } from "@/lib/server/auth";
 
 export const metadata: Metadata = {
   title: "Project BlackVault",
   description: "Tactical firearm inventory & build management platform",
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [passwordModeEnabled, hasValidSession] = await Promise.all([
-    isPasswordModeEnabled(),
-    hasValidSessionCookie(),
-  ]);
-  const shouldShowUnlock = passwordModeEnabled && !hasValidSession;
-
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -35,19 +27,15 @@ export default async function RootLayout({
       </head>
       <body className="antialiased bg-vault-bg text-vault-text">
         <ThemeProvider>
-          {shouldShowUnlock ? (
-            <UnlockScreen />
-          ) : (
-            <div className="flex h-screen overflow-hidden">
-              <Sidebar passwordModeEnabled={passwordModeEnabled} sessionUnlocked={hasValidSession} />
-              <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-                <MobileHeader passwordModeEnabled={passwordModeEnabled} sessionUnlocked={hasValidSession} />
-                <main className="flex-1 overflow-y-auto min-w-0">
-                  {children}
-                </main>
-              </div>
+          <div className="flex h-screen overflow-hidden">
+            <Sidebar />
+            <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+              <MobileHeader />
+              <main className="flex-1 overflow-y-auto min-w-0">
+                {children}
+              </main>
             </div>
-          )}
+          </div>
           <ThemeToggle />
         </ThemeProvider>
       </body>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,9 +7,6 @@ import {
   Loader2,
   AlertCircle,
   CheckCircle2,
-  Lock,
-  Eye,
-  EyeOff,
   Settings,
   ShieldCheck,
   Archive,
@@ -27,7 +24,6 @@ const LABEL_CLASS =
 
 interface AppSettings {
   id: string;
-  appPassword: string | null;
   encryptionEnabled?: boolean;
   includeUploadsInBackup?: boolean;
   autoBackupEnabled?: boolean;
@@ -39,9 +35,6 @@ export default function SettingsPage() {
   const [dataLoading, setDataLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
 
-  const [appPassword, setAppPassword] = useState("");
-  const [appPasswordDirty, setAppPasswordDirty] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const [includeUploadsInBackup, setIncludeUploadsInBackup] = useState(true);
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
   const [autoBackupCadence, setAutoBackupCadence] = useState<"daily" | "weekly" | "monthly">("weekly");
@@ -82,10 +75,6 @@ export default function SettingsPage() {
       autoBackupCadence,
     };
 
-    if (appPasswordDirty) {
-      payload.appPassword = appPassword || null;
-    }
-
     try {
       const res = await fetch("/api/settings", {
         method: "PUT",
@@ -99,8 +88,6 @@ export default function SettingsPage() {
         setSaveError(json.error ?? "Failed to save settings");
       } else {
         setSettings(json);
-        setAppPassword("");
-        setAppPasswordDirty(false);
         setSaveSuccess(true);
         setTimeout(() => setSaveSuccess(false), 3000);
       }
@@ -156,62 +143,6 @@ export default function SettingsPage() {
         )}
 
         <form onSubmit={handleSave} className="space-y-6">
-          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-5">
-            <div className="flex items-center justify-between">
-              <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
-                <Lock className="w-3.5 h-3.5" />
-                Security
-              </legend>
-              <span
-                className={`text-[10px] font-mono px-2 py-0.5 rounded border uppercase ${
-                  settings?.appPassword
-                    ? "text-[#F5A623] border-[#F5A623]/40"
-                    : "text-vault-text-faint border-vault-border"
-                }`}
-              >
-                {settings?.appPassword ? "Password Set" : "No Password"}
-              </span>
-            </div>
-
-            <p className="text-xs text-vault-text-muted leading-relaxed">
-              Set an optional app password to restrict access to the vault. Leave blank to disable password protection.
-            </p>
-
-            <div>
-              <label className={LABEL_CLASS}>
-                <Lock className="w-3 h-3 inline mr-1" />
-                App Password
-              </label>
-              <div className="relative">
-                <input
-                  type={showPassword ? "text" : "password"}
-                  value={appPassword}
-                  onChange={(e) => {
-                    setAppPassword(e.target.value);
-                    setAppPasswordDirty(true);
-                  }}
-                  placeholder={
-                    settings?.appPassword
-                      ? "Leave unchanged to keep current password"
-                      : "Leave blank to disable password protection"
-                  }
-                  className={`${INPUT_CLASS} pr-10`}
-                  autoComplete="new-password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-vault-text-faint hover:text-vault-text-muted"
-                >
-                  {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                </button>
-              </div>
-              <p className="text-xs text-vault-text-faint mt-1">
-                Note: This is a simple access restriction, not end-to-end encryption.
-              </p>
-            </div>
-          </fieldset>
-
           <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-5">
             <div className="flex items-center justify-between">
               <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
@@ -359,11 +290,6 @@ export default function SettingsPage() {
               Current Configuration Status
             </p>
             <div className="space-y-2">
-              <StatusRow
-                label="App Password"
-                value={settings?.appPassword ? "Enabled" : "Disabled"}
-                ok={!!settings?.appPassword}
-              />
               <StatusRow
                 label="Include Upload References"
                 value={includeUploadsInBackup ? "Enabled" : "Disabled"}

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -4,12 +4,7 @@ import { useState } from "react";
 import { Shield, Menu } from "lucide-react";
 import { Sidebar } from "./Sidebar";
 
-interface MobileHeaderProps {
-  passwordModeEnabled?: boolean;
-  sessionUnlocked?: boolean;
-}
-
-export function MobileHeader({ passwordModeEnabled = false, sessionUnlocked = false }: MobileHeaderProps) {
+export function MobileHeader() {
   const [open, setOpen] = useState(false);
 
   return (
@@ -38,8 +33,6 @@ export function MobileHeader({ passwordModeEnabled = false, sessionUnlocked = fa
         mobileOnly
         mobileOpen={open}
         onMobileClose={() => setOpen(false)}
-        passwordModeEnabled={passwordModeEnabled}
-        sessionUnlocked={sessionUnlocked}
       />
     </>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   ChevronRight,
   Zap,
   X,
-  LogOut,
   FileText,
   ChevronDown,
   Timer,
@@ -49,14 +48,11 @@ interface SidebarProps {
   mobileOnly?: boolean;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
-  passwordModeEnabled?: boolean;
-  sessionUnlocked?: boolean;
 }
 
-export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose, passwordModeEnabled = false, sessionUnlocked = false }: SidebarProps) {
+export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose }: SidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
-  const [loggingOut, setLoggingOut] = useState(false);
   const [rangeOpen, setRangeOpen] = useState(pathname.startsWith("/range"));
 
   useEffect(() => {
@@ -68,19 +64,6 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose,
       setRangeOpen(true);
     }
   }, [pathname]);
-
-  async function handleLogout() {
-    if (loggingOut) return;
-    setLoggingOut(true);
-    try {
-      await fetch("/api/session/logout", { method: "POST", cache: "no-store" });
-    } finally {
-      sessionStorage.clear();
-      sessionStorage.removeItem("blackvault-unlocked");
-      localStorage.removeItem("blackvault-unlocked");
-      window.location.href = "/";
-    }
-  }
 
   const navContent = (
     <>
@@ -179,13 +162,6 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose,
       </nav>
 
       <div className="px-2 pb-3 shrink-0 border-t border-vault-border pt-2 space-y-1.5">
-        {passwordModeEnabled && sessionUnlocked && (
-          <button onClick={handleLogout} disabled={loggingOut} className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md border border-red-500/25 bg-red-500/10 text-red-200 hover:text-red-100 hover:bg-red-500/15 transition-colors disabled:opacity-60" title={collapsed ? "Logout" : undefined}>
-            <LogOut className="w-4 h-4 shrink-0" />
-            {!collapsed && <span className="text-xs tracking-wider uppercase">{loggingOut ? "Logging Out..." : "Logout"}</span>}
-          </button>
-        )}
-
         <button onClick={() => setCollapsed(!collapsed)} className="hidden md:flex w-full items-center justify-center gap-2 px-2.5 py-2 rounded-md text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border transition-colors">
           {collapsed ? <ChevronRight className="w-4 h-4" /> : <><ChevronLeft className="w-4 h-4" /><span className="text-xs tracking-wider uppercase">Collapse</span></>}
         </button>

--- a/src/components/shared/DocumentUploader.tsx
+++ b/src/components/shared/DocumentUploader.tsx
@@ -106,9 +106,6 @@ export function DocumentUploader({
 
       if (!res.ok) {
         const json = await res.json().catch(() => ({} as { error?: string }));
-        if (res.status === 401) {
-          throw new Error("Upload blocked: vault is locked. Unlock and try again.");
-        }
         throw new Error(json.error ?? "Upload failed");
       }
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,35 +1,15 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
-import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 
 export const SESSION_COOKIE_NAME = "blackvault_session";
 
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 
-function getSessionSigningSecret() {
-  return (
-    process.env.BLACKVAULT_SESSION_SECRET ??
-    process.env.VAULT_ENCRYPTION_KEY ??
-    process.env.NEXTAUTH_SECRET ??
-    "blackvault-dev-session-secret"
-  );
-}
-
-function buildSessionSignature(appPassword: string) {
-  return createHmac("sha256", getSessionSigningSecret())
-    .update(appPassword)
-    .digest("hex");
-}
-
-async function getAppPassword() {
-  const settings = await prisma.appSettings.findUnique({
-    where: { id: "singleton" },
-    select: { appPassword: true },
-  });
-
-  return settings?.appPassword ?? null;
-}
+/**
+ * V1 release mode:
+ * the app behaves as always-unlocked in self-hosted environments.
+ * These helpers remain in place so auth can be reintroduced later
+ * without touching every caller.
+ */
 
 export function getSessionCookieOptions() {
   return {
@@ -42,7 +22,7 @@ export function getSessionCookieOptions() {
 }
 
 export function createSessionCookieValue(appPassword: string) {
-  return buildSessionSignature(appPassword);
+  return appPassword;
 }
 
 export function clearSessionCookie(response: NextResponse) {
@@ -55,47 +35,13 @@ export function clearSessionCookie(response: NextResponse) {
 }
 
 export async function isPasswordModeEnabled() {
-  return Boolean(await getAppPassword());
+  return false;
 }
 
 export async function hasValidSessionCookie() {
-  const appPassword = await getAppPassword();
-  if (!appPassword) return true;
-
-  try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
-    if (!sessionCookie) return false;
-
-    const expected = createSessionCookieValue(appPassword);
-    const expectedBuffer = Buffer.from(expected);
-    const actualBuffer = Buffer.from(sessionCookie);
-
-    if (expectedBuffer.length !== actualBuffer.length) {
-      return false;
-    }
-
-    return timingSafeEqual(expectedBuffer, actualBuffer);
-  } catch {
-    return false;
-  }
+  return true;
 }
 
 export async function requireAuth(): Promise<NextResponse | null> {
-  const appPassword = await getAppPassword();
-  if (!appPassword) {
-    return null;
-  }
-
-  const sessionIsValid = await hasValidSessionCookie();
-  if (sessionIsValid) {
-    return null;
-  }
-
-  const response = NextResponse.json(
-    { error: "Vault is locked. Unlock the vault and retry.", code: "VAULT_LOCKED" },
-    { status: 401 }
-  );
-  clearSessionCookie(response);
-  return response;
+  return null;
 }


### PR DESCRIPTION
### Motivation
- Prevent intermittent "vault is locked" failures in core workflows for V1 by disabling the app-level password/unlock flow so the self-hosted app behaves as always-unlocked.
- Keep changes minimal and reversible so proper auth can be reintroduced later without touching every caller.

### Description
- Made server auth helpers no-op for V1 by updating `src/lib/server/auth.ts` so `requireAuth` always returns `null`, `isPasswordModeEnabled` returns `false`, and session checks always pass; helpers remain for future reintroduction.
- Removed UnlockScreen gating from the top-level shell by updating `src/app/layout.tsx` so the app navigation and content always render (no lock-screen branch).
- Removed password/logout UI wiring and props from `Sidebar` and `MobileHeader` by updating `src/components/layout/Sidebar.tsx` and `src/components/layout/MobileHeader.tsx` (logout flow and password props removed).
- Removed password fields and UI from settings and changed API handling so `appPassword` is no longer accepted and API responses return `appPassword: null`; changes in `src/app/settings/page.tsx` and `src/app/api/settings/route.ts` (and updated test `src/app/api/settings/route.test.ts`).
- Eliminated user-facing lock-specific copy and guards that surfaced "vault is locked" messaging in core flows by updating `src/components/shared/DocumentUploader.tsx`, `src/app/documents/page.tsx`, and `src/app/exports/full-armory/page.tsx`.
- Removed `hasAppPassword` from export metadata to avoid confusing password-related metadata in exports by updating `src/app/api/exports/data/route.ts`.

### Testing
- Ran unit tests for impacted APIs: `npx vitest run src/app/api/settings/route.test.ts src/app/api/exports/data/route.backup.test.ts`; result: all tests passed (2 test files, 14 tests total).
- Verified production build: `npm run build`; result: build completed successfully (Next.js production build succeeded).
- Ran linter: `npm run lint`; result: lint run reported pre-existing unrelated failures in other files and did not surface new errors introduced by these changes.
- Attempted Docker config check: `docker compose -f docker-compose.dev.yml config`; result: skipped in this environment due to missing `docker` binary (runner limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18af73cbc83269e923288b89f7d28)