### PR TITLE
Stabilize V1: disable encryption, fix exports & documents, and improve drill flows

### DIFF
--- a/prisma/migrations/20260323160000_add_documents/migration.sql
+++ b/prisma/migrations/20260323160000_add_documents/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "fileUrl" TEXT NOT NULL,
+    "fileSize" INTEGER,
+    "mimeType" TEXT,
+    "notes" TEXT,
+    "firearmId" TEXT,
+    "accessoryId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Document_firearmId_fkey" FOREIGN KEY ("firearmId") REFERENCES "Firearm" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Document_accessoryId_fkey" FOREIGN KEY ("accessoryId") REFERENCES "Accessory" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Document_firearmId_idx" ON "Document"("firearmId");
+
+-- CreateIndex
+CREATE INDEX "Document_accessoryId_idx" ON "Document"("accessoryId");
+
+-- CreateIndex
+CREATE INDEX "Document_type_idx" ON "Document"("type");
+
+-- CreateIndex
+CREATE INDEX "Document_createdAt_idx" ON "Document"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Firearm {
 
   builds          Build[]
   rangeSessions   RangeSession[]
+  documents       Document[]
 
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
@@ -106,6 +107,7 @@ model Accessory {
   roundCountLogs         RoundCountLog[]
 
   buildSlots             BuildSlot[]
+  documents              Document[]
 
   // Comma-separated compatible values, e.g. "RIFLE,SMG"
   compatibleFirearmTypes String?
@@ -122,6 +124,27 @@ model Accessory {
 
   @@index([type])
   @@index([roundCount])
+}
+
+model Document {
+  id         String    @id @default(cuid())
+  name       String
+  type       String
+  fileUrl    String
+  fileSize   Int?
+  mimeType   String?
+  notes      String?
+  firearmId  String?
+  accessoryId String?
+  firearm    Firearm?  @relation(fields: [firearmId], references: [id], onDelete: SetNull)
+  accessory  Accessory? @relation(fields: [accessoryId], references: [id], onDelete: SetNull)
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@index([firearmId])
+  @@index([accessoryId])
+  @@index([type])
+  @@index([createdAt])
 }
 
 model RoundCountLog {

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -36,7 +36,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
   try {
     const { id } = await params;
-    const doc = await (prisma as any).document.findUnique({
+    const doc = await prisma.document.findUnique({
       where: { id },
       include: {
         firearm: { select: { id: true, name: true } },
@@ -60,7 +60,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     const body = await req.json();
     const { name, type, notes, firearmId, accessoryId } = body;
 
-    const doc = await (prisma as any).document.update({
+    const doc = await prisma.document.update({
       where: { id },
       data: {
         ...(name !== undefined && { name }),
@@ -89,7 +89,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
 
   try {
     const { id } = await params;
-    const doc = await (prisma as any).document.findUnique({
+    const doc = await prisma.document.findUnique({
       where: { id },
       select: { id: true, fileUrl: true },
     });
@@ -99,7 +99,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     }
 
     await deleteFileIfSafe(doc.fileUrl);
-    await (prisma as any).document.delete({ where: { id } });
+    await prisma.document.delete({ where: { id } });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest) {
     const accessoryId = searchParams.get("accessoryId");
     const type = searchParams.get("type");
 
-    const docs = await (prisma as any).document.findMany({
+    const docs = await prisma.document.findMany({
       where: {
         ...(firearmId ? { firearmId } : {}),
         ...(accessoryId ? { accessoryId } : {}),
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "name and fileUrl are required" }, { status: 400 });
     }
 
-    const doc = await (prisma as any).document.create({
+    const doc = await prisma.document.create({
       data: {
         name,
         type: type || "RECEIPT",

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { randomUUID } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { detectFileSignature } from "@/lib/server/file-signatures";
 import { enforceRateLimit } from "@/lib/rate-limit";
@@ -63,7 +64,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Generate a unique ID for the file
-    const fileId = crypto.randomUUID().replace(/-/g, "");
+    const fileId = randomUUID().replace(/-/g, "");
 
     const fileName = `${fileId}.${detected.extension}`;
     const relativeUrl = `/api/files/documents/${fileName}`;
@@ -75,7 +76,7 @@ export async function POST(request: NextRequest) {
 
     await fs.writeFile(filePath, buffer);
 
-    const doc = await (prisma as any).document.create({
+    const doc = await prisma.document.create({
       data: {
         name,
         type,

--- a/src/app/api/exports/data/route.ts
+++ b/src/app/api/exports/data/route.ts
@@ -427,13 +427,13 @@ export async function GET(request: NextRequest) {
 
     if (flags.documents) {
       queries.push(
-        (prisma as any).document.findMany({
+        prisma.document.findMany({
           include: {
             firearm: { select: { id: true, name: true } },
             accessory: { select: { id: true, name: true } },
           },
           orderBy: { createdAt: "desc" },
-        }).then((rows: any) => {
+        }).then((rows) => {
           payload.documents = rows;
         })
       );
@@ -450,7 +450,6 @@ export async function GET(request: NextRequest) {
           payload.settings = {
             id: settingsRecord.id,
             defaultCurrency: settingsRecord.defaultCurrency,
-            hasEncryptionKey: !!settingsRecord.encryptionKey,
             dataStoragePath: settingsRecord.dataStoragePath,
             createdAt: settingsRecord.createdAt,
             updatedAt: settingsRecord.updatedAt,

--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -164,12 +164,6 @@ function formatDate(value: Date | null | undefined): string {
   return value.toISOString().slice(0, 10);
 }
 
-function maskSerial(serialNumber: string | null | undefined): string {
-  if (!serialNumber) return "";
-  if (serialNumber.length <= 4) return "****";
-  return `${"*".repeat(Math.max(serialNumber.length - 4, 3))}${serialNumber.slice(-4)}`;
-}
-
 function pdfEscape(value: string): string {
   return value
     .replace(/[^\x20-\x7E]/g, "?")
@@ -385,9 +379,7 @@ export async function GET(request: NextRequest) {
         const receiptCount = itemDocs.filter((doc) => doc.type === "RECEIPT").length;
         const hasPhoto = exportOptions.includeImages && !!firearm.imageUrl;
         const resolvedSerial = exportOptions.includeSerialNumbers
-          ? preset === "BACKUP"
-            ? maskSerial(firearm.serialNumber)
-            : (firearm.serialNumber ?? "")
+          ? (firearm.serialNumber ?? "")
           : "";
 
         return {

--- a/src/app/api/files/documents/[fileName]/route.ts
+++ b/src/app/api/files/documents/[fileName]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import { basename } from "path";
+import { requireAuth } from "@/lib/server/auth";
+import { resolveDocumentStoragePath } from "@/lib/upload-security";
+
+function guessMimeType(fileName: string): string {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".pdf")) return "application/pdf";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  return "application/octet-stream";
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ fileName: string }> }
+) {
+  const auth = await requireAuth();
+  if (auth) return auth;
+
+  try {
+    const { fileName } = await params;
+    const safeName = basename(fileName);
+    const fileUrl = `/api/files/documents/${safeName}`;
+    const filePath = resolveDocumentStoragePath(fileUrl);
+
+    if (!filePath) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+
+    const fileBuffer = await fs.readFile(filePath);
+
+    return new NextResponse(new Uint8Array(fileBuffer), {
+      headers: {
+        "Content-Type": guessMimeType(safeName),
+        "Cache-Control": "private, max-age=60",
+      },
+    });
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
+
+    console.error("GET /api/files/documents/[fileName] error:", error);
+    return NextResponse.json({ error: "Failed to read file" }, { status: 500 });
+  }
+}

--- a/src/app/api/firearms/[id]/route.ts
+++ b/src/app/api/firearms/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { encryptField, decryptField } from "@/lib/crypto";
 import { revalidateDashboardData } from "@/lib/dashboard/revalidate-dashboard";
 
 
@@ -47,8 +46,8 @@ export async function GET(
 
     return NextResponse.json({
       ...firearm,
-      serialNumber: decryptField(firearm.serialNumber) ?? firearm.serialNumber,
-      notes: decryptField(firearm.notes),
+      serialNumber: firearm.serialNumber,
+      notes: firearm.notes,
       buildCount: firearm._count.builds,
       activeBuild,
       _count: undefined,
@@ -100,14 +99,14 @@ export async function PUT(
         ...(manufacturer !== undefined && { manufacturer: normalizeString(manufacturer) || "Unknown" }),
         ...(model !== undefined && { model: normalizeString(model) || "Unknown" }),
         ...(caliber !== undefined && { caliber: normalizeString(caliber) || "Unknown" }),
-        ...(serialNumber !== undefined && { serialNumber: encryptField(normalizeString(serialNumber) || fallbackSerialNumber()) }),
+        ...(serialNumber !== undefined && { serialNumber: normalizeString(serialNumber) || fallbackSerialNumber() }),
         ...(type !== undefined && { type: normalizeString(type) || "UNSPECIFIED" }),
         ...(acquisitionDate !== undefined && {
           acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : existing.acquisitionDate,
         }),
         ...(purchasePrice !== undefined && { purchasePrice }),
         ...(currentValue !== undefined && { currentValue }),
-        ...(notes !== undefined && { notes: notes ? encryptField(notes) : null }),
+        ...(notes !== undefined && { notes: notes ? normalizeString(notes) : null }),
         ...(imageUrl !== undefined && { imageUrl }),
         ...(imageSource !== undefined && { imageSource }),
         ...(lastMaintenanceDate !== undefined && {

--- a/src/app/api/firearms/route.ts
+++ b/src/app/api/firearms/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { encryptField, decryptField } from "@/lib/crypto";
 import { revalidateDashboardData } from "@/lib/dashboard/revalidate-dashboard";
 
 
@@ -37,8 +36,8 @@ export async function GET() {
 
     const result = firearms.map((firearm) => ({
       ...firearm,
-      serialNumber: decryptField(firearm.serialNumber) ?? firearm.serialNumber,
-      notes: decryptField(firearm.notes),
+      serialNumber: firearm.serialNumber,
+      notes: firearm.notes,
       buildCount: firearm._count.builds,
       activeBuild: firearm.builds[0] ?? null,
       builds: undefined,
@@ -91,12 +90,12 @@ export async function POST(request: NextRequest) {
         manufacturer: normalizeString(manufacturer) || "Unknown",
         model: normalizeString(model) || "Unknown",
         caliber: normalizeString(caliber) || "Unknown",
-        serialNumber: encryptField(normalizeString(serialNumber) || fallbackSerialNumber()),
+        serialNumber: normalizeString(serialNumber) || fallbackSerialNumber(),
         type: normalizeString(type) || "UNSPECIFIED",
         acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : new Date(),
         purchasePrice: purchasePrice ?? null,
         currentValue: currentValue ?? null,
-        notes: notes ? encryptField(notes) : null,
+        notes: notes ? normalizeString(notes) : null,
         imageUrl: imageUrl ?? null,
         imageSource: imageSource ?? null,
         lastMaintenanceDate: lastMaintenanceDate ? new Date(lastMaintenanceDate) : null,

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -39,17 +39,19 @@ export async function GET() {
       });
     }
 
-    const {
-      googleCseApiKey: _googleCseApiKey,
-      googleCseSearchEngineId: _googleCseSearchEngineId,
-      enableImageSearch: _enableImageSearch,
-      ...v1Settings
-    } = settings;
+    const v1Settings = {
+      id: settings.id,
+      includeUploadsInBackup: settings.includeUploadsInBackup,
+      autoBackupEnabled: settings.autoBackupEnabled,
+      autoBackupCadence: settings.autoBackupCadence,
+      defaultCurrency: settings.defaultCurrency,
+      createdAt: settings.createdAt,
+      updatedAt: settings.updatedAt,
+    };
 
     return NextResponse.json({
       ...v1Settings,
       appPassword: null,
-      encryptionEnabled: !!process.env.VAULT_ENCRYPTION_KEY,
     });
   } catch (error) {
     console.error("GET /api/settings error:", error);
@@ -146,12 +148,15 @@ export async function PUT(request: NextRequest) {
       update: updateData,
     });
 
-    const {
-      googleCseApiKey: _googleCseApiKey,
-      googleCseSearchEngineId: _googleCseSearchEngineId,
-      enableImageSearch: _enableImageSearch,
-      ...v1Settings
-    } = settings;
+    const v1Settings = {
+      id: settings.id,
+      includeUploadsInBackup: settings.includeUploadsInBackup,
+      autoBackupEnabled: settings.autoBackupEnabled,
+      autoBackupCadence: settings.autoBackupCadence,
+      defaultCurrency: settings.defaultCurrency,
+      createdAt: settings.createdAt,
+      updatedAt: settings.updatedAt,
+    };
 
     return NextResponse.json({
       ...v1Settings,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,7 +8,6 @@ import {
   AlertCircle,
   CheckCircle2,
   Settings,
-  ShieldCheck,
   Archive,
   Database,
   Download,
@@ -22,16 +21,7 @@ const INPUT_CLASS =
 const LABEL_CLASS =
   "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
 
-interface AppSettings {
-  id: string;
-  encryptionEnabled?: boolean;
-  includeUploadsInBackup?: boolean;
-  autoBackupEnabled?: boolean;
-  autoBackupCadence?: "daily" | "weekly" | "monthly";
-}
-
 export default function SettingsPage() {
-  const [settings, setSettings] = useState<AppSettings | null>(null);
   const [dataLoading, setDataLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
 
@@ -50,7 +40,6 @@ export default function SettingsPage() {
         if (data.error) {
           setDataError(data.error);
         } else {
-          setSettings(data);
           setIncludeUploadsInBackup(data.includeUploadsInBackup ?? true);
           setAutoBackupEnabled(data.autoBackupEnabled ?? false);
           setAutoBackupCadence(data.autoBackupCadence ?? "weekly");
@@ -87,7 +76,6 @@ export default function SettingsPage() {
       if (!res.ok) {
         setSaveError(json.error ?? "Failed to save settings");
       } else {
-        setSettings(json);
         setSaveSuccess(true);
         setTimeout(() => setSaveSuccess(false), 3000);
       }
@@ -232,59 +220,6 @@ export default function SettingsPage() {
             </Link>
           </fieldset>
 
-          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
-            <div className="flex items-center justify-between">
-              <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
-                <ShieldCheck className="w-3.5 h-3.5" />
-                Encryption at Rest
-              </legend>
-              <span
-                className={`text-[10px] font-mono px-2 py-0.5 rounded border uppercase ${
-                  settings?.encryptionEnabled
-                    ? "text-[#00C853] border-[#00C853]/40"
-                    : "text-vault-text-faint border-vault-border"
-                }`}
-              >
-                {settings?.encryptionEnabled ? "Active" : "Not Configured"}
-              </span>
-            </div>
-
-            <p className="text-xs text-vault-text-muted leading-relaxed">
-              Encryption protects sensitive values before they are written to your database files.
-              If someone copies the raw DB without your key, those encrypted values stay unreadable.
-              Set <code className="text-vault-text-faint font-mono">VAULT_ENCRYPTION_KEY</code> in{" "}
-              <code className="text-vault-text-faint font-mono">.blackvault.env</code> (or your
-              Docker environment), then restart the app so the key is loaded.
-            </p>
-
-            {settings?.encryptionEnabled ? (
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-widest text-vault-text-faint font-mono mb-2">
-                  Encrypted Fields
-                </p>
-                {["Serial Number", "Notes"].map((field) => (
-                  <div key={field} className="flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-[#00C853]" />
-                    <span className="text-xs text-vault-text-muted">{field}</span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="bg-[#F5A623]/5 border border-[#F5A623]/20 rounded-md px-4 py-3">
-                <p className="text-xs text-[#F5A623] font-mono">
-                  To enable encryption, generate a key and add it to your environment:
-                </p>
-                <p className="text-[11px] font-mono text-vault-text-faint mt-1 break-all">
-                  openssl rand -hex 32
-                </p>
-                <p className="text-[11px] text-vault-text-faint mt-1">
-                  Then set <code className="font-mono">VAULT_ENCRYPTION_KEY=&lt;key&gt;</code> in{" "}
-                  <code className="font-mono">.blackvault.env</code> and restart.
-                </p>
-              </div>
-            )}
-          </fieldset>
-
           <div className="bg-vault-bg border border-vault-border rounded-lg p-4">
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-3 font-mono">
               Current Configuration Status
@@ -299,11 +234,6 @@ export default function SettingsPage() {
                 label="Auto Backup"
                 value={autoBackupEnabled ? `Plan saved (${autoBackupCadence})` : "No backup plan saved"}
                 ok={autoBackupEnabled}
-              />
-              <StatusRow
-                label="Encryption at Rest"
-                value={settings?.encryptionEnabled ? "Active" : "Not configured"}
-                ok={!!settings?.encryptionEnabled}
               />
             </div>
           </div>

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { formatNumber } from "@/lib/utils";
 import { Target, ChevronDown, Loader2, AlertCircle, CheckCircle2, Shield, Timer, BookPlus, Plus, Minus, Calculator } from "lucide-react";
+import Link from "next/link";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 const INPUT_CLASS =
   "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
@@ -95,6 +97,16 @@ interface DrillEntryDraft {
   notes: string;
 }
 
+type DrillPerformanceMode = "time" | "accuracy" | "both";
+
+interface DrillTemplate {
+  id: string;
+  name: string;
+  notes: string | null;
+  mode: DrillPerformanceMode;
+  createdAt: string;
+}
+
 const SLOT_TYPE_LABELS: Record<string, string> = {
   BARREL: "Barrel",
   SUPPRESSOR: "Suppressor",
@@ -127,6 +139,12 @@ interface RangeWorkspaceProps {
 
 type PowerFactorMode = "minor" | "major";
 
+const DEFAULT_DRILL_LIBRARY: DrillTemplate[] = [
+  { id: "bill-drill", name: "Bill Drill", notes: "6 shots from holster at 7 yards", mode: "both", createdAt: "2026-01-01T00:00:00.000Z" },
+  { id: "draw-to-first-shot", name: "Draw to First Shot", notes: "Pure speed drill", mode: "time", createdAt: "2026-01-01T00:00:00.000Z" },
+  { id: "dot-torture", name: "Dot Torture", notes: "Accuracy-focused control drill", mode: "accuracy", createdAt: "2026-01-01T00:00:00.000Z" },
+];
+
 export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const isDrillPage = view === "log-drill" || view === "drill-performance" || view === "drill-library" || view === "hit-factor";
   const [firearms, setFirearms] = useState<Firearm[]>([]);
@@ -156,7 +174,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const [drillNotes, setDrillNotes] = useState<string>("");
   const [customDrillName, setCustomDrillName] = useState("");
   const [customDrillNotes, setCustomDrillNotes] = useState("");
-  const [customDrills, setCustomDrills] = useState<Array<{ id: string; name: string; notes: string | null; createdAt: string }>>([]);
+  const [customDrillMode, setCustomDrillMode] = useState<DrillPerformanceMode>("both");
+  const [drillLibrary, setDrillLibrary] = useState<DrillTemplate[]>(DEFAULT_DRILL_LIBRARY);
   const [calculatorPoints, setCalculatorPoints] = useState("");
   const [calculatorPenalties, setCalculatorPenalties] = useState("");
   const [calculatorTime, setCalculatorTime] = useState("");
@@ -168,6 +187,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const [penaltyCounts, setPenaltyCounts] = useState({ miss: 0, noShoot: 0, procedural: 0 });
   const [performanceMetric, setPerformanceMetric] = useState<"time" | "score" | "hitFactor">("hitFactor");
   const [performanceDrillName, setPerformanceDrillName] = useState("");
+  const [selectedPerformanceDrillId, setSelectedPerformanceDrillId] = useState<string>("");
 
   const [loadingFirearms, setLoadingFirearms] = useState(true);
   const [loadingBuilds, setLoadingBuilds] = useState(false);
@@ -298,11 +318,16 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      const raw = window.localStorage.getItem("blackvault-custom-drills");
+      const raw = window.localStorage.getItem("blackvault-drill-library");
       if (!raw) return;
-      const parsed = JSON.parse(raw) as Array<{ id: string; name: string; notes: string | null; createdAt: string }>;
+      const parsed = JSON.parse(raw) as DrillTemplate[];
       if (Array.isArray(parsed)) {
-        setCustomDrills(parsed.filter((item) => typeof item.id === "string" && typeof item.name === "string"));
+        const valid = parsed.filter((item) =>
+          typeof item.id === "string" &&
+          typeof item.name === "string" &&
+          (item.mode === "time" || item.mode === "accuracy" || item.mode === "both")
+        );
+        if (valid.length > 0) setDrillLibrary(valid);
       }
     } catch {
       // ignore invalid localStorage payload
@@ -311,8 +336,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem("blackvault-custom-drills", JSON.stringify(customDrills));
-  }, [customDrills]);
+    window.localStorage.setItem("blackvault-drill-library", JSON.stringify(drillLibrary));
+  }, [drillLibrary]);
 
   const selectedFirearmData = firearms.find((f) => f.id === selectedFirearm);
   const selectedBuildData = builds.find((b) => b.id === selectedBuild);
@@ -324,13 +349,18 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
   const selectedSession = sessions.find((session) => session.id === selectedSessionId) ?? null;
 
+  const selectedDrillTemplate = useMemo(
+    () => drillLibrary.find((template) => template.name === drillName) ?? null,
+    [drillLibrary, drillName]
+  );
+
   const drillHitFactorPreview = useMemo(() => {
-    const time = Number.parseFloat(drillTime);
-    const points = Number.parseFloat(drillPoints);
+    const time = selectedDrillTemplate?.mode === "accuracy" ? 1 : Number.parseFloat(drillTime);
+    const points = selectedDrillTemplate?.mode === "time" ? 0 : Number.parseFloat(drillPoints);
     const penalties = Number.parseFloat(drillPenalties || "0");
     const adjustedPoints = Number.isFinite(points) ? Math.max(0, points - (Number.isFinite(penalties) ? penalties : 0)) : 0;
     return calculateHitFactor(adjustedPoints, time);
-  }, [drillTime, drillPoints, drillPenalties]);
+  }, [drillTime, drillPoints, drillPenalties, selectedDrillTemplate]);
 
   const nextSetNumberForSelectedDrill = useMemo(() => {
     const normalizedName = drillName.trim().toLowerCase();
@@ -529,13 +559,30 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     setSubmittingDrill(true);
 
     try {
+      if (!selectedDrillTemplate) {
+        throw new Error("Select a drill template from the Drill Library.");
+      }
+
+      const parsedTime = Number.parseFloat(drillTime);
+      const parsedPoints = Number.parseFloat(drillPoints);
+      const resolvedTime = selectedDrillTemplate.mode === "accuracy" ? 1 : parsedTime;
+      const resolvedPoints = selectedDrillTemplate.mode === "time" ? 0 : parsedPoints;
+
+      if (!Number.isFinite(resolvedTime) || resolvedTime <= 0) {
+        throw new Error("Enter a valid drill time.");
+      }
+
+      if (!Number.isFinite(resolvedPoints) || resolvedPoints < 0) {
+        throw new Error("Enter a valid points value.");
+      }
+
       const payload = {
         name: drillName,
         setNumber: nextSetNumberForSelectedDrill,
-        timeSeconds: Number.parseFloat(drillTime),
-        points: Number.parseFloat(drillPoints),
-        penalties: drillPenalties ? Number.parseFloat(drillPenalties) : undefined,
-        hits: drillHits ? Number.parseInt(drillHits, 10) : undefined,
+        timeSeconds: resolvedTime,
+        points: resolvedPoints,
+        penalties: selectedDrillTemplate.mode === "time" ? undefined : (drillPenalties ? Number.parseFloat(drillPenalties) : undefined),
+        hits: selectedDrillTemplate.mode === "time" ? undefined : (drillHits ? Number.parseInt(drillHits, 10) : undefined),
         notes: drillNotes,
       };
 
@@ -606,6 +653,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     }
   }, [drillNameLibrary, performanceDrillName]);
 
+  useEffect(() => {
+    if (!drillName && drillLibrary.length > 0) {
+      setDrillName(drillLibrary[0].name);
+    }
+  }, [drillLibrary, drillName]);
+
   const performanceRows = useMemo(() => {
     const filtered = performanceDrillName
       ? allLoggedDrills.filter((drill) => drill.name.trim() === performanceDrillName)
@@ -621,14 +674,18 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
       return drill.hitFactor;
     };
 
-    const maxMetricValue = sorted.reduce((max, drill) => Math.max(max, metricValueFor(drill)), 0);
-
-    return sorted.map((drill) => ({
+    return sorted.map((drill, index) => ({
       ...drill,
+      index: index + 1,
+      displayDate: new Date(drill.sessionDate).toLocaleDateString(),
       metricValue: metricValueFor(drill),
-      barWidth: maxMetricValue > 0 ? Math.max(6, Math.round((metricValueFor(drill) / maxMetricValue) * 100)) : 0,
     }));
   }, [allLoggedDrills, performanceDrillName, performanceMetric]);
+
+  const selectedPerformanceRow = useMemo(
+    () => performanceRows.find((row) => row.id === selectedPerformanceDrillId) ?? null,
+    [performanceRows, selectedPerformanceDrillId]
+  );
 
   const pointsPerHit = powerFactor === "major"
     ? { alpha: 5, charlie: 4, delta: 2, steel: 5 }
@@ -681,17 +738,19 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     const name = customDrillName.trim();
     if (!name) return;
 
-    setCustomDrills((prev) => [
+    setDrillLibrary((prev) => [
       {
         id: crypto.randomUUID(),
         name,
         notes: customDrillNotes.trim() || null,
+        mode: customDrillMode,
         createdAt: new Date().toISOString(),
       },
       ...prev,
     ]);
     setCustomDrillName("");
     setCustomDrillNotes("");
+    setCustomDrillMode("both");
   }
 
   const pageTitle = ({
@@ -1090,31 +1149,58 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           <form onSubmit={handleAddDrill} className="space-y-4">
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <label className={LABEL_CLASS}>Drill Name <span className="text-[#E53935]">*</span></label>
-                <input required value={drillName} onChange={(e) => setDrillName(e.target.value)} className={INPUT_CLASS} placeholder="e.g. Bill Drill" />
+                <label className={LABEL_CLASS}>Drill Template <span className="text-[#E53935]">*</span></label>
+                <div className="relative">
+                  <select
+                    required
+                    value={drillName}
+                    onChange={(e) => setDrillName(e.target.value)}
+                    className={INPUT_CLASS}
+                    disabled={drillLibrary.length === 0}
+                  >
+                    <option value="">Select drill template...</option>
+                    {drillLibrary.map((template) => (
+                      <option key={template.id} value={template.name}>
+                        {template.name} ({template.mode})
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
+                </div>
                 {selectedSessionId && drillName.trim() && (
                   <p className="mt-1 text-xs text-vault-text-faint">This will be saved as set {nextSetNumberForSelectedDrill} for this drill in the selected session.</p>
                 )}
+                {selectedDrillTemplate?.notes && (
+                  <p className="mt-1 text-xs text-vault-text-faint">{selectedDrillTemplate.notes}</p>
+                )}
               </div>
+              {selectedDrillTemplate?.mode !== "accuracy" && (
               <div>
                 <label className={LABEL_CLASS}>Time (seconds) <span className="text-[#E53935]">*</span></label>
                 <input type="number" step="0.01" min="0.01" required value={drillTime} onChange={(e) => setDrillTime(e.target.value)} className={INPUT_CLASS} placeholder="2.45" />
               </div>
+              )}
             </div>
 
             <div id="hit-factor-calculator" className="grid sm:grid-cols-2 md:grid-cols-4 gap-4 scroll-mt-20">
+              {selectedDrillTemplate?.mode !== "time" && (
               <div>
                 <label className={LABEL_CLASS}>Points <span className="text-[#E53935]">*</span></label>
                 <input type="number" step="0.01" min="0" required value={drillPoints} onChange={(e) => setDrillPoints(e.target.value)} className={INPUT_CLASS} placeholder="90" />
               </div>
+              )}
+              {selectedDrillTemplate?.mode !== "time" && (
               <div>
                 <label className={LABEL_CLASS}>Penalties</label>
                 <input type="number" step="0.01" min="0" value={drillPenalties} onChange={(e) => setDrillPenalties(e.target.value)} className={INPUT_CLASS} placeholder="10" />
               </div>
+              )}
+              {selectedDrillTemplate?.mode !== "time" && (
               <div>
                 <label className={LABEL_CLASS}>Hits</label>
                 <input type="number" min="0" value={drillHits} onChange={(e) => setDrillHits(e.target.value)} className={INPUT_CLASS} placeholder="6" />
               </div>
+              )}
               <div className="bg-vault-bg border border-vault-border rounded-md px-3 py-2">
                 <p className="text-[11px] text-vault-text-faint uppercase tracking-widest">Hit Factor</p>
                 <p className="text-lg font-mono text-[#00C2FF]">{drillHitFactorPreview.toFixed(4)}</p>
@@ -1184,27 +1270,69 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           {performanceRows.length === 0 ? (
             <p className="text-sm text-vault-text-faint">No historical data for the selected drill yet.</p>
           ) : (
-            <div className="space-y-2">
-              {performanceRows.map((drill) => (
-                <div key={drill.id} className="bg-vault-bg border border-vault-border rounded-md p-3">
-                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
-                    <p className="text-vault-text font-medium">{drill.name}</p>
-                    <p className="font-mono text-[#00C2FF]">
-                      {performanceMetric === "time"
-                        ? `${drill.metricValue.toFixed(2)}s`
-                        : performanceMetric === "score"
-                          ? `${drill.metricValue.toFixed(2)} pts`
-                          : `HF ${drill.metricValue.toFixed(4)}`}
-                    </p>
-                  </div>
-                  <div className="mt-2 h-2 rounded bg-vault-border overflow-hidden">
-                    <div className="h-full rounded bg-[#00C2FF]" style={{ width: `${drill.barWidth}%` }} />
-                  </div>
-                  <p className="mt-1 text-[11px] text-vault-text-faint">
-                    {new Date(drill.sessionDate).toLocaleDateString()} · {drill.location} · {drill.points} pts in {drill.timeSeconds}s
+            <div className="space-y-3">
+              <div className="h-64 w-full rounded-md border border-vault-border bg-vault-bg p-2">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={performanceRows} margin={{ top: 8, right: 12, left: 8, bottom: 8 }}>
+                    <XAxis dataKey="displayDate" tick={{ fill: "#9CA3AF", fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
+                    <YAxis tick={{ fill: "#9CA3AF", fontSize: 11 }} width={52} />
+                    <Tooltip
+                      contentStyle={{ backgroundColor: "#101114", border: "1px solid #2C2F36", borderRadius: 8 }}
+                      labelStyle={{ color: "#E5E7EB" }}
+                      formatter={(value) => {
+                        const numericValue = typeof value === "number" ? value : Number(value ?? 0);
+                        if (performanceMetric === "time") return [`${numericValue.toFixed(2)}s`, "Time"];
+                        if (performanceMetric === "score") return [`${numericValue.toFixed(2)} pts`, "Score"];
+                        return [`${numericValue.toFixed(4)}`, "Hit Factor"];
+                      }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="metricValue"
+                      stroke="#00C2FF"
+                      strokeWidth={2}
+                      dot={(props: { cx?: number; cy?: number; payload?: { id?: string; sessionId?: string } }) => (
+                        <circle
+                          cx={props.cx}
+                          cy={props.cy}
+                          r={4}
+                          fill="#00C2FF"
+                          stroke="#00C2FF"
+                          strokeWidth={1}
+                          style={{ cursor: "pointer" }}
+                          onClick={() => {
+                            const pointId = props.payload?.id;
+                            const sessionId = props.payload?.sessionId;
+                            if (pointId) setSelectedPerformanceDrillId(pointId);
+                            if (sessionId) setSelectedSessionId(sessionId);
+                          }}
+                        />
+                      )}
+                      activeDot={{ r: 6, stroke: "#00C2FF", fill: "#101114" }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+              <p className="text-xs text-vault-text-faint">
+                Tap a point to open that specific drill result context.
+              </p>
+
+              {selectedPerformanceRow && (
+                <div className="bg-vault-bg border border-[#00C2FF]/30 rounded-md p-3">
+                  <p className="text-sm font-medium text-vault-text">{selectedPerformanceRow.name} · Set {selectedPerformanceRow.setNumber}</p>
+                  <p className="text-xs text-vault-text-faint mt-1">
+                    {selectedPerformanceRow.displayDate} · {selectedPerformanceRow.location} · {selectedPerformanceRow.points} pts in {selectedPerformanceRow.timeSeconds}s
                   </p>
+                  <div className="mt-2">
+                    <Link
+                      href={`/range/log-drill?sessionId=${selectedPerformanceRow.sessionId}#logged-drills`}
+                      className="text-xs text-[#00C2FF] hover:underline"
+                    >
+                      Open this drill entry
+                    </Link>
+                  </div>
                 </div>
-              ))}
+              )}
             </div>
           )}
         </fieldset>
@@ -1213,7 +1341,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         {showDrillLibrary && (
         <fieldset id="drill-library" className={`${SECTION_CARD_CLASS} scroll-mt-20`}>
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drill Library</legend>
-          <form onSubmit={addCustomDrill} className="grid gap-3 md:grid-cols-[1fr_1fr_auto] items-end">
+          <form onSubmit={addCustomDrill} className="grid gap-3 md:grid-cols-[1fr_1fr_160px_auto] items-end">
             <div>
               <label className={LABEL_CLASS}>Custom Drill Name</label>
               <input
@@ -1232,6 +1360,14 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 className={INPUT_CLASS}
               />
             </div>
+            <div>
+              <label className={LABEL_CLASS}>Mode</label>
+              <select value={customDrillMode} onChange={(e) => setCustomDrillMode(e.target.value as DrillPerformanceMode)} className={INPUT_CLASS}>
+                <option value="both">Time + Accuracy</option>
+                <option value="time">Time only</option>
+                <option value="accuracy">Accuracy only</option>
+              </select>
+            </div>
             <button
               type="submit"
               className="h-10 px-4 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20"
@@ -1242,28 +1378,30 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
           <div className="grid md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <p className="text-xs uppercase tracking-widest text-vault-text-muted">Logged Drill Names</p>
-              {drillNameLibrary.length === 0 ? (
-                <p className="text-sm text-vault-text-faint">No logged drill names yet.</p>
+              <p className="text-xs uppercase tracking-widest text-vault-text-muted">Template Library</p>
+              {drillLibrary.length === 0 ? (
+                <p className="text-sm text-vault-text-faint">No drill templates yet.</p>
               ) : (
                 <div className="space-y-1.5">
-                  {drillNameLibrary.map((name) => (
-                    <div key={name} className="text-sm text-vault-text bg-vault-bg border border-vault-border rounded px-3 py-2">{name}</div>
+                  {drillLibrary.map((template) => (
+                    <div key={template.id} className="text-sm text-vault-text bg-vault-bg border border-vault-border rounded px-3 py-2">
+                      <p>{template.name}</p>
+                      <p className="text-xs text-vault-text-faint mt-1 uppercase tracking-widest">{template.mode}</p>
+                    </div>
                   ))}
                 </div>
               )}
             </div>
 
             <div className="space-y-2">
-              <p className="text-xs uppercase tracking-widest text-vault-text-muted">Custom Drills</p>
-              {customDrills.length === 0 ? (
-                <p className="text-sm text-vault-text-faint">No custom drills added yet.</p>
+              <p className="text-xs uppercase tracking-widest text-vault-text-muted">Logged Drill Names</p>
+              {drillNameLibrary.length === 0 ? (
+                <p className="text-sm text-vault-text-faint">No drills logged yet.</p>
               ) : (
                 <div className="space-y-1.5">
-                  {customDrills.map((drill) => (
-                    <div key={drill.id} className="bg-vault-bg border border-vault-border rounded px-3 py-2">
-                      <p className="text-sm text-vault-text">{drill.name}</p>
-                      {drill.notes && <p className="text-xs text-vault-text-faint mt-1">{drill.notes}</p>}
+                  {drillNameLibrary.map((name) => (
+                    <div key={name} className="bg-vault-bg border border-vault-border rounded px-3 py-2">
+                      <p className="text-sm text-vault-text">{name}</p>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
### Motivation
- Remove unstable encryption paths that cause runtime/export errors and simplify V1 behavior. 
- Ensure exports include real serial numbers for armory/insurance workflows. 
- Fix failing document upload/library flows and make drill logging/performance reliable and practical for V1.

### Description
- Disabled active encryption for V1 by removing `encryptField`/`decryptField` usage from firearm create/read/update flows and removing the encryption status UI/flag from settings and export metadata. (`src/app/api/firearms/*`, `src/app/api/settings/route.ts`, `src/app/settings/page.tsx`).
- Restored serial number inclusion in Full Armory exports so `includeSerialNumbers=true` returns the stored serial directly for both JSON/CSV/PDF export outputs and removed the masked-backup behavior. (`src/app/api/exports/full-armory/route.ts`).
- Added a proper `Document` Prisma model and migration, switched document APIs to use `prisma.document`, implemented safe file storage serving endpoint, and fixed the upload flow to persist DB records and return proper library entries. (`prisma/schema.prisma`, `prisma/migrations/20260323160000_add_documents/migration.sql`, `src/app/api/documents/*`, `src/app/api/files/documents/[fileName]/route.ts`, `src/app/api/documents/upload/route.ts`).
- Introduced a Drill Library template concept and mode-aware logging (modes: `time`, `accuracy`, `both`), made the Log Drill form require a template and show only relevant fields, and replaced the simple performance list with a line chart that has clickable data points which open the related drill context. (`src/components/range/RangeWorkspace.tsx`).

### Testing
- Ran `npx prisma generate` and client generation completed successfully.
- Ran unit tests: `npx vitest run src/app/api/exports/full-armory/route.test.ts` — all tests passed.
- Ran targeted linting for changed files with `npx eslint ...` — no new errors introduced for modified files (targeted files pass); note the repository still has pre-existing unrelated lint warnings/errors in files not changed by this PR.
- Built the app: `npm run build` — build and static/SSR page generation completed successfully (migrations applied; document migration added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c191ace5b48326b2a90de2d5ec7983)