### PR TITLE
Fix Next.js build type error in getLocalIp network interface handling

### DIFF
--- a/src/lib/network/get-local-ip.ts
+++ b/src/lib/network/get-local-ip.ts
@@ -1,21 +1,20 @@
-import os from "node:os";
+import os, { NetworkInterfaceInfo } from "os";
 
 export function getLocalIp(): string | null {
-  const networkInterfaces = os.networkInterfaces();
+  const interfaces = os.networkInterfaces();
 
-  for (const interfaceAddresses of Object.values(networkInterfaces)) {
-    if (!interfaceAddresses) {
-      continue;
-    }
+  for (const name of Object.keys(interfaces)) {
+    const netInterface = interfaces[name];
 
-    for (const address of interfaceAddresses) {
-      const isIpv4 =
-        address.family === "IPv4" ||
-        (typeof address.family === "number" && address.family === 4);
+    if (!netInterface) continue;
 
-      if (!isIpv4 || address.internal || address.address === "127.0.0.1") {
-        continue;
-      }
+    for (const address of netInterface as NetworkInterfaceInfo[]) {
+      const family = address.family as string | number;
+      const isIpv4 = family === "IPv4" || family === 4;
+
+      if (!isIpv4) continue;
+      if (address.internal) continue;
+      if (address.address === "127.0.0.1") continue;
 
       return address.address;
     }


### PR DESCRIPTION
### Motivation
- The production Next.js build failed with a TypeScript error (`Property 'family' does not exist on type 'never'`) when compiling `os.networkInterfaces()` handling in `get-local-ip.ts`. 
- The goal is a minimal, V1-safe change that avoids refactoring or new dependencies while preserving existing behavior. 
- The fix should explicitly type network interface entries and accept both `"IPv4"` and numeric `4` family representations.

### Description
- Replaced `src/lib/network/get-local-ip.ts` with an explicitly typed implementation that imports `NetworkInterfaceInfo` from `os` and treats each entry as `NetworkInterfaceInfo[]`.
- Iterates interface names via `Object.keys(interfaces)` and defensively skips missing entries before casting and inspecting addresses.
- Normalizes `address.family` to a `string | number` check supporting `"IPv4"` and `4`, and returns the first non-internal IPv4 LAN address while ignoring `127.0.0.1`.
- Made the change small and isolated to a single file with no dependency or architecture changes.

### Testing
- Ran `npm run build`, which completed successfully and included a successful TypeScript compilation and Next.js production build. 
- The change was verified to be limited to `src/lib/network/get-local-ip.ts` and introduced no new dependencies or runtime behavior changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c293f03d1083269433edf9ecc4eeee)