### PR TITLE
Stabilize V1 lint hooks and range UI consistency

### DIFF
--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -391,7 +391,8 @@ export default function AccessoryDetailPage() {
               </div>
             ) : (
               <>
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full min-w-[520px] text-sm">
                   <thead>
                     <tr className="border-b border-vault-border">
                       <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-vault-text-faint font-medium">
@@ -427,6 +428,7 @@ export default function AccessoryDetailPage() {
                     ))}
                   </tbody>
                 </table>
+                </div>
 
                 {accessory.roundCountLogs.length > 5 && (
                   <button

--- a/src/app/ammo/page.tsx
+++ b/src/app/ammo/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { VaultButton, VaultInput } from "@/components/shared/ui-primitives";
 import { formatCurrency, formatNumber } from "@/lib/utils";
 import {
   Target,
@@ -109,7 +110,7 @@ function AddRoundsModal({
             <label className="block text-[10px] uppercase tracking-widest text-vault-text-muted mb-1.5">
               Quantity to Add <span className="text-[#E53935]">*</span>
             </label>
-            <input
+            <VaultInput
               type="number"
               min={1}
               required
@@ -122,7 +123,7 @@ function AddRoundsModal({
           </div>
           <div>
             <label className="block text-[10px] uppercase tracking-widest text-vault-text-muted mb-1.5">Note</label>
-            <input
+            <VaultInput
               type="text"
               value={note}
               onChange={(e) => setNote(e.target.value)}
@@ -131,17 +132,17 @@ function AddRoundsModal({
             />
           </div>
           <div className="flex gap-2 justify-end pt-2">
-            <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md transition-colors">
+            <VaultButton type="button" onClick={onClose} variant="ghost">
               Cancel
-            </button>
-            <button
+            </VaultButton>
+            <VaultButton
               type="submit"
               disabled={submitting}
-              className="flex items-center gap-2 bg-[#00C853]/10 border border-[#00C853]/30 text-[#00C853] hover:bg-[#00C853]/20 disabled:opacity-50 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              variant="success"
             >
               {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
               Add
-            </button>
+            </VaultButton>
           </div>
         </form>
       </div>
@@ -200,7 +201,7 @@ function LogUseModal({
             <label className="block text-[10px] uppercase tracking-widest text-vault-text-muted mb-1.5">
               Rounds Used <span className="text-[#E53935]">*</span>
             </label>
-            <input
+            <VaultInput
               type="number"
               min={1}
               max={stock.quantity}
@@ -213,7 +214,7 @@ function LogUseModal({
           </div>
           <div>
             <label className="block text-[10px] uppercase tracking-widest text-vault-text-muted mb-1.5">Note</label>
-            <input
+            <VaultInput
               type="text"
               value={note}
               onChange={(e) => setNote(e.target.value)}
@@ -222,17 +223,17 @@ function LogUseModal({
             />
           </div>
           <div className="flex gap-2 justify-end pt-2">
-            <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md transition-colors">
+            <VaultButton type="button" onClick={onClose} variant="ghost">
               Cancel
-            </button>
-            <button
+            </VaultButton>
+            <VaultButton
               type="submit"
               disabled={submitting}
-              className="flex items-center gap-2 bg-[#F5A623]/10 border border-[#F5A623]/30 text-[#F5A623] hover:bg-[#F5A623]/20 disabled:opacity-50 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+              variant="warning"
             >
               {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <TrendingDown className="w-3 h-3" />}
               Log Use
-            </button>
+            </VaultButton>
           </div>
         </form>
       </div>
@@ -247,16 +248,25 @@ export default function AmmoPage() {
   const [addModal, setAddModal] = useState<AmmoStock | null>(null);
   const [logModal, setLogModal] = useState<AmmoStock | null>(null);
 
-  const fetchAmmo = useCallback(async () => {
-    const res = await fetch("/api/ammo");
-    const data = await res.json();
-    setGroups(data.grouped ?? []);
-    setLoading(false);
-  }, []);
-
   useEffect(() => {
-    fetchAmmo();
-  }, [fetchAmmo]);
+    let isMounted = true;
+
+    void fetch("/api/ammo")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!isMounted) return;
+        setGroups(data.grouped ?? []);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   function handleQtyUpdate(stockId: string, newQty: number) {
     setGroups((prev) =>

--- a/src/app/builds/page.tsx
+++ b/src/app/builds/page.tsx
@@ -139,7 +139,8 @@ export default async function BuildsPage() {
 
               {/* Builds table */}
               <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full min-w-[760px] text-sm">
                   <thead>
                     <tr className="border-b border-vault-border">
                       <th className="text-left px-4 py-3 text-[10px] uppercase tracking-widest text-vault-text-faint font-medium">
@@ -225,6 +226,7 @@ export default async function BuildsPage() {
                     })}
                   </tbody>
                 </table>
+                </div>
               </div>
             </section>
           );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -54,16 +54,13 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const [rangeOpen, setRangeOpen] = useState(pathname.startsWith("/range"));
+  const isRangeRoute = pathname.startsWith("/range");
+  const rangeSectionOpen = isRangeRoute || rangeOpen;
 
   useEffect(() => {
     onMobileClose?.();
   }, [pathname, onMobileClose]);
 
-  useEffect(() => {
-    if (pathname.startsWith("/range")) {
-      setRangeOpen(true);
-    }
-  }, [pathname]);
 
   const navContent = (
     <>
@@ -109,24 +106,24 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
             onClick={() => setRangeOpen((prev) => !prev)}
             className={cn(
               "w-full flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative",
-              pathname.startsWith("/range") ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border"
+              isRangeRoute ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border"
             )}
             title={collapsed ? "Range" : undefined}
           >
-            {pathname.startsWith("/range") && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
-            <Target className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", pathname.startsWith("/range") ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
+            {isRangeRoute && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
+            <Target className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", isRangeRoute ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
             {!collapsed && (
               <>
                 <span className="min-w-0 text-left">
                   <span className="block font-medium tracking-wide truncate">Range</span>
                   <span className="block text-[11px] text-vault-text-faint truncate">Sessions & drills</span>
                 </span>
-                <ChevronDown className={cn("w-4 h-4 ml-auto transition-transform", rangeOpen ? "rotate-180" : "rotate-0")} />
+                <ChevronDown className={cn("w-4 h-4 ml-auto transition-transform", rangeSectionOpen ? "rotate-180" : "rotate-0")} />
               </>
             )}
           </button>
 
-          {!collapsed && rangeOpen && (
+          {!collapsed && rangeSectionOpen && (
             <div className="mt-1 ml-4 border-l border-vault-border pl-2 space-y-0.5">
               {RANGE_CHILD_ITEMS.map((item) => {
                 const Icon = item.icon;

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -23,14 +23,15 @@ function applyTheme(t: Theme) {
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "dark";
+    const stored = localStorage.getItem("vault-theme") as Theme | null;
+    return stored === "light" ? "light" : "dark";
+  });
 
   useEffect(() => {
-    const stored = localStorage.getItem("vault-theme") as Theme | null;
-    const resolved: Theme = stored === "light" ? "light" : "dark";
-    setTheme(resolved);
-    applyTheme(resolved);
-  }, []);
+    applyTheme(theme);
+  }, [theme]);
 
   function toggleTheme() {
     setTheme((prev) => {

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -2,15 +2,13 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { VaultInput, VaultSelect, VaultTextArea, vaultCardClass, vaultLabelClass, VaultButton } from "@/components/shared/ui-primitives";
 import { formatNumber } from "@/lib/utils";
 import { Target, ChevronDown, Loader2, AlertCircle, CheckCircle2, Shield, Timer, BookPlus, Plus, Minus, Calculator } from "lucide-react";
 import Link from "next/link";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
-const INPUT_CLASS =
-  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
-const LABEL_CLASS = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
-const SECTION_CARD_CLASS = "bg-vault-surface border border-vault-border rounded-lg p-4 sm:p-5 space-y-4";
+const SECTION_CARD_CLASS = `${vaultCardClass} space-y-4`;
 
 interface Firearm {
   id: string;
@@ -816,46 +814,46 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <label className={LABEL_CLASS}>Session Date</label>
-                <input
+                <label className={vaultLabelClass}>Session Date</label>
+                <VaultInput
                   type="date"
                   value={sessionDate}
                   onChange={(e) => setSessionDate(e.target.value)}
-                  className={INPUT_CLASS}
+                  
                 />
               </div>
 
               <div>
-                <label className={LABEL_CLASS}>Location</label>
-                <input
+                <label className={vaultLabelClass}>Location</label>
+                <VaultInput
                   type="text"
                   value={sessionLocation}
                   onChange={(e) => setSessionLocation(e.target.value)}
                   placeholder="e.g. Oak Ridge Sportsmen Club"
-                  className={INPUT_CLASS}
+                  
                 />
               </div>
             </div>
 
             <div>
-              <label className={LABEL_CLASS}>Firearm</label>
+              <label className={vaultLabelClass}>Firearm</label>
               {loadingFirearms ? (
                 <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" /></div>
               ) : (
                 <div className="relative">
-                  <select
+                  <VaultSelect
                     value={selectedFirearm}
                     onChange={(e) => {
                       setSelectedFirearm(e.target.value);
                       setSelectedBuild("");
                     }}
-                    className={INPUT_CLASS}
+                    
                   >
                     <option value="">Auto-select first firearm</option>
                     {firearms.map((f) => (
                       <option key={f.id} value={f.id}>{f.name} ({f.caliber})</option>
                     ))}
-                  </select>
+                  </VaultSelect>
                   <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
                 </div>
               )}
@@ -863,19 +861,19 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
             {selectedFirearm && (
               <div>
-                <label className={LABEL_CLASS}>Build</label>
+                <label className={vaultLabelClass}>Build</label>
                 {loadingBuilds ? (
                   <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#00C2FF] animate-spin" /></div>
                 ) : builds.length === 0 ? (
                   <p className="text-sm text-vault-text-faint py-2">No builds for this firearm.</p>
                 ) : (
                   <div className="relative">
-                    <select value={selectedBuild} onChange={(e) => setSelectedBuild(e.target.value)} className={INPUT_CLASS}>
+                    <VaultSelect value={selectedBuild} onChange={(e) => setSelectedBuild(e.target.value)} >
                       <option value="">No build selected</option>
                       {builds.map((b) => (
                         <option key={b.id} value={b.id}>{b.name}{b.isActive ? " (Active)" : ""}</option>
                       ))}
-                    </select>
+                    </VaultSelect>
                     <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
                   </div>
                 )}
@@ -884,28 +882,28 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <label className={LABEL_CLASS}>Rounds Fired</label>
-                <input
+                <label className={vaultLabelClass}>Rounds Fired</label>
+                <VaultInput
                   type="number"
                   min={0}
                   value={roundsFired}
                   onChange={(e) => setRoundsFired(e.target.value)}
                   placeholder="Optional (auto-sums ammo rows)"
-                  className={INPUT_CLASS}
+                  
                 />
               </div>
             </div>
 
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <label className={LABEL_CLASS}>Ammo Used (multiple types supported)</label>
-                <button
+                <label className={vaultLabelClass}>Ammo Used (multiple types supported)</label>
+                <VaultButton
                   type="button"
                   onClick={addAmmoSelection}
-                  className="px-2.5 py-1.5 rounded-md text-xs border border-[#00C2FF]/30 text-[#00C2FF] bg-[#00C2FF]/10 hover:bg-[#00C2FF]/20"
+                  className="px-2.5 py-1.5 text-xs"
                 >
                   Add Ammo Type
-                </button>
+                </VaultButton>
               </div>
               {loadingAmmo ? (
                 <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#F5A623] animate-spin" /></div>
@@ -913,10 +911,10 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 ammoSelections.map((selection, index) => (
                   <div key={`ammo-selection-${index}`} className="grid sm:grid-cols-[1fr_160px_auto] gap-2">
                     <div className="relative">
-                      <select
+                      <VaultSelect
                         value={selection.ammoStockId}
                         onChange={(e) => updateAmmoSelection(index, { ammoStockId: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                       >
                         <option value="">No ammo selected</option>
                         {compatibleAmmo.map((a) => (
@@ -924,16 +922,16 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                             {a.caliber} · {a.brand}{a.grainWeight ? ` ${a.grainWeight}gr` : ""}{a.bulletType ? ` ${a.bulletType}` : ""} — {formatNumber(a.quantity)} rds
                           </option>
                         ))}
-                      </select>
+                      </VaultSelect>
                       <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
                     </div>
-                    <input
+                    <VaultInput
                       type="number"
                       min={0}
                       value={selection.roundsUsed}
                       onChange={(e) => updateAmmoSelection(index, { roundsUsed: e.target.value })}
                       placeholder="Rounds"
-                      className={INPUT_CLASS}
+                      
                     />
                     <button
                       type="button"
@@ -951,14 +949,14 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <label className={LABEL_CLASS}>Drills Completed During This Session</label>
-                <button
+                <label className={vaultLabelClass}>Drills Completed During This Session</label>
+                <VaultButton
                   type="button"
                   onClick={addSessionDrillEntry}
-                  className="px-2.5 py-1.5 rounded-md text-xs border border-[#00C2FF]/30 text-[#00C2FF] bg-[#00C2FF]/10 hover:bg-[#00C2FF]/20"
+                  className="px-2.5 py-1.5 text-xs"
                 >
                   Add Drill Set
-                </button>
+                </VaultButton>
               </div>
               <p className="text-xs text-vault-text-faint">Add zero, one, or many drill sets. Repeat the same drill name for multiple attempts (Set 1, Set 2, Set 3...).</p>
               {sessionDrillEntries.map((entry, index) => (
@@ -975,60 +973,60 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                   </div>
                   <div className="grid md:grid-cols-2 gap-3">
                     <div>
-                      <label className={LABEL_CLASS}>Drill Name</label>
-                      <input
+                      <label className={vaultLabelClass}>Drill Name</label>
+                      <VaultInput
                         value={entry.name}
                         onChange={(e) => updateSessionDrillEntry(entry.id, { name: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                         placeholder="e.g. Bill Drill"
                       />
                     </div>
                     <div>
-                      <label className={LABEL_CLASS}>Time (seconds)</label>
-                      <input
+                      <label className={vaultLabelClass}>Time (seconds)</label>
+                      <VaultInput
                         type="number"
                         step="0.01"
                         min="0.01"
                         value={entry.timeSeconds}
                         onChange={(e) => updateSessionDrillEntry(entry.id, { timeSeconds: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                         placeholder="2.45"
                       />
                     </div>
                   </div>
                   <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-3">
                     <div>
-                      <label className={LABEL_CLASS}>Points</label>
-                      <input
+                      <label className={vaultLabelClass}>Points</label>
+                      <VaultInput
                         type="number"
                         step="0.01"
                         min="0"
                         value={entry.points}
                         onChange={(e) => updateSessionDrillEntry(entry.id, { points: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                         placeholder="90"
                       />
                     </div>
                     <div>
-                      <label className={LABEL_CLASS}>Penalties</label>
-                      <input
+                      <label className={vaultLabelClass}>Penalties</label>
+                      <VaultInput
                         type="number"
                         step="0.01"
                         min="0"
                         value={entry.penalties}
                         onChange={(e) => updateSessionDrillEntry(entry.id, { penalties: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                         placeholder="0"
                       />
                     </div>
                     <div>
-                      <label className={LABEL_CLASS}>Hits</label>
-                      <input
+                      <label className={vaultLabelClass}>Hits</label>
+                      <VaultInput
                         type="number"
                         min="0"
                         value={entry.hits}
                         onChange={(e) => updateSessionDrillEntry(entry.id, { hits: e.target.value })}
-                        className={INPUT_CLASS}
+                        
                         placeholder="6"
                       />
                     </div>
@@ -1043,12 +1041,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                     </div>
                   </div>
                   <div>
-                    <label className={LABEL_CLASS}>Set Notes</label>
-                    <textarea
+                    <label className={vaultLabelClass}>Set Notes</label>
+                    <VaultTextArea
                       rows={2}
                       value={entry.notes}
                       onChange={(e) => updateSessionDrillEntry(entry.id, { notes: e.target.value })}
-                      className={`${INPUT_CLASS} resize-none`}
+                      className={`resize-none`}
                     />
                   </div>
                 </div>
@@ -1056,13 +1054,13 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
             </div>
 
             <div>
-              <label className={LABEL_CLASS}>Notes</label>
-              <textarea
+              <label className={vaultLabelClass}>Notes</label>
+              <VaultTextArea
                 rows={3}
                 value={sessionNote}
                 onChange={(e) => setSessionNote(e.target.value)}
                 placeholder="e.g. Match prep and transition work"
-                className={`${INPUT_CLASS} resize-none`}
+                className={`resize-none`}
               />
             </div>
           </fieldset>
@@ -1121,12 +1119,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         <fieldset className={SECTION_CARD_CLASS}>
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session Selector</legend>
           <div>
-            <label className={LABEL_CLASS}>Session</label>
+            <label className={vaultLabelClass}>Session</label>
             <div className="relative">
-              <select
+              <VaultSelect
                 value={selectedSessionId}
                 onChange={(e) => setSelectedSessionId(e.target.value)}
-                className={INPUT_CLASS}
+                
                 disabled={loadingSessions || sessions.length === 0}
               >
                 <option value="">Select session...</option>
@@ -1135,7 +1133,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                     {new Date(session.sessionDate).toLocaleDateString()} · {session.location} · {session.firearm.name}
                   </option>
                 ))}
-              </select>
+              </VaultSelect>
               <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
             </div>
           </div>
@@ -1149,13 +1147,13 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           <form onSubmit={handleAddDrill} className="space-y-4">
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <label className={LABEL_CLASS}>Drill Template <span className="text-[#E53935]">*</span></label>
+                <label className={vaultLabelClass}>Drill Template <span className="text-[#E53935]">*</span></label>
                 <div className="relative">
-                  <select
+                  <VaultSelect
                     required
                     value={drillName}
                     onChange={(e) => setDrillName(e.target.value)}
-                    className={INPUT_CLASS}
+                    
                     disabled={drillLibrary.length === 0}
                   >
                     <option value="">Select drill template...</option>
@@ -1164,7 +1162,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                         {template.name} ({template.mode})
                       </option>
                     ))}
-                  </select>
+                  </VaultSelect>
                   <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
                 </div>
                 {selectedSessionId && drillName.trim() && (
@@ -1176,8 +1174,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               </div>
               {selectedDrillTemplate?.mode !== "accuracy" && (
               <div>
-                <label className={LABEL_CLASS}>Time (seconds) <span className="text-[#E53935]">*</span></label>
-                <input type="number" step="0.01" min="0.01" required value={drillTime} onChange={(e) => setDrillTime(e.target.value)} className={INPUT_CLASS} placeholder="2.45" />
+                <label className={vaultLabelClass}>Time (seconds) <span className="text-[#E53935]">*</span></label>
+                <VaultInput type="number" step="0.01" min="0.01" required value={drillTime} onChange={(e) => setDrillTime(e.target.value)}  placeholder="2.45" />
               </div>
               )}
             </div>
@@ -1185,20 +1183,20 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
             <div id="hit-factor-calculator" className="grid sm:grid-cols-2 md:grid-cols-4 gap-4 scroll-mt-20">
               {selectedDrillTemplate?.mode !== "time" && (
               <div>
-                <label className={LABEL_CLASS}>Points <span className="text-[#E53935]">*</span></label>
-                <input type="number" step="0.01" min="0" required value={drillPoints} onChange={(e) => setDrillPoints(e.target.value)} className={INPUT_CLASS} placeholder="90" />
+                <label className={vaultLabelClass}>Points <span className="text-[#E53935]">*</span></label>
+                <VaultInput type="number" step="0.01" min="0" required value={drillPoints} onChange={(e) => setDrillPoints(e.target.value)}  placeholder="90" />
               </div>
               )}
               {selectedDrillTemplate?.mode !== "time" && (
               <div>
-                <label className={LABEL_CLASS}>Penalties</label>
-                <input type="number" step="0.01" min="0" value={drillPenalties} onChange={(e) => setDrillPenalties(e.target.value)} className={INPUT_CLASS} placeholder="10" />
+                <label className={vaultLabelClass}>Penalties</label>
+                <VaultInput type="number" step="0.01" min="0" value={drillPenalties} onChange={(e) => setDrillPenalties(e.target.value)}  placeholder="10" />
               </div>
               )}
               {selectedDrillTemplate?.mode !== "time" && (
               <div>
-                <label className={LABEL_CLASS}>Hits</label>
-                <input type="number" min="0" value={drillHits} onChange={(e) => setDrillHits(e.target.value)} className={INPUT_CLASS} placeholder="6" />
+                <label className={vaultLabelClass}>Hits</label>
+                <VaultInput type="number" min="0" value={drillHits} onChange={(e) => setDrillHits(e.target.value)}  placeholder="6" />
               </div>
               )}
               <div className="bg-vault-bg border border-vault-border rounded-md px-3 py-2">
@@ -1208,8 +1206,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
             </div>
 
             <div>
-              <label className={LABEL_CLASS}>Drill Notes</label>
-              <textarea rows={2} value={drillNotes} onChange={(e) => setDrillNotes(e.target.value)} className={`${INPUT_CLASS} resize-none`} />
+              <label className={vaultLabelClass}>Drill Notes</label>
+              <VaultTextArea rows={2} value={drillNotes} onChange={(e) => setDrillNotes(e.target.value)} className={`resize-none`} />
             </div>
 
             <div className="flex justify-end">
@@ -1231,12 +1229,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drill Performance Graph</legend>
           <div className="grid sm:grid-cols-2 gap-4">
             <div>
-              <label className={LABEL_CLASS}>Drill</label>
+              <label className={vaultLabelClass}>Drill</label>
               <div className="relative">
-                <select
+                <VaultSelect
                   value={performanceDrillName}
                   onChange={(e) => setPerformanceDrillName(e.target.value)}
-                  className={INPUT_CLASS}
+                  
                   disabled={drillNameLibrary.length === 0}
                 >
                   {drillNameLibrary.length === 0 ? (
@@ -1246,22 +1244,22 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                       <option key={name} value={name}>{name}</option>
                     ))
                   )}
-                </select>
+                </VaultSelect>
                 <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
               </div>
             </div>
             <div>
-              <label className={LABEL_CLASS}>History Metric</label>
+              <label className={vaultLabelClass}>History Metric</label>
               <div className="relative">
-                <select
+                <VaultSelect
                   value={performanceMetric}
                   onChange={(e) => setPerformanceMetric(e.target.value as "time" | "score" | "hitFactor")}
-                  className={INPUT_CLASS}
+                  
                 >
                   <option value="time">Time (sec)</option>
                   <option value="score">Score (points - penalties)</option>
                   <option value="hitFactor">Hit Factor</option>
-                </select>
+                </VaultSelect>
                 <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-vault-text-faint pointer-events-none" />
               </div>
             </div>
@@ -1343,30 +1341,30 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drill Library</legend>
           <form onSubmit={addCustomDrill} className="grid gap-3 md:grid-cols-[1fr_1fr_160px_auto] items-end">
             <div>
-              <label className={LABEL_CLASS}>Custom Drill Name</label>
-              <input
+              <label className={vaultLabelClass}>Custom Drill Name</label>
+              <VaultInput
                 value={customDrillName}
                 onChange={(e) => setCustomDrillName(e.target.value)}
                 placeholder="e.g. El Prez"
-                className={INPUT_CLASS}
+                
               />
             </div>
             <div>
-              <label className={LABEL_CLASS}>Notes</label>
-              <input
+              <label className={vaultLabelClass}>Notes</label>
+              <VaultInput
                 value={customDrillNotes}
                 onChange={(e) => setCustomDrillNotes(e.target.value)}
                 placeholder="Optional setup notes"
-                className={INPUT_CLASS}
+                
               />
             </div>
             <div>
-              <label className={LABEL_CLASS}>Mode</label>
-              <select value={customDrillMode} onChange={(e) => setCustomDrillMode(e.target.value as DrillPerformanceMode)} className={INPUT_CLASS}>
+              <label className={vaultLabelClass}>Mode</label>
+              <VaultSelect value={customDrillMode} onChange={(e) => setCustomDrillMode(e.target.value as DrillPerformanceMode)} >
                 <option value="both">Time + Accuracy</option>
                 <option value="time">Time only</option>
                 <option value="accuracy">Accuracy only</option>
-              </select>
+              </VaultSelect>
             </div>
             <button
               type="submit"
@@ -1447,23 +1445,23 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               </div>
 
               <div className="grid grid-cols-[1fr_1fr_auto] gap-2 w-full sm:w-auto sm:min-w-[320px]">
-                <input
+                <VaultInput
                   type="number"
                   min="0"
                   step="0.1"
                   value={bulletWeight}
                   onChange={(e) => setBulletWeight(e.target.value)}
                   placeholder="gr"
-                  className={INPUT_CLASS}
+                  
                 />
-                <input
+                <VaultInput
                   type="number"
                   min="0"
                   step="1"
                   value={muzzleVelocity}
                   onChange={(e) => setMuzzleVelocity(e.target.value)}
                   placeholder="fps"
-                  className={INPUT_CLASS}
+                  
                 />
                 <button
                   type="button"
@@ -1579,16 +1577,16 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
             <div className="grid sm:grid-cols-3 gap-3">
               <div>
-                <label className={LABEL_CLASS}>Extra Points</label>
-                <input type="number" step="0.01" min="0" value={calculatorPoints} onChange={(e) => setCalculatorPoints(e.target.value)} className={INPUT_CLASS} placeholder="0" />
+                <label className={vaultLabelClass}>Extra Points</label>
+                <VaultInput type="number" step="0.01" min="0" value={calculatorPoints} onChange={(e) => setCalculatorPoints(e.target.value)}  placeholder="0" />
               </div>
               <div>
-                <label className={LABEL_CLASS}>Other Penalties</label>
-                <input type="number" step="0.01" min="0" value={calculatorPenalties} onChange={(e) => setCalculatorPenalties(e.target.value)} className={INPUT_CLASS} placeholder="0" />
+                <label className={vaultLabelClass}>Other Penalties</label>
+                <VaultInput type="number" step="0.01" min="0" value={calculatorPenalties} onChange={(e) => setCalculatorPenalties(e.target.value)}  placeholder="0" />
               </div>
               <div>
-                <label className={LABEL_CLASS}>Time (sec)</label>
-                <input type="number" step="0.01" min="0.01" value={calculatorTime} onChange={(e) => setCalculatorTime(e.target.value)} className={INPUT_CLASS} placeholder="2.45" />
+                <label className={vaultLabelClass}>Time (sec)</label>
+                <VaultInput type="number" step="0.01" min="0.01" value={calculatorTime} onChange={(e) => setCalculatorTime(e.target.value)}  placeholder="2.45" />
               </div>
             </div>
           </div>

--- a/src/components/shared/ui-primitives.tsx
+++ b/src/components/shared/ui-primitives.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+import type { ComponentPropsWithoutRef } from "react";
+
+export const vaultInputClass =
+  "w-full bg-vault-surface border border-vault-border text-vault-text rounded-md px-3 py-2 text-sm focus:outline-none focus:border-[#00C2FF] placeholder-vault-text-faint transition-colors";
+
+export const vaultLabelClass = "block text-xs font-medium uppercase tracking-widest text-vault-text-muted mb-1.5";
+
+export const vaultCardClass = "bg-vault-surface border border-vault-border rounded-lg p-4 sm:p-5";
+
+export function VaultInput({ className, ...props }: ComponentPropsWithoutRef<"input">) {
+  return <input className={cn(vaultInputClass, className)} {...props} />;
+}
+
+export function VaultSelect({ className, ...props }: ComponentPropsWithoutRef<"select">) {
+  return <select className={cn(vaultInputClass, className)} {...props} />;
+}
+
+export function VaultTextArea({ className, ...props }: ComponentPropsWithoutRef<"textarea">) {
+  return <textarea className={cn(vaultInputClass, className)} {...props} />;
+}
+
+const BUTTON_VARIANTS = {
+  primary: "bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20",
+  success: "bg-[#00C853]/10 border border-[#00C853]/30 text-[#00C853] hover:bg-[#00C853]/20",
+  warning: "bg-[#F5A623]/10 border border-[#F5A623]/30 text-[#F5A623] hover:bg-[#F5A623]/20",
+  ghost: "border border-vault-border text-vault-text-faint hover:text-vault-text",
+} as const;
+
+export function VaultButton({
+  className,
+  variant = "primary",
+  ...props
+}: ComponentPropsWithoutRef<"button"> & { variant?: keyof typeof BUTTON_VARIANTS }) {
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+        BUTTON_VARIANTS[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation

- Clean up remaining React Hook lint violations to ensure a reliable V1 release without changing app logic. 
- Bring Range / Hit Factor views onto the shared UI system for consistent controls and spacing (presentation only). 
- Remove a handful of legacy inline button/input patterns on high-visibility pages to standardize visuals. 
- Improve table usability on small screens in a low-risk way (horizontal scroll wrappers/min-widths) without reworking data models.

### Description

- Fixed React hook rule violations in the known problem files by making minimal, safe changes: `ThemeProvider` now uses a lazy `useState` initializer and a single `useEffect` to apply theme; `Sidebar` derives an in-render `isRangeRoute` flag and avoids calling `setRangeOpen` in an effect; `ammo/page.tsx` replaced the callback-driven effect with an in-effect async fetch guarded by an `isMounted` flag to avoid synchronous setState-in-effect. (Files: `src/components/layout/ThemeProvider.tsx`, `src/components/layout/Sidebar.tsx`, `src/app/ammo/page.tsx`.)
- Added a small shared UI primitives module for consistent presentation: `src/components/shared/ui-primitives.tsx` exposing `VaultButton`, `VaultInput`, `VaultSelect`, `VaultTextArea`, and shared class tokens (`vaultCardClass`, `vaultLabelClass`, etc.).
- Migrated Range / Hit Factor surfaces in `RangeWorkspace` to the shared primitives and card/label tokens to align spacing and control variants (inputs/selects/textareas/buttons switched to the Vault primitives and section cards use shared token). (File: `src/components/range/RangeWorkspace.tsx`.)
- Replaced legacy inline button/input styles in high-visibility Ammo modals with the shared primitives (Add Rounds / Log Use) for consistent button variants and input styling. (File: `src/app/ammo/page.tsx`.)
- Applied safe mobile table improvements by wrapping large tables with `overflow-x-auto` and adding reasonable `min-width` values to avoid layout breakage on small screens for high-visibility pages: `builds/page.tsx` and accessory round-history table (`src/app/builds/page.tsx`, `src/app/accessories/[id]/page.tsx`).
- Kept all changes focused on presentation and hook safety; no business logic, data model, or Prisma schema refactors were introduced.

### Testing

- Ran `npm run lint` (ESLint) after changes; result: no ESLint errors and only existing, understood warnings remain (warnings: `@next/next/no-img-element` in `ImagePicker`, unused placeholder params in `entity-write-access`, anonymous default export style in `vitest.config.ts`).
- Ran `npm run build` (Next build); result: successful production build and static page generation completed.
- Notes: automated lint/builds succeeded and are the primary verification steps for this stabilization pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ac0f445483269442cc7332711e4f)