### PR TITLE
Add multi-set drill support and inline drill logging in Range sessions

### DIFF
--- a/prisma/migrations/20260323133000_add_session_drill_set_number/migration.sql
+++ b/prisma/migrations/20260323133000_add_session_drill_set_number/migration.sql
@@ -1,0 +1,2 @@
+-- Add explicit set/attempt number for drills logged within a range session.
+ALTER TABLE "SessionDrill" ADD COLUMN "setNumber" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -206,6 +206,7 @@ model SessionDrill {
   rangeSessionId String
   rangeSession   RangeSession @relation(fields: [rangeSessionId], references: [id], onDelete: Cascade)
   name           String
+  setNumber      Int          @default(1)
   timeSeconds    Float
   points         Float
   penalties      Float?

--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -415,7 +415,7 @@ export async function GET(request: NextRequest) {
       queries.push(
         prisma.rangeSession.findMany({
           include: {
-            sessionDrills: { orderBy: { sortOrder: "asc" } },
+            sessionDrills: { orderBy: [{ sortOrder: "asc" }, { name: "asc" }, { setNumber: "asc" }] },
             ammoLinks: true,
           },
           orderBy: { sessionDate: "desc" },

--- a/src/app/api/range/sessions/[id]/drills/route.ts
+++ b/src/app/api/range/sessions/[id]/drills/route.ts
@@ -31,7 +31,7 @@ export async function GET(
 
     const drills = await prisma.sessionDrill.findMany({
       where: { rangeSessionId: id },
-      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+      orderBy: [{ sortOrder: "asc" }, { name: "asc" }, { setNumber: "asc" }, { createdAt: "asc" }],
     });
 
     return NextResponse.json(drills);
@@ -52,7 +52,7 @@ export async function POST(
     const { id } = await params;
     const body = await request.json();
 
-    const { name, timeSeconds, points, penalties, hits, notes, sortOrder } = body;
+    const { name, timeSeconds, points, penalties, hits, notes, sortOrder, setNumber } = body;
 
     if (!name || timeSeconds === undefined || points === undefined) {
       return NextResponse.json(
@@ -85,18 +85,34 @@ export async function POST(
       return NextResponse.json({ error: "hits must be a non-negative integer" }, { status: 400 });
     }
 
+    if (
+      setNumber !== undefined &&
+      setNumber !== null &&
+      (typeof setNumber !== "number" || !Number.isInteger(setNumber) || setNumber < 1)
+    ) {
+      return NextResponse.json({ error: "setNumber must be an integer greater than 0" }, { status: 400 });
+    }
+
     const session = await prisma.rangeSession.findUnique({ where: { id }, select: { id: true } });
     if (!session) {
       return NextResponse.json({ error: "Range session not found" }, { status: 404 });
     }
 
+    const normalizedName = name.trim();
     const adjustedPoints = Math.max(0, points - (typeof penalties === "number" ? penalties : 0));
     const hitFactor = calculateHitFactor(adjustedPoints, timeSeconds);
+    const fallbackSetNumber = await prisma.sessionDrill.count({
+      where: {
+        rangeSessionId: id,
+        name: normalizedName,
+      },
+    }) + 1;
 
     const drill = await prisma.sessionDrill.create({
       data: {
         rangeSessionId: id,
-        name: name.trim(),
+        name: normalizedName,
+        setNumber: typeof setNumber === "number" ? setNumber : fallbackSetNumber,
         timeSeconds,
         points,
         penalties: typeof penalties === "number" ? penalties : null,

--- a/src/app/api/range/sessions/route.ts
+++ b/src/app/api/range/sessions/route.ts
@@ -2,6 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/server/auth";
 
+function calculateHitFactor(points: number, timeSeconds: number): number {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= 0) {
+    return 0;
+  }
+
+  if (!Number.isFinite(points) || points < 0) {
+    return 0;
+  }
+
+  return Number((points / timeSeconds).toFixed(4));
+}
+
 export async function GET() {
   const auth = await requireAuth();
   if (auth) return auth;
@@ -37,7 +49,7 @@ export async function GET() {
           orderBy: { createdAt: "asc" },
         },
         sessionDrills: {
-          orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+          orderBy: [{ sortOrder: "asc" }, { name: "asc" }, { setNumber: "asc" }, { createdAt: "asc" }],
         },
       },
       orderBy: [{ sessionDate: "desc" }, { createdAt: "desc" }],
@@ -56,7 +68,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { sessionDate, location, firearmId, buildId, roundsFired, notes, ammoLinks } = body;
+    const { sessionDate, location, firearmId, buildId, roundsFired, notes, ammoLinks, sessionDrills } = body;
 
     const normalizedAmmoLinks = (Array.isArray(ammoLinks) ? ammoLinks : [])
       .map((link) => ({
@@ -83,6 +95,56 @@ export async function POST(request: NextRequest) {
     const resolvedRoundsFired = typeof roundsFired === "number" && Number.isInteger(roundsFired) && roundsFired >= 0
       ? roundsFired
       : totalAmmoRounds;
+    const normalizedSessionDrills = Array.isArray(sessionDrills)
+      ? sessionDrills.flatMap((entry, index) => {
+        const name = typeof entry?.name === "string" ? entry.name.trim() : "";
+        const timeSeconds = typeof entry?.timeSeconds === "number" ? entry.timeSeconds : NaN;
+        const points = typeof entry?.points === "number" ? entry.points : NaN;
+        const penaltiesValue = entry?.penalties;
+        const hitsValue = entry?.hits;
+        const sortOrderValue = entry?.sortOrder;
+        const setNumberValue = entry?.setNumber;
+
+        if (!name || !Number.isFinite(timeSeconds) || timeSeconds <= 0 || !Number.isFinite(points) || points < 0) {
+          return [];
+        }
+
+        const penalties = typeof penaltiesValue === "number" && Number.isFinite(penaltiesValue) && penaltiesValue >= 0
+          ? penaltiesValue
+          : null;
+        const hits = typeof hitsValue === "number" && Number.isInteger(hitsValue) && hitsValue >= 0
+          ? hitsValue
+          : null;
+        const sortOrder = typeof sortOrderValue === "number" && Number.isInteger(sortOrderValue)
+          ? sortOrderValue
+          : index;
+        const setNumber = typeof setNumberValue === "number" && Number.isInteger(setNumberValue) && setNumberValue > 0
+          ? setNumberValue
+          : null;
+        const adjustedPoints = Math.max(0, points - (penalties ?? 0));
+
+        return [{
+          name,
+          timeSeconds,
+          points,
+          penalties,
+          hits,
+          notes: typeof entry?.notes === "string" ? entry.notes.trim() || null : null,
+          sortOrder,
+          setNumber,
+          hitFactor: calculateHitFactor(adjustedPoints, timeSeconds),
+        }];
+      })
+      : [];
+
+    const setCounterByDrillName = new Map<string, number>();
+    for (const drillEntry of normalizedSessionDrills) {
+      const nextCounter = (setCounterByDrillName.get(drillEntry.name) ?? 0) + 1;
+      setCounterByDrillName.set(drillEntry.name, nextCounter);
+      if (drillEntry.setNumber == null) {
+        drillEntry.setNumber = nextCounter;
+      }
+    }
 
     const parsedDate = (() => {
       if (typeof sessionDate !== "string" || sessionDate.trim().length === 0) return new Date();
@@ -169,6 +231,19 @@ export async function POST(request: NextRequest) {
         ammoLinks: {
           create: normalizedAmmoLinks,
         },
+        sessionDrills: {
+          create: normalizedSessionDrills.map((entry) => ({
+            name: entry.name,
+            setNumber: entry.setNumber ?? 1,
+            timeSeconds: entry.timeSeconds,
+            points: entry.points,
+            penalties: entry.penalties,
+            hits: entry.hits,
+            notes: entry.notes,
+            hitFactor: entry.hitFactor,
+            sortOrder: entry.sortOrder,
+          })),
+        },
       },
       include: {
         firearm: { select: { id: true, name: true, caliber: true } },
@@ -186,6 +261,9 @@ export async function POST(request: NextRequest) {
             },
           },
           orderBy: { createdAt: "asc" },
+        },
+        sessionDrills: {
+          orderBy: [{ sortOrder: "asc" }, { name: "asc" }, { setNumber: "asc" }, { createdAt: "asc" }],
         },
       },
     });

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -53,6 +53,7 @@ interface AmmoSelection {
 interface SessionDrill {
   id: string;
   name: string;
+  setNumber: number;
   timeSeconds: number;
   points: number;
   penalties: number | null;
@@ -82,6 +83,16 @@ interface RangeSession {
     };
   }>;
   sessionDrills: SessionDrill[];
+}
+
+interface DrillEntryDraft {
+  id: string;
+  name: string;
+  timeSeconds: string;
+  points: string;
+  penalties: string;
+  hits: string;
+  notes: string;
 }
 
 const SLOT_TYPE_LABELS: Record<string, string> = {
@@ -123,6 +134,9 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const [sessionLocation, setSessionLocation] = useState<string>("");
   const [sessionNote, setSessionNote] = useState<string>("");
   const [selectedAccessories, setSelectedAccessories] = useState<Set<string>>(new Set());
+  const [sessionDrillEntries, setSessionDrillEntries] = useState<DrillEntryDraft[]>([
+    { id: crypto.randomUUID(), name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" },
+  ]);
 
   const [selectedSessionId, setSelectedSessionId] = useState<string>("");
   const [drillName, setDrillName] = useState<string>("");
@@ -303,6 +317,13 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     return calculateHitFactor(adjustedPoints, time);
   }, [drillTime, drillPoints, drillPenalties]);
 
+  const nextSetNumberForSelectedDrill = useMemo(() => {
+    const normalizedName = drillName.trim().toLowerCase();
+    if (!normalizedName) return 1;
+    const existingCount = sessionDrills.filter((entry) => entry.name.trim().toLowerCase() === normalizedName).length;
+    return existingCount + 1;
+  }, [drillName, sessionDrills]);
+
   function updateAmmoSelection(index: number, next: Partial<AmmoSelection>) {
     setAmmoSelections((prev) => prev.map((item, itemIndex) => (itemIndex === index ? { ...item, ...next } : item)));
   }
@@ -313,6 +334,26 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
   function removeAmmoSelection(index: number) {
     setAmmoSelections((prev) => (prev.length <= 1 ? prev : prev.filter((_, itemIndex) => itemIndex !== index)));
+  }
+
+  function updateSessionDrillEntry(entryId: string, next: Partial<DrillEntryDraft>) {
+    setSessionDrillEntries((prev) => prev.map((entry) => (entry.id === entryId ? { ...entry, ...next } : entry)));
+  }
+
+  function addSessionDrillEntry() {
+    setSessionDrillEntries((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" },
+    ]);
+  }
+
+  function removeSessionDrillEntry(entryId: string) {
+    setSessionDrillEntries((prev) => {
+      if (prev.length <= 1) {
+        return [{ ...prev[0], name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" }];
+      }
+      return prev.filter((entry) => entry.id !== entryId);
+    });
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -330,6 +371,36 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         roundsUsed: Number.parseInt(selection.roundsUsed, 10),
       }))
       .filter((selection) => selection.ammoStockId && Number.isInteger(selection.roundsUsed) && selection.roundsUsed > 0);
+    const drillSetCounter = new Map<string, number>();
+    const normalizedSessionDrills = sessionDrillEntries.flatMap((entry, index) => {
+      const name = entry.name.trim();
+      const timeSeconds = Number.parseFloat(entry.timeSeconds);
+      const points = Number.parseFloat(entry.points);
+      const penalties = Number.parseFloat(entry.penalties || "0");
+      const hits = Number.parseInt(entry.hits, 10);
+
+      if (!name && !entry.timeSeconds && !entry.points && !entry.penalties && !entry.hits && !entry.notes.trim()) {
+        return [];
+      }
+
+      if (!name || !Number.isFinite(timeSeconds) || timeSeconds <= 0 || !Number.isFinite(points) || points < 0) {
+        return [];
+      }
+
+      const setNumber = (drillSetCounter.get(name) ?? 0) + 1;
+      drillSetCounter.set(name, setNumber);
+
+      return [{
+        name,
+        setNumber,
+        timeSeconds,
+        points,
+        penalties: Number.isFinite(penalties) && penalties >= 0 ? penalties : undefined,
+        hits: Number.isInteger(hits) && hits >= 0 ? hits : undefined,
+        notes: entry.notes.trim() || undefined,
+        sortOrder: index,
+      }];
+    });
 
     const ammoRoundsTotal = normalizedAmmoLinks.reduce((sum, selection) => sum + selection.roundsUsed, 0);
     const explicitRounds = Number.parseInt(roundsFired, 10);
@@ -341,6 +412,18 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
     if (!selectedFirearmId) {
       setError("Add at least one firearm in the vault before logging a range session.");
+      setSubmitting(false);
+      return;
+    }
+
+    const hasIncompleteDrillRows = sessionDrillEntries.some((entry) => {
+      const hasAnyValue = Boolean(entry.name.trim() || entry.timeSeconds || entry.points || entry.penalties || entry.hits || entry.notes.trim());
+      if (!hasAnyValue) return false;
+      const hasRequired = Boolean(entry.name.trim() && entry.timeSeconds && entry.points);
+      return !hasRequired;
+    });
+    if (hasIncompleteDrillRows) {
+      setError("Each drill set row must include drill name, time, and points (or leave the row blank).");
       setSubmitting(false);
       return;
     }
@@ -372,6 +455,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           roundsFired: resolvedRounds,
           notes: sessionNote,
           ammoLinks: normalizedAmmoLinks,
+          sessionDrills: normalizedSessionDrills,
         }),
       });
 
@@ -410,6 +494,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
       setRoundsFired("");
       setSessionNote("");
       setAmmoSelections([{ ammoStockId: "", roundsUsed: "" }]);
+      setSessionDrillEntries([{ id: crypto.randomUUID(), name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" }]);
     } catch (err) {
       setFinalizeState("idle");
       setError(err instanceof Error ? err.message : "Session log failed");
@@ -431,6 +516,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     try {
       const payload = {
         name: drillName,
+        setNumber: nextSetNumberForSelectedDrill,
         timeSeconds: Number.parseFloat(drillTime),
         points: Number.parseFloat(drillPoints),
         penalties: drillPenalties ? Number.parseFloat(drillPenalties) : undefined,
@@ -454,13 +540,11 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
       setSessionDrills(Array.isArray(drillsJson) ? drillsJson : []);
       await loadSessions();
 
-      setDrillName("");
       setDrillTime("");
       setDrillPoints("");
       setDrillPenalties("");
       setDrillHits("");
-      setDrillNotes("");
-      setSuccess("Drill logged successfully.");
+      setSuccess(`Drill set ${nextSetNumberForSelectedDrill} logged successfully.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Drill log failed");
     } finally {
@@ -751,6 +835,112 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               <p className="text-xs text-vault-text-faint">Leave rows blank to skip ammo deductions. When rounds fired is blank, it auto-calculates from ammo rows.</p>
             </div>
 
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <label className={LABEL_CLASS}>Drills Completed During This Session</label>
+                <button
+                  type="button"
+                  onClick={addSessionDrillEntry}
+                  className="px-2.5 py-1.5 rounded-md text-xs border border-[#00C2FF]/30 text-[#00C2FF] bg-[#00C2FF]/10 hover:bg-[#00C2FF]/20"
+                >
+                  Add Drill Set
+                </button>
+              </div>
+              <p className="text-xs text-vault-text-faint">Add zero, one, or many drill sets. Repeat the same drill name for multiple attempts (Set 1, Set 2, Set 3...).</p>
+              {sessionDrillEntries.map((entry, index) => (
+                <div key={entry.id} className="rounded-md border border-vault-border bg-vault-bg p-3 space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-xs uppercase tracking-widest text-vault-text-muted">Set {index + 1}</p>
+                    <button
+                      type="button"
+                      onClick={() => removeSessionDrillEntry(entry.id)}
+                      className="px-2.5 py-1.5 rounded-md text-xs border border-vault-border text-vault-text-faint hover:text-vault-text"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <div className="grid md:grid-cols-2 gap-3">
+                    <div>
+                      <label className={LABEL_CLASS}>Drill Name</label>
+                      <input
+                        value={entry.name}
+                        onChange={(e) => updateSessionDrillEntry(entry.id, { name: e.target.value })}
+                        className={INPUT_CLASS}
+                        placeholder="e.g. Bill Drill"
+                      />
+                    </div>
+                    <div>
+                      <label className={LABEL_CLASS}>Time (seconds)</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0.01"
+                        value={entry.timeSeconds}
+                        onChange={(e) => updateSessionDrillEntry(entry.id, { timeSeconds: e.target.value })}
+                        className={INPUT_CLASS}
+                        placeholder="2.45"
+                      />
+                    </div>
+                  </div>
+                  <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-3">
+                    <div>
+                      <label className={LABEL_CLASS}>Points</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={entry.points}
+                        onChange={(e) => updateSessionDrillEntry(entry.id, { points: e.target.value })}
+                        className={INPUT_CLASS}
+                        placeholder="90"
+                      />
+                    </div>
+                    <div>
+                      <label className={LABEL_CLASS}>Penalties</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={entry.penalties}
+                        onChange={(e) => updateSessionDrillEntry(entry.id, { penalties: e.target.value })}
+                        className={INPUT_CLASS}
+                        placeholder="0"
+                      />
+                    </div>
+                    <div>
+                      <label className={LABEL_CLASS}>Hits</label>
+                      <input
+                        type="number"
+                        min="0"
+                        value={entry.hits}
+                        onChange={(e) => updateSessionDrillEntry(entry.id, { hits: e.target.value })}
+                        className={INPUT_CLASS}
+                        placeholder="6"
+                      />
+                    </div>
+                    <div className="bg-vault-surface border border-vault-border rounded-md px-3 py-2">
+                      <p className="text-[11px] text-vault-text-faint uppercase tracking-widest">Hit Factor</p>
+                      <p className="text-lg font-mono text-[#00C2FF]">
+                        {calculateHitFactor(
+                          Math.max(0, (Number.parseFloat(entry.points) || 0) - (Number.parseFloat(entry.penalties) || 0)),
+                          Number.parseFloat(entry.timeSeconds)
+                        ).toFixed(4)}
+                      </p>
+                    </div>
+                  </div>
+                  <div>
+                    <label className={LABEL_CLASS}>Set Notes</label>
+                    <textarea
+                      rows={2}
+                      value={entry.notes}
+                      onChange={(e) => updateSessionDrillEntry(entry.id, { notes: e.target.value })}
+                      className={`${INPUT_CLASS} resize-none`}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+
             <div>
               <label className={LABEL_CLASS}>Notes</label>
               <textarea
@@ -847,6 +1037,9 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               <div>
                 <label className={LABEL_CLASS}>Drill Name <span className="text-[#E53935]">*</span></label>
                 <input required value={drillName} onChange={(e) => setDrillName(e.target.value)} className={INPUT_CLASS} placeholder="e.g. Bill Drill" />
+                {selectedSessionId && drillName.trim() && (
+                  <p className="mt-1 text-xs text-vault-text-faint">This will be saved as set {nextSetNumberForSelectedDrill} for this drill in the selected session.</p>
+                )}
               </div>
               <div>
                 <label className={LABEL_CLASS}>Time (seconds) <span className="text-[#E53935]">*</span></label>
@@ -1062,7 +1255,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 {sessionDrills.map((drill) => (
                   <div key={drill.id} className="bg-vault-bg border border-vault-border rounded-md p-3">
                     <div className="flex items-center justify-between gap-3">
-                      <p className="text-sm font-semibold text-vault-text">{drill.name}</p>
+                      <p className="text-sm font-semibold text-vault-text">{drill.name} · Set {drill.setNumber}</p>
                       <p className="text-xs font-mono text-[#00C2FF]">HF {drill.hitFactor.toFixed(4)}</p>
                     </div>
                     <div className="mt-1 text-xs text-vault-text-muted flex flex-wrap gap-3">
@@ -1104,13 +1297,27 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                   <p className="text-xs text-vault-text-muted mt-1">
                     {session.firearm.name}{session.build ? ` · ${session.build.name}` : ""} · {session.ammoLinks.map((link) => `${link.ammoStock.brand} (${link.roundsUsed})`).join(", ")}
                   </p>
+                  {session.sessionDrills.length > 0 && (
+                    <div className="mt-2 space-y-1.5">
+                      {session.sessionDrills.map((drill) => (
+                        <div key={drill.id} className="text-[11px] text-vault-text-muted flex flex-wrap gap-2">
+                          <span className="font-medium text-vault-text">{drill.name}</span>
+                          <span>Set {drill.setNumber}</span>
+                          <span>·</span>
+                          <span>{drill.points} pts</span>
+                          <span>in {drill.timeSeconds}s</span>
+                          <span className="font-mono text-[#00C2FF]">HF {drill.hitFactor.toFixed(4)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </button>
               ))}
             </div>
           )}
 
           {selectedSession?.sessionDrills?.length ? (
-            <p className="text-xs text-vault-text-faint">Session has {selectedSession.sessionDrills.length} drill entr{selectedSession.sessionDrills.length === 1 ? "y" : "ies"}.</p>
+            <p className="text-xs text-vault-text-faint">Selected session has {selectedSession.sessionDrills.length} drill set{selectedSession.sessionDrills.length === 1 ? "" : "s"} logged.</p>
           ) : null}
         </fieldset>
         )}


### PR DESCRIPTION
### Motivation
- Users frequently run the same drill multiple times in one range session and need those attempts recorded as sets under the parent session. 
- The Log Range Session workflow should allow adding drills as part of the session save flow instead of a separate disconnected step. 
- Keep changes minimal and V1-safe by using an additive schema update and reusing existing session/drill logic.

### Description
- Data model: added a `setNumber` integer field to `SessionDrill` with a production-safe Prisma migration that defaults existing rows to `1` (`prisma/schema.prisma`, `prisma/migrations/20260323133000_add_session_drill_set_number/migration.sql`).
- API: updated `POST /api/range/sessions` to accept an optional `sessionDrills` array, normalize and validate per-set metrics, deterministically assign set numbers per drill name, and create drills in the same nested create as the session; updated session and drill fetch ordering to include `setNumber` (`src/app/api/range/sessions/route.ts`).
- Drill endpoint: updated `/api/range/sessions/[id]/drills` to accept an optional `setNumber` and to auto-assign the next set number for the same drill name when omitted, and to order returned drills by `sortOrder`, `name`, `setNumber`, and `createdAt` (`src/app/api/range/sessions/[id]/drills/route.ts`).
- UI/UX: integrated a compact "Drills Completed During This Session" section into the Log Range Session form that supports adding multiple drill rows (multiple names and repeated names for multiple sets) with per-set metrics and hit-factor preview, and wired those draft rows into the session save payload; improved Log Drill view to show the next set number for the selected drill and updated session history and recent-drills panels to show set numbers and metrics (`src/components/range/RangeWorkspace.tsx`).
- Export: made export ordering deterministic by adding `setNumber` to the drill ordering used in the data export query (`src/app/api/exports/data/route.ts`).

### Testing
- Ran `npm run build` which executed Prisma client generation, applied migrations (including the new migration), and produced a successful Next.js production build (succeeded).
- Ran `npm run lint` which failed due to pre-existing repository lint issues unrelated to these changes (reported `no-explicit-any` and `set-state-in-effect` violations in other files) (failed, unrelated).
- Verified migration SQL added `setNumber` with `DEFAULT 1` and that the migration was applied during the build step (succeeded).
- Confirmed the following validation scenarios are implemented: session with no drills, session with a single drill and single set, session with a single drill and multiple sets (by repeating the drill name), session with multiple distinct drills, session history shows drills and set numbers, and drill rows remain associated with their parent session (manual code-path validation during build and code inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18c9813f88326aad10f8ef4a39703)