### PR TITLE
Enable LAN access and show local access URL in Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "build": "DATABASE_URL=${DATABASE_URL:-file:${PWD}/prisma/prisma/dev.db} prisma generate && DATABASE_URL=${DATABASE_URL:-file:${PWD}/prisma/prisma/dev.db} prisma migrate deploy && DATABASE_URL=${DATABASE_URL:-file:${PWD}/prisma/prisma/dev.db} next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0",
     "lint": "eslint"
   },
   "dependencies": {

--- a/src/app/api/network/local-access/route.ts
+++ b/src/app/api/network/local-access/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getLocalIp } from "@/lib/network/get-local-ip";
+
+export const runtime = "nodejs";
+
+function getAppPort(): string {
+  return process.env.PORT || "3000";
+}
+
+export async function GET() {
+  try {
+    const ip = getLocalIp();
+    const port = getAppPort();
+
+    if (!ip) {
+      return NextResponse.json({
+        ip: null,
+        port,
+        url: null,
+        message: "Unable to detect local network IP",
+      });
+    }
+
+    return NextResponse.json({
+      ip,
+      port,
+      url: `http://${ip}:${port}`,
+      message: null,
+    });
+  } catch (error) {
+    console.error("GET /api/network/local-access error:", error);
+    return NextResponse.json({
+      ip: null,
+      port: getAppPort(),
+      url: null,
+      message: "Unable to detect local network IP",
+    });
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   AlertCircle,
   CheckCircle2,
+  Copy,
   Settings,
   Archive,
   Database,
@@ -32,6 +33,11 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [localIp, setLocalIp] = useState<string | null>(null);
+  const [localPort, setLocalPort] = useState("3000");
+  const [localUrl, setLocalUrl] = useState<string | null>(null);
+  const [localAccessMessage, setLocalAccessMessage] = useState<string | null>(null);
+  const [copySuccess, setCopySuccess] = useState(false);
 
   useEffect(() => {
     fetch("/api/settings")
@@ -49,6 +55,23 @@ export default function SettingsPage() {
       .catch(() => {
         setDataError("Failed to load settings");
         setDataLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/network/local-access")
+      .then((r) => r.json())
+      .then((data) => {
+        setLocalIp(data.ip ?? null);
+        setLocalPort(data.port ?? "3000");
+        setLocalUrl(data.url ?? null);
+        setLocalAccessMessage(data.message ?? null);
+      })
+      .catch(() => {
+        setLocalIp(null);
+        setLocalPort("3000");
+        setLocalUrl(null);
+        setLocalAccessMessage("Unable to detect local network IP");
       });
   }, []);
 
@@ -83,6 +106,17 @@ export default function SettingsPage() {
       setSaveError("Network error. Please try again.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleCopyLocalUrl() {
+    if (!localUrl || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(localUrl);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch {
+      setCopySuccess(false);
     }
   }
 
@@ -218,6 +252,56 @@ export default function SettingsPage() {
               <Download className="w-4 h-4" />
               Open Full Armory Exports
             </Link>
+          </fieldset>
+
+          <fieldset className="bg-vault-surface border border-vault-border rounded-lg p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <legend className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-[#00C2FF]">
+                <Database className="w-3.5 h-3.5" />
+                Local Network Access
+              </legend>
+            </div>
+
+            <p className="text-xs text-vault-text-muted leading-relaxed">
+              Make sure your phone is on the same WiFi network.
+            </p>
+
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center justify-between">
+                <span className="text-vault-text-muted">Device IP</span>
+                <span className="font-mono text-vault-text">{localIp ?? "—"}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-vault-text-muted">Port</span>
+                <span className="font-mono text-vault-text">{localPort}</span>
+              </div>
+            </div>
+
+            {localUrl ? (
+              <div className="space-y-3">
+                <div className="rounded-md border border-vault-border bg-vault-bg px-3 py-2">
+                  <p className="text-[10px] uppercase tracking-widest text-vault-text-faint font-mono">
+                    Access URL
+                  </p>
+                  <p className="font-mono text-sm text-vault-text break-all">{localUrl}</p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleCopyLocalUrl}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/10 transition-colors text-sm font-medium"
+                >
+                  <Copy className="w-4 h-4" />
+                  {copySuccess ? "Copied!" : "Copy URL"}
+                </button>
+              </div>
+            ) : (
+              <div className="rounded-md border border-[#E53935]/30 bg-[#E53935]/10 px-3 py-2">
+                <p className="text-sm text-[#E53935]">
+                  {localAccessMessage ?? "Unable to detect local network IP"}
+                </p>
+              </div>
+            )}
           </fieldset>
 
           <div className="bg-vault-bg border border-vault-border rounded-lg p-4">

--- a/src/lib/network/get-local-ip.ts
+++ b/src/lib/network/get-local-ip.ts
@@ -1,0 +1,25 @@
+import os from "node:os";
+
+export function getLocalIp(): string | null {
+  const networkInterfaces = os.networkInterfaces();
+
+  for (const interfaceAddresses of Object.values(networkInterfaces)) {
+    if (!interfaceAddresses) {
+      continue;
+    }
+
+    for (const address of interfaceAddresses) {
+      const isIpv4 =
+        address.family === "IPv4" ||
+        (typeof address.family === "number" && address.family === 4);
+
+      if (!isIpv4 || address.internal || address.address === "127.0.0.1") {
+        continue;
+      }
+
+      return address.address;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
### Motivation
- Make the app reachable from other devices on the same local network by binding the server to `0.0.0.0` while preserving existing Docker and port behavior.  
- Provide users an easy way to find the correct LAN access URL (IP + port) from the Settings page.  
- Give a simple copy UX and a safe fallback when no LAN IP can be detected so the app does not crash.

### Description
- Bind dev/start scripts to all interfaces by adding `-H 0.0.0.0` to the `dev` and `start` npm scripts in `package.json`.  
- Add a synchronous Node.js helper `src/lib/network/get-local-ip.ts` that uses `os.networkInterfaces()` and returns the first non-internal IPv4 address while ignoring loopback and internal interfaces.  
- Add a server endpoint `GET /api/network/local-access` at `src/app/api/network/local-access/route.ts` that returns `{ ip, port, url, message }` and provides a graceful fallback (`"Unable to detect local network IP"`) when detection fails.  
- Extend the Settings UI in `src/app/settings/page.tsx` with a new "Local Network Access" section that displays Device IP, Port, the full access URL (`http://<LAN_IP>:<PORT>`), a `Copy URL` button, and the instruction "Make sure your phone is on the same WiFi network"; the UI shows the fallback message when no IP is available.  
- No external dependencies were introduced and the API route runs with `runtime = "nodejs"` to allow usage of Node APIs.

### Testing
- Ran targeted linting with `npx eslint src/app/settings/page.tsx src/app/api/network/local-access/route.ts src/lib/network/get-local-ip.ts`, which passed for the modified files.  
- Ran full project lint with `npm run lint`, which failed due to pre-existing unrelated lint errors in other files (`src/app/ammo/page.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/ThemeProvider.tsx`) and not related to these changes.  
- No other automated tests were added or run by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a1a0fb248326a17ef376a5ba7e9f)