### PR TITLE
V1 polish: first-run guidance, action feedback, and export/document reliability

### DIFF
--- a/src/app/api/exports/full-armory/route.ts
+++ b/src/app/api/exports/full-armory/route.ts
@@ -304,8 +304,8 @@ function buildExportPdfLines(payload: FullArmoryExportResponse): string[] {
 }
 
 function buildFileName(extension: ExportFormat): string {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  return `full-armory-export-${timestamp}.${extension}`;
+  const date = new Date().toISOString().slice(0, 10);
+  return `blackvault-export-${date}.${extension}`;
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -61,7 +61,7 @@ export default async function BuildsPage() {
   return (
     <div className="min-h-full">
       <PageHeader
-        title="ALL LOADOUTS"
+        title="ALL BUILDS"
         subtitle={`${totalBuilds} build${totalBuilds !== 1 ? "s" : ""} across ${firearms.length} firearm${firearms.length !== 1 ? "s" : ""}`}
       />
 
@@ -96,7 +96,7 @@ export default async function BuildsPage() {
             <div className="w-16 h-16 rounded-full bg-[#00C2FF]/10 border border-[#00C2FF]/20 flex items-center justify-center mb-4">
               <Layers className="w-8 h-8 text-[#00C2FF]" />
             </div>
-            <h3 className="text-lg font-semibold text-vault-text mb-2">No loadouts yet</h3>
+            <h3 className="text-lg font-semibold text-vault-text mb-2">No builds yet</h3>
             <p className="text-sm text-vault-text-muted mb-6 max-w-sm">
               Open a firearm from the Vault and create your first build configuration.
             </p>

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -25,6 +25,7 @@ export default function DocumentLibraryPage() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   useEffect(() => {
     fetch("/api/documents", { credentials: "include", cache: "no-store" })
@@ -59,12 +60,16 @@ export default function DocumentLibraryPage() {
       const res = await fetch(`/api/documents/${id}`, { method: "DELETE" });
       if (!res.ok) {
         const json = await res.json().catch(() => null);
-        alert(json?.error ?? "Failed to delete document");
+        setActionMessage({
+          type: "error",
+          text: json?.error ?? "Could not delete document.",
+        });
         return;
       }
       setDocuments((prev) => prev.filter((d) => d.id !== id));
+      setActionMessage({ type: "success", text: "Document deleted." });
     } catch {
-      alert("Network error — could not delete document");
+      setActionMessage({ type: "error", text: "Network error — could not delete document." });
     } finally {
       setDeletingId(null);
     }
@@ -99,6 +104,17 @@ export default function DocumentLibraryPage() {
         {uploadSuccess && (
           <div className="rounded-lg border border-[#00C853]/30 bg-[#00C853]/10 px-4 py-3 text-sm text-[#00C853]">
             {uploadSuccess}
+          </div>
+        )}
+        {actionMessage && (
+          <div
+            className={`rounded-lg px-4 py-3 text-sm border ${
+              actionMessage.type === "success"
+                ? "border-[#00C853]/30 bg-[#00C853]/10 text-[#00C853]"
+                : "border-[#E53935]/30 bg-[#E53935]/10 text-[#E53935]"
+            }`}
+          >
+            {actionMessage.text}
           </div>
         )}
 
@@ -269,7 +285,14 @@ export default function DocumentLibraryPage() {
                       className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs border border-vault-border text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 transition-colors"
                     >
                       <ExternalLink className="w-3.5 h-3.5" />
-                      Open
+                      View
+                    </a>
+                    <a
+                      href={doc.fileUrl}
+                      download={doc.name}
+                      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs border border-vault-border text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 transition-colors"
+                    >
+                      Download
                     </a>
                     <button
                       onClick={() => handleDelete(doc.id)}

--- a/src/app/exports/full-armory/page.tsx
+++ b/src/app/exports/full-armory/page.tsx
@@ -18,6 +18,7 @@ export default function FullArmoryExportPage() {
   const [options, setOptions] = useState<FullArmoryExportOptions>(DEFAULT_OPTIONS);
   const [loadingFormat, setLoadingFormat] = useState<"csv" | "pdf" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
 
   const previewHref = useMemo(
     () => `/exports/full-armory/preview?${buildExportQueryString(options)}`,
@@ -33,6 +34,7 @@ export default function FullArmoryExportPage() {
   async function runExport(format: "csv" | "pdf") {
     setLoadingFormat(format);
     setError(null);
+    setSuccess(null);
     try {
       const query = buildExportQueryString(options, format);
       const response = await fetch(`/api/exports/full-armory?${query}`, {
@@ -58,14 +60,22 @@ export default function FullArmoryExportPage() {
       if (!blob.size) {
         throw new Error(`No ${format.toUpperCase()} content was generated. Try adjusting export options and retry.`);
       }
+
+      const exportDate = new Date().toISOString().slice(0, 10);
+      const preferredName = `blackvault-export-${exportDate}.${format}`;
+      const disposition = response.headers.get("content-disposition") ?? "";
+      const nameMatch = disposition.match(/filename="?([^"]+)"?/i);
+      const serverName = nameMatch?.[1];
+
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = format === "csv" ? "full-armory-export.csv" : "full-armory-export.pdf";
+      link.download = serverName || preferredName;
       document.body.append(link);
       link.click();
       link.remove();
       window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+      setSuccess(`${format.toUpperCase()} export downloaded.`);
     } catch (exportError) {
       const message = exportError instanceof Error ? exportError.message : "Export failed";
       setError(message);
@@ -145,6 +155,11 @@ export default function FullArmoryExportPage() {
           {error && (
             <p className="rounded border border-[#E53935]/30 bg-[#E53935]/10 px-3 py-2 text-sm text-[#E53935]">
               {error}
+            </p>
+          )}
+          {success && (
+            <p className="rounded border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2 text-sm text-[#00C853]">
+              {success}
             </p>
           )}
         </div>

--- a/src/app/vault/[id]/builds/[buildId]/page.tsx
+++ b/src/app/vault/[id]/builds/[buildId]/page.tsx
@@ -867,6 +867,7 @@ export default function BuildConfiguratorPage() {
   const [allBuilds, setAllBuilds] = useState<Build[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   const [activatingBuild, setActivatingBuild] = useState(false);
 
@@ -904,14 +905,22 @@ export default function BuildConfiguratorPage() {
   async function handleRemoveSlot(slotType: string) {
     if (!build) return;
     try {
-      await fetch(`/api/builds/${buildId}/slots`, {
+      const res = await fetch(`/api/builds/${buildId}/slots`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ slotType, accessoryId: null }),
       });
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error ?? "Could not remove accessory from slot.");
+      }
+      setActionFeedback({ type: "success", text: "Accessory removed from slot." });
       fetchBuild();
-    } catch {
-      // silently fail
+    } catch (err) {
+      setActionFeedback({
+        type: "error",
+        text: err instanceof Error ? err.message : "Could not remove accessory from slot.",
+      });
     }
   }
 
@@ -919,14 +928,22 @@ export default function BuildConfiguratorPage() {
     if (!build || build.isActive) return;
     setActivatingBuild(true);
     try {
-      await fetch(`/api/builds/${buildId}`, {
+      const res = await fetch(`/api/builds/${buildId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ isActive: true }),
       });
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error ?? "Could not activate build.");
+      }
+      setActionFeedback({ type: "success", text: "Build set as active." });
       fetchBuild();
-    } catch {
-      // silently fail
+    } catch (err) {
+      setActionFeedback({
+        type: "error",
+        text: err instanceof Error ? err.message : "Could not activate build.",
+      });
     } finally {
       setActivatingBuild(false);
     }
@@ -1023,6 +1040,17 @@ export default function BuildConfiguratorPage() {
           )}
         </div>
       </div>
+      {actionFeedback && (
+        <div
+          className={`mx-4 mt-3 rounded-md border px-3 py-2 text-xs ${
+            actionFeedback.type === "success"
+              ? "border-[#00C853]/30 bg-[#00C853]/10 text-[#00C853]"
+              : "border-[#E53935]/30 bg-[#E53935]/10 text-[#E53935]"
+          }`}
+        >
+          {actionFeedback.text}
+        </div>
+      )}
 
       {/* Main split layout — vertical on mobile, side-by-side on md+ */}
       <div className="flex flex-col md:flex-row flex-1 overflow-hidden">

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -507,6 +507,7 @@ function AmmoSummaryWidget({ ammoStocks }: { ammoStocks: AmmoStockItem[] }) {
 // ── Main client component ─────────────────────────────────────
 export function DashboardClient({ data }: { data: DashboardData }) {
   const [liveData, setLiveData] = useState<DashboardData>(data);
+  const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
   const [order, setOrder] = useState<string[]>(() => {
     if (typeof window === "undefined") return DEFAULT_ORDER;
     try {
@@ -523,6 +524,8 @@ export function DashboardClient({ data }: { data: DashboardData }) {
   });
   const [editMode, setEditMode] = useState(false);
   const [mounted] = useState(() => typeof window !== "undefined");
+  const isFirstRun =
+    liveData.firearmCount === 0 && liveData.accessoryCount === 0 && liveData.totalAmmoRounds === 0;
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -542,6 +545,7 @@ export function DashboardClient({ data }: { data: DashboardData }) {
         recentFirearms: stats.recent?.firearms ?? [],
         ammoStocks: stats.ammo?.stocks ?? [],
       });
+      setLastUpdated(new Date());
     } catch {
       // Keep server-provided data when refresh fails.
     }
@@ -617,7 +621,10 @@ export function DashboardClient({ data }: { data: DashboardData }) {
   return (
     <div className="p-6">
       {/* Customize bar */}
-      <div className="flex items-center justify-end mb-6">
+      <div className="flex items-center justify-between mb-6">
+        <p className="text-xs text-vault-text-faint">
+          Last updated {lastUpdated.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}
+        </p>
         {editMode ? (
           <div className="flex items-center gap-3">
             <p className="text-xs text-vault-text-muted">Drag widgets to reorder</p>
@@ -639,6 +646,20 @@ export function DashboardClient({ data }: { data: DashboardData }) {
           </button>
         )}
       </div>
+
+      {isFirstRun && (
+        <section className="mb-6 rounded-lg border border-[#00C2FF]/25 bg-[#00C2FF]/5 p-4">
+          <h2 className="text-sm font-semibold text-vault-text mb-1">Welcome to BlackVault</h2>
+          <p className="text-xs text-vault-text-muted mb-3">
+            Start by adding a firearm, then attach accessories, upload receipts or tax stamps, and track ammo and range sessions.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/vault/new" className="text-xs px-3 py-1.5 rounded border border-[#00C2FF]/30 text-[#00C2FF] bg-[#00C2FF]/10 hover:bg-[#00C2FF]/20 transition-colors">Add Firearm</Link>
+            <Link href="/documents" className="text-xs px-3 py-1.5 rounded border border-vault-border text-vault-text-muted hover:text-vault-text hover:border-vault-text-muted/30 transition-colors">Upload Documents</Link>
+            <Link href="/range/log-session" className="text-xs px-3 py-1.5 rounded border border-vault-border text-vault-text-muted hover:text-vault-text hover:border-vault-text-muted/30 transition-colors">Log Range Session</Link>
+          </div>
+        </section>
+      )}
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={order} strategy={verticalListSortingStrategy}>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -25,7 +25,7 @@ import { useState, useEffect } from "react";
 const PRIMARY_NAV_ITEMS = [
   { label: "Command", href: "/", icon: Zap, description: "Overview & stats" },
   { label: "Vault", href: "/vault", icon: Shield, description: "Firearms inventory" },
-  { label: "Loadouts", href: "/builds", icon: Layers, description: "Build configurations" },
+  { label: "Builds", href: "/builds", icon: Layers, description: "Build configurations" },
   { label: "Accessories", href: "/accessories", icon: Crosshair, description: "Parts & attachments" },
   { label: "Ammo", href: "/ammo", icon: Target, description: "Ammunition storage" },
 ] as const;

--- a/src/components/shared/ItemDocumentPanel.tsx
+++ b/src/components/shared/ItemDocumentPanel.tsx
@@ -40,6 +40,7 @@ export function ItemDocumentPanel({ entityType, entityId, title = "Documents" }:
   const [loading, setLoading] = useState(true);
   const [showUploader, setShowUploader] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   useEffect(() => {
     const query = entityType === "firearm" ? `firearmId=${entityId}` : `accessoryId=${entityId}`;
@@ -60,12 +61,13 @@ export function ItemDocumentPanel({ entityType, entityId, title = "Documents" }:
       const res = await fetch(`/api/documents/${id}`, { method: "DELETE" });
       if (!res.ok) {
         const json = await res.json().catch(() => null);
-        alert(json?.error ?? "Failed to delete document");
+        setFeedback({ type: "error", text: json?.error ?? "Could not delete document." });
         return;
       }
       setDocuments((prev) => prev.filter((d) => d.id !== id));
+      setFeedback({ type: "success", text: "Document deleted." });
     } catch {
-      alert("Network error — could not delete document");
+      setFeedback({ type: "error", text: "Network error — could not delete document." });
     } finally {
       setDeletingId(null);
     }
@@ -109,6 +111,18 @@ export function ItemDocumentPanel({ entityType, entityId, title = "Documents" }:
         </div>
       )}
 
+      {feedback && (
+        <div
+          className={`mx-4 mt-4 rounded-md border px-3 py-2 text-xs ${
+            feedback.type === "success"
+              ? "border-[#00C853]/30 bg-[#00C853]/10 text-[#00C853]"
+              : "border-[#E53935]/30 bg-[#E53935]/10 text-[#E53935]"
+          }`}
+        >
+          {feedback.text}
+        </div>
+      )}
+
       {loading ? (
         <div className="py-8 flex justify-center">
           <div className="w-5 h-5 border-2 border-[#00C2FF]/30 border-t-[#00C2FF] rounded-full animate-spin" />
@@ -149,7 +163,14 @@ export function ItemDocumentPanel({ entityType, entityId, title = "Documents" }:
                     className="flex items-center gap-1 px-2 py-1 rounded border border-vault-border text-xs text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 transition-colors"
                   >
                     <ExternalLink className="w-3.5 h-3.5" />
-                    Open
+                    View
+                  </a>
+                  <a
+                    href={doc.fileUrl}
+                    download={doc.name}
+                    className="px-2 py-1 rounded border border-vault-border text-xs text-vault-text-muted hover:text-[#00C2FF] hover:border-[#00C2FF]/30 transition-colors"
+                  >
+                    Download
                   </a>
                   <button
                     onClick={() => handleDelete(doc.id)}


### PR DESCRIPTION
### Motivation

- New users lacked clear first steps on first launch, reducing trust and discoverability. 
- Several important actions could silently fail or only show `alert(...)`, which is poor UX for a self-hosted V1. 
- Exports and document workflows needed more predictable naming and clearer success/error feedback for backup/insurance use. 
- Terminology and small UI polish (e.g., Loadouts vs Builds) needed standardization for clarity.

### Description

- Added a compact first-run guidance panel to the Command Center and a `Last updated` timestamp so empty installs show clear CTAs (`Add Firearm`, `Upload Documents`, `Log Range Session`).
- Replaced alert-based document/delete feedback with inline success/error banners and added explicit `View` + `Download` actions in both the Document Library and entity document panel for reliable file access.
- Made the full-armory export filename deterministic (`blackvault-export-YYYY-MM-DD.{csv|pdf}`) and added UI success messaging after downloads while preserving server Content-Disposition when present.
- Removed silent failure behavior in the build configurator for slot removal and activation by checking response status, surfacing error messages, and showing inline action feedback.

Files primarily touched: `src/components/dashboard/DashboardClient.tsx`, `src/app/documents/page.tsx`, `src/components/shared/ItemDocumentPanel.tsx`, `src/app/exports/full-armory/page.tsx`, `src/app/api/exports/full-armory/route.ts`, `src/app/vault/[id]/builds/[buildId]/page.tsx`, `src/components/layout/Sidebar.tsx`, and `src/app/builds/page.tsx`.

### Testing

- Built the production app with `npm run build` and the build completed successfully. 
- Ran lint via `npm run lint` which surfaced pre-existing repo lint issues (failed; notable errors: `react-hooks/set-state-in-effect` in `src/app/ammo/page.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/ThemeProvider.tsx` and some unused-var warnings), these are existing issues outside the focused UI polish changes. 
- `npm run test` was not executed because no `test` script exists in `package.json` (verify test harness if desired).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a158fc348326bf5f3b9d1ea57417)