### PR TITLE
V1 cleanup: drill delete/edit UX, session edit API, backup path, and mobile/LAN fixes

### DIFF
--- a/prisma/migrations/20260324103000_add_backup_destination_path/migration.sql
+++ b/prisma/migrations/20260324103000_add_backup_destination_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AppSettings" ADD COLUMN "backupDestinationPath" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -286,6 +286,7 @@ model AppSettings {
   includeUploadsInBackup  Boolean  @default(true)
   autoBackupEnabled       Boolean  @default(false)
   autoBackupCadence       String   @default("weekly")
+  backupDestinationPath   String?
   defaultCurrency         String   @default("USD")
   appPassword             String?
   createdAt               DateTime @default(now())

--- a/src/app/api/range/sessions/[id]/route.ts
+++ b/src/app/api/range/sessions/[id]/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/server/auth";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth();
+  if (auth) return auth;
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const updateData: {
+      sessionDate?: Date;
+      location?: string;
+      firearmId?: string;
+      buildId?: string | null;
+      roundsFired?: number;
+      notes?: string | null;
+    } = {};
+
+    if (body.sessionDate !== undefined) {
+      if (typeof body.sessionDate !== "string" || body.sessionDate.trim().length === 0) {
+        return NextResponse.json({ error: "sessionDate must be a valid date string" }, { status: 400 });
+      }
+      const parsed = new Date(body.sessionDate);
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json({ error: "sessionDate must be a valid date string" }, { status: 400 });
+      }
+      updateData.sessionDate = parsed;
+    }
+
+    if (body.location !== undefined) {
+      if (typeof body.location !== "string") {
+        return NextResponse.json({ error: "location must be a string" }, { status: 400 });
+      }
+      updateData.location = body.location.trim() || "Unspecified location";
+    }
+
+    if (body.firearmId !== undefined) {
+      if (typeof body.firearmId !== "string" || body.firearmId.trim().length === 0) {
+        return NextResponse.json({ error: "firearmId must be a non-empty string" }, { status: 400 });
+      }
+      updateData.firearmId = body.firearmId;
+    }
+
+    if (body.buildId !== undefined) {
+      if (body.buildId !== null && typeof body.buildId !== "string") {
+        return NextResponse.json({ error: "buildId must be a string or null" }, { status: 400 });
+      }
+      updateData.buildId = body.buildId && body.buildId.trim().length > 0 ? body.buildId : null;
+    }
+
+    if (body.roundsFired !== undefined) {
+      if (typeof body.roundsFired !== "number" || !Number.isInteger(body.roundsFired) || body.roundsFired < 0) {
+        return NextResponse.json({ error: "roundsFired must be a non-negative integer" }, { status: 400 });
+      }
+      updateData.roundsFired = body.roundsFired;
+    }
+
+    if (body.notes !== undefined) {
+      if (body.notes !== null && typeof body.notes !== "string") {
+        return NextResponse.json({ error: "notes must be a string or null" }, { status: 400 });
+      }
+      updateData.notes = typeof body.notes === "string" ? body.notes.trim() || null : null;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: "No valid fields provided for update" }, { status: 400 });
+    }
+
+    const existing = await prisma.rangeSession.findUnique({
+      where: { id },
+      select: { id: true, firearmId: true, buildId: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: "Range session not found" }, { status: 404 });
+    }
+
+    const resolvedFirearmId = updateData.firearmId ?? existing.firearmId;
+    const resolvedBuildId = updateData.buildId !== undefined ? updateData.buildId : existing.buildId;
+
+    const firearm = await prisma.firearm.findUnique({ where: { id: resolvedFirearmId }, select: { id: true } });
+    if (!firearm) {
+      return NextResponse.json({ error: "Firearm not found" }, { status: 404 });
+    }
+
+    if (resolvedBuildId) {
+      const build = await prisma.build.findUnique({ where: { id: resolvedBuildId }, select: { firearmId: true } });
+      if (!build) {
+        return NextResponse.json({ error: "Build not found" }, { status: 404 });
+      }
+      if (build.firearmId !== resolvedFirearmId) {
+        return NextResponse.json(
+          { error: "Selected build does not belong to the selected firearm" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const updated = await prisma.rangeSession.update({
+      where: { id },
+      data: updateData,
+      include: {
+        firearm: { select: { id: true, name: true, caliber: true } },
+        build: { select: { id: true, name: true } },
+        ammoLinks: {
+          include: {
+            ammoStock: {
+              select: {
+                id: true,
+                caliber: true,
+                brand: true,
+                grainWeight: true,
+                bulletType: true,
+              },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+        sessionDrills: {
+          orderBy: [{ sortOrder: "asc" }, { name: "asc" }, { setNumber: "asc" }, { createdAt: "asc" }],
+        },
+      },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("PUT /api/range/sessions/[id] error:", error);
+    return NextResponse.json({ error: "Failed to update range session" }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -32,6 +32,7 @@ describe("/api/settings backup fields", () => {
       includeUploadsInBackup: false,
       autoBackupEnabled: true,
       autoBackupCadence: "monthly",
+      backupDestinationPath: "/srv/blackvault/backups",
       defaultCurrency: "USD",
       appPassword: null,
       createdAt: new Date("2026-03-01T00:00:00.000Z"),
@@ -45,6 +46,7 @@ describe("/api/settings backup fields", () => {
     expect(json.includeUploadsInBackup).toBe(false);
     expect(json.autoBackupEnabled).toBe(true);
     expect(json.autoBackupCadence).toBe("monthly");
+    expect(json.backupDestinationPath).toBe("/srv/blackvault/backups");
   });
 
   it("persists backup settings via PUT", async () => {
@@ -55,6 +57,7 @@ describe("/api/settings backup fields", () => {
       includeUploadsInBackup: true,
       autoBackupEnabled: true,
       autoBackupCadence: "weekly",
+      backupDestinationPath: "/mnt/blackvault/backups",
       defaultCurrency: "USD",
       appPassword: null,
       createdAt: new Date("2026-03-01T00:00:00.000Z"),
@@ -67,6 +70,7 @@ describe("/api/settings backup fields", () => {
         includeUploadsInBackup: true,
         autoBackupEnabled: true,
         autoBackupCadence: "weekly",
+        backupDestinationPath: "/mnt/blackvault/backups",
       }),
       headers: {
         "Content-Type": "application/json",
@@ -82,6 +86,7 @@ describe("/api/settings backup fields", () => {
     expect(upsertArgs.update.includeUploadsInBackup).toBe(true);
     expect(upsertArgs.update.autoBackupEnabled).toBe(true);
     expect(upsertArgs.update.autoBackupCadence).toBe("weekly");
+    expect(upsertArgs.update.backupDestinationPath).toBe("/mnt/blackvault/backups");
     expect(json.autoBackupCadence).toBe("weekly");
   });
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -24,6 +24,13 @@ function normalizeCurrency(value: unknown): string | null {
   return normalized;
 }
 
+function normalizeBackupDestinationPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (normalized.length > 512) return null;
+  return normalized.length > 0 ? normalized : "";
+}
+
 // GET /api/settings - Get the singleton AppSettings
 export async function GET() {
   try {
@@ -44,6 +51,7 @@ export async function GET() {
       includeUploadsInBackup: settings.includeUploadsInBackup,
       autoBackupEnabled: settings.autoBackupEnabled,
       autoBackupCadence: settings.autoBackupCadence,
+      backupDestinationPath: settings.backupDestinationPath,
       defaultCurrency: settings.defaultCurrency,
       createdAt: settings.createdAt,
       updatedAt: settings.updatedAt,
@@ -77,6 +85,7 @@ export async function PUT(request: NextRequest) {
       includeUploadsInBackup,
       autoBackupEnabled,
       autoBackupCadence,
+      backupDestinationPath,
       defaultCurrency,
     } = body;
 
@@ -132,6 +141,17 @@ export async function PUT(request: NextRequest) {
       updateData.defaultCurrency = normalized;
     }
 
+    if (backupDestinationPath !== undefined) {
+      const normalized = normalizeBackupDestinationPath(backupDestinationPath);
+      if (normalized == null) {
+        return NextResponse.json(
+          { error: "backupDestinationPath must be a string up to 512 characters." },
+          { status: 400 }
+        );
+      }
+      updateData.backupDestinationPath = normalized || null;
+    }
+
     if (Object.keys(updateData).length === 0) {
       return NextResponse.json(
         { error: "No valid settings fields provided." },
@@ -153,6 +173,7 @@ export async function PUT(request: NextRequest) {
       includeUploadsInBackup: settings.includeUploadsInBackup,
       autoBackupEnabled: settings.autoBackupEnabled,
       autoBackupCadence: settings.autoBackupCadence,
+      backupDestinationPath: settings.backupDestinationPath,
       defaultCurrency: settings.defaultCurrency,
       createdAt: settings.createdAt,
       updatedAt: settings.updatedAt,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -18,6 +18,7 @@ export default function SettingsPage() {
   const [includeUploadsInBackup, setIncludeUploadsInBackup] = useState(true);
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
   const [autoBackupCadence, setAutoBackupCadence] = useState<"daily" | "weekly" | "monthly">("weekly");
+  const [backupDestinationPath, setBackupDestinationPath] = useState("");
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -39,6 +40,7 @@ export default function SettingsPage() {
           setIncludeUploadsInBackup(data.includeUploadsInBackup ?? true);
           setAutoBackupEnabled(data.autoBackupEnabled ?? false);
           setAutoBackupCadence(data.autoBackupCadence ?? "weekly");
+          setBackupDestinationPath(data.backupDestinationPath ?? "");
         }
         setDataLoading(false);
       })
@@ -79,6 +81,7 @@ export default function SettingsPage() {
           includeUploadsInBackup,
           autoBackupEnabled,
           autoBackupCadence,
+          backupDestinationPath,
         }),
       });
 
@@ -188,6 +191,20 @@ export default function SettingsPage() {
                 <option value="monthly">Monthly</option>
               </select>
             </FormField>
+
+            <FormField
+              label="Preferred Backup Destination Path"
+              hint="Saved as a reference path for your backup process. Exports are still downloaded through your browser in V1."
+            >
+              <input
+                id="backupDestinationPath"
+                type="text"
+                value={backupDestinationPath}
+                onChange={(e) => setBackupDestinationPath(e.target.value)}
+                className={INPUT_CLASS}
+                placeholder="/srv/blackvault/backups or D:\\Backups\\BlackVault"
+              />
+            </FormField>
           </div>
         </SectionCard>
 
@@ -271,6 +288,11 @@ export default function SettingsPage() {
               label="Auto Backup"
               value={autoBackupEnabled ? `Enabled (${autoBackupCadence})` : "Disabled"}
               ok={autoBackupEnabled}
+            />
+            <StatusRow
+              label="Backup Destination Preference"
+              value={backupDestinationPath ? "Saved" : "Not set"}
+              ok={Boolean(backupDestinationPath)}
             />
             <StatusRow
               label="LAN URL Available"

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -9,11 +9,13 @@ export function MobileHeader() {
 
   return (
     <>
-      <header className="md:hidden sticky top-0 z-30 flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
+      <header className="md:hidden sticky top-0 z-40 flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
         <button
-          onClick={() => setOpen(true)}
+          onClick={() => setOpen((prev) => !prev)}
           className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"
           aria-label="Open navigation"
+          aria-expanded={open}
+          aria-controls="mobile-navigation"
         >
           <Menu className="w-5 h-5" />
           <span className="text-[11px] font-medium tracking-wider uppercase">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -174,14 +174,18 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
         </aside>
       )}
 
-      {mobileOpen && (
-        <>
-          <div className="fixed inset-0 z-[90] bg-black/60 md:hidden" onClick={onMobileClose} />
-          <aside className="fixed inset-y-0 left-0 z-[100] flex h-dvh max-h-dvh flex-col w-72 max-w-[88vw] bg-vault-surface border-r border-vault-border md:hidden">
-            {navContent}
-          </aside>
-        </>
-      )}
+      <div className={cn("fixed inset-0 z-[130] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")}>
+        <div className="absolute inset-0 bg-black/60" onClick={onMobileClose} />
+        <aside
+          id="mobile-navigation"
+          className={cn(
+            "absolute inset-y-0 left-0 flex h-screen max-h-screen w-72 max-w-[88vw] flex-col border-r border-vault-border bg-vault-surface shadow-2xl transition-transform duration-200",
+            mobileOpen ? "translate-x-0" : "-translate-x-full"
+          )}
+        >
+          {navContent}
+        </aside>
+      </div>
     </>
   );
 }

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { VaultInput, VaultSelect, VaultTextArea, vaultCardClass, vaultLabelClass, VaultButton } from "@/components/shared/ui-primitives";
 import { formatNumber } from "@/lib/utils";
-import { Target, ChevronDown, Loader2, AlertCircle, CheckCircle2, Shield, Timer, BookPlus, Plus, Minus, Calculator } from "lucide-react";
+import { Target, ChevronDown, Loader2, AlertCircle, CheckCircle2, Shield, Timer, BookPlus, Plus, Minus, Calculator, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { safeId } from "@/lib/client/id";
 import { inferDrillModeFromEntry, resolveDrillMetrics, type DrillPerformanceMode } from "@/lib/range/drill-metrics";
@@ -165,6 +165,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   ]);
 
   const [selectedSessionId, setSelectedSessionId] = useState<string>("");
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [drillName, setDrillName] = useState<string>("");
   const [drillTime, setDrillTime] = useState<string>("");
   const [drillPoints, setDrillPoints] = useState<string>("");
@@ -175,6 +176,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const [customDrillNotes, setCustomDrillNotes] = useState("");
   const [customDrillMode, setCustomDrillMode] = useState<DrillPerformanceMode>("both");
   const [editingDrillId, setEditingDrillId] = useState<string | null>(null);
+  const [deletingDrillId, setDeletingDrillId] = useState<string | null>(null);
   const [drillLibrary, setDrillLibrary] = useState<DrillTemplate[]>(DEFAULT_DRILL_LIBRARY);
   const [calculatorPoints, setCalculatorPoints] = useState("");
   const [calculatorPenalties, setCalculatorPenalties] = useState("");
@@ -188,6 +190,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
   const [performanceDrillName, setPerformanceDrillName] = useState("");
   const [selectedPerformanceDrillId, setSelectedPerformanceDrillId] = useState<string>("");
   const router = useRouter();
+  const showLogSession = view === "log-session";
+  const showSessionHistory = view === "session-history";
+  const showLogDrill = view === "log-drill";
+  const showDrillPerformance = view === "drill-performance";
+  const showDrillLibrary = view === "drill-library";
+  const showHitFactor = view === "hit-factor";
 
   const [loadingFirearms, setLoadingFirearms] = useState(true);
   const [loadingBuilds, setLoadingBuilds] = useState(false);
@@ -366,6 +374,35 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     if (sessionFromQuery && sessionFromQuery !== selectedSessionId) setSelectedSessionId(sessionFromQuery);
   }, [drillName, performanceDrillName, selectedSessionId]);
 
+  useEffect(() => {
+    if (!showLogSession || typeof window === "undefined") return;
+    const editSessionId = new URLSearchParams(window.location.search).get("edit");
+    if (!editSessionId) {
+      setEditingSessionId(null);
+      return;
+    }
+
+    const sessionToEdit = sessions.find((session) => session.id === editSessionId);
+    if (!sessionToEdit) return;
+
+    setEditingSessionId(sessionToEdit.id);
+    setSelectedSessionId(sessionToEdit.id);
+    setSessionDate(new Date(sessionToEdit.sessionDate).toISOString().slice(0, 10));
+    setSessionLocation(sessionToEdit.location);
+    setSelectedFirearm(sessionToEdit.firearm.id);
+    setSelectedBuild(sessionToEdit.build?.id ?? "");
+    setRoundsFired(String(sessionToEdit.roundsFired));
+    setSessionNote(sessionToEdit.notes ?? "");
+    setAmmoSelections(
+      sessionToEdit.ammoLinks.length > 0
+        ? sessionToEdit.ammoLinks.map((link) => ({
+            ammoStockId: link.ammoStock.id,
+            roundsUsed: String(link.roundsUsed),
+          }))
+        : [{ ammoStockId: "", roundsUsed: "" }]
+    );
+  }, [sessions, showLogSession]);
+
   const drillHitFactorPreview = useMemo(() => {
     const time = selectedDrillTemplate?.mode === "accuracy" ? 1 : Number.parseFloat(drillTime);
     const points = selectedDrillTemplate?.mode === "time" ? 0 : Number.parseFloat(drillPoints);
@@ -466,6 +503,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     const accessoryIdsForFinalize = selectedBuildData?.slots
       .map((slot) => slot.accessory?.id)
       .filter((id): id is string => Boolean(id)) ?? [];
+    const isEditingSession = Boolean(editingSessionId);
 
     if (!selectedFirearmId) {
       setError("Add at least one firearm in the vault before logging a range session.");
@@ -479,7 +517,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
       const hasRequired = Boolean(entry.name.trim() && entry.timeSeconds && entry.points);
       return !hasRequired;
     });
-    if (hasIncompleteDrillRows) {
+    if (!isEditingSession && hasIncompleteDrillRows) {
       setError("Each drill set row must include drill name, time, and points (or leave the row blank).");
       setSubmitting(false);
       return;
@@ -501,8 +539,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     }
 
     try {
-      const sessionRes = await fetch("/api/range/sessions", {
-        method: "POST",
+      const sessionRes = await fetch(isEditingSession ? `/api/range/sessions/${editingSessionId}` : "/api/range/sessions", {
+        method: isEditingSession ? "PUT" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sessionDate: sessionDate || new Date().toISOString().slice(0, 10),
@@ -511,8 +549,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           buildId: selectedBuild || null,
           roundsFired: resolvedRounds,
           notes: sessionNote,
-          ammoLinks: normalizedAmmoLinks,
-          sessionDrills: normalizedSessionDrills,
+          ...(isEditingSession ? {} : { ammoLinks: normalizedAmmoLinks, sessionDrills: normalizedSessionDrills }),
         }),
       });
 
@@ -523,35 +560,42 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
 
       setSavedSessionId(sessionJson.id);
 
-      const finalizeRes = await fetch(`/api/range/sessions/${sessionJson.id}/finalize`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          selectedAccessoryIds: accessoryIdsForFinalize.length > 0 ? accessoryIdsForFinalize : Array.from(selectedAccessories),
-        }),
-      });
+      if (!isEditingSession) {
+        const finalizeRes = await fetch(`/api/range/sessions/${sessionJson.id}/finalize`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            selectedAccessoryIds: accessoryIdsForFinalize.length > 0 ? accessoryIdsForFinalize : Array.from(selectedAccessories),
+          }),
+        });
 
-      const finalizeJson = await finalizeRes.json();
-      if (!finalizeRes.ok) {
-        setFinalizeState("failed_after_save");
-        setSuccess("Session saved.");
-        setWarning("Finalize failed. Retry save to safely re-run updates.");
-        setError(finalizeJson.error ?? "Finalize failed");
+        const finalizeJson = await finalizeRes.json();
+        if (!finalizeRes.ok) {
+          setFinalizeState("failed_after_save");
+          setSuccess("Session saved.");
+          setWarning("Finalize failed. Retry save to safely re-run updates.");
+          setError(finalizeJson.error ?? "Finalize failed");
+          await loadSessions();
+          setSelectedSessionId(sessionJson.id);
+          setSubmitting(false);
+          return;
+        }
+
         await loadSessions();
         setSelectedSessionId(sessionJson.id);
-        setSubmitting(false);
-        return;
+        setFinalizeState("success");
+        setSuccess("Session saved and finalized.");
+        setWarning(null);
+        setRoundsFired("");
+        setSessionNote("");
+        setAmmoSelections([{ ammoStockId: "", roundsUsed: "" }]);
+        setSessionDrillEntries([{ id: safeId("session-drill"), name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" }]);
+      } else {
+        await loadSessions();
+        setSelectedSessionId(sessionJson.id);
+        setSuccess("Session updated.");
+        setWarning("V1 edit mode updates session details only. Existing ammo links and drill logs are preserved.");
       }
-
-      await loadSessions();
-      setSelectedSessionId(sessionJson.id);
-      setFinalizeState("success");
-      setSuccess("Session saved and finalized.");
-      setWarning(null);
-      setRoundsFired("");
-      setSessionNote("");
-      setAmmoSelections([{ ammoStockId: "", roundsUsed: "" }]);
-      setSessionDrillEntries([{ id: safeId("session-drill"), name: "", timeSeconds: "", points: "", penalties: "", hits: "", notes: "" }]);
     } catch (err) {
       setFinalizeState("idle");
       setError(err instanceof Error ? err.message : "Session log failed");
@@ -626,13 +670,6 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
       setSubmittingDrill(false);
     }
   }
-
-  const showLogSession = view === "log-session";
-  const showSessionHistory = view === "session-history";
-  const showLogDrill = view === "log-drill";
-  const showDrillPerformance = view === "drill-performance";
-  const showDrillLibrary = view === "drill-library";
-  const showHitFactor = view === "hit-factor";
 
   const allLoggedDrills = useMemo(
     () =>
@@ -770,19 +807,55 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     const name = customDrillName.trim();
     if (!name) return;
 
-    setDrillLibrary((prev) => [
-      {
-        id: crypto.randomUUID(),
-        name,
-        notes: customDrillNotes.trim() || null,
-        mode: customDrillMode,
-        createdAt: new Date().toISOString(),
-      },
-      ...prev,
-    ]);
+    if (editingDrillId) {
+      setDrillLibrary((prev) =>
+        prev.map((item) =>
+          item.id === editingDrillId
+            ? { ...item, name, notes: customDrillNotes.trim() || null, mode: customDrillMode }
+            : item
+        )
+      );
+      setSuccess(`Updated "${name}" drill template.`);
+      if (typeof window !== "undefined") {
+        router.replace("/range/drill-library");
+      }
+      setEditingDrillId(null);
+    } else {
+      setDrillLibrary((prev) => [
+        {
+          id: crypto.randomUUID(),
+          name,
+          notes: customDrillNotes.trim() || null,
+          mode: customDrillMode,
+          createdAt: new Date().toISOString(),
+        },
+        ...prev,
+      ]);
+    }
     setCustomDrillName("");
     setCustomDrillNotes("");
     setCustomDrillMode("both");
+  }
+
+  function handleDeleteDrill(template: DrillTemplate) {
+    if (deletingDrillId) return;
+    const hasHistory = drillNameLibrary.some((name) => name.trim().toLowerCase() === template.name.trim().toLowerCase());
+    if (hasHistory) {
+      setError(`Cannot delete "${template.name}" because it has linked logged history.`);
+      return;
+    }
+
+    if (!window.confirm(`Delete drill template "${template.name}"? This cannot be undone.`)) {
+      return;
+    }
+
+    setDeletingDrillId(template.id);
+    setDrillLibrary((prev) => prev.filter((item) => item.id !== template.id));
+    setSuccess(`Deleted "${template.name}" from drill library.`);
+    if (drillName === template.name) {
+      setDrillName("");
+    }
+    setDeletingDrillId(null);
   }
 
   const pageTitle = ({
@@ -845,6 +918,11 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         <form id="log-range-session" onSubmit={handleSubmit} className="space-y-6 scroll-mt-20">
           <fieldset className={SECTION_CARD_CLASS}>
             <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Session Details</legend>
+            {editingSessionId && (
+              <p className="text-xs text-vault-text-muted">
+                Editing session <span className="font-mono">{editingSessionId.slice(0, 12)}</span>. V1 edit mode updates session details only and preserves existing ammo links/drill logs.
+              </p>
+            )}
 
             <div className="grid md:grid-cols-2 gap-4">
               <div>
@@ -928,6 +1006,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               </div>
             </div>
 
+            {!editingSessionId && (
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
                 <label className={vaultLabelClass}>Ammo Used (multiple types supported)</label>
@@ -980,7 +1059,9 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               )}
               <p className="text-xs text-vault-text-faint">Leave rows blank to skip ammo deductions. When rounds fired is blank, it auto-calculates from ammo rows.</p>
             </div>
+            )}
 
+            {!editingSessionId && (
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
                 <label className={vaultLabelClass}>Drills Completed During This Session</label>
@@ -1086,6 +1167,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 </div>
               ))}
             </div>
+            )}
 
             <div>
               <label className={vaultLabelClass}>Notes</label>
@@ -1143,7 +1225,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-6 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Target className="w-4 h-4" />}
-              {submitting ? "Logging..." : "Log Session"}
+              {submitting ? (editingSessionId ? "Saving..." : "Logging...") : (editingSessionId ? "Save Session Changes" : "Log Session")}
             </button>
           </div>
         </form>
@@ -1360,40 +1442,44 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         {showDrillLibrary && (
         <fieldset id="drill-library" className={`${SECTION_CARD_CLASS} scroll-mt-20`}>
           <legend className="text-xs font-mono uppercase tracking-widest text-[#00C2FF] px-1 -ml-1">Drill Library</legend>
-          <form onSubmit={addCustomDrill} className="grid gap-3 md:grid-cols-[1fr_1fr_160px_auto] items-end">
-            <div>
-              <label className={vaultLabelClass}>Custom Drill Name</label>
-              <VaultInput
-                value={customDrillName}
-                onChange={(e) => setCustomDrillName(e.target.value)}
-                placeholder="e.g. El Prez"
-                
-              />
+          <div className="space-y-4">
+            <div className="rounded-lg border border-vault-border bg-vault-bg p-4 space-y-3">
+              <p className="text-xs uppercase tracking-widest text-vault-text-muted">Create New Drill</p>
+              <p className="text-xs text-vault-text-faint">Choose a name and how the drill is scored so logging screens show the right performance fields.</p>
+              <form onSubmit={addCustomDrill} className="grid gap-3 md:grid-cols-[1fr_1fr_180px_auto] items-end">
+                <div>
+                  <label className={vaultLabelClass}>Basic Info · Drill Name</label>
+                  <VaultInput
+                    value={customDrillName}
+                    onChange={(e) => setCustomDrillName(e.target.value)}
+                    placeholder="e.g. El Prez"
+                  />
+                </div>
+                <div>
+                  <label className={vaultLabelClass}>Notes / Configuration</label>
+                  <VaultInput
+                    value={customDrillNotes}
+                    onChange={(e) => setCustomDrillNotes(e.target.value)}
+                    placeholder="Optional setup notes"
+                  />
+                </div>
+                <div>
+                  <label className={vaultLabelClass}>Performance Tracking</label>
+                  <VaultSelect value={customDrillMode} onChange={(e) => setCustomDrillMode(e.target.value as DrillPerformanceMode)} >
+                    <option value="both">Time + Accuracy</option>
+                    <option value="time">Time only</option>
+                    <option value="accuracy">Accuracy only</option>
+                  </VaultSelect>
+                </div>
+                <button
+                  type="submit"
+                  className="h-10 px-4 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20"
+                >
+                  <span className="inline-flex items-center gap-2"><BookPlus className="w-4 h-4" />{editingDrillId ? "Save Drill" : "Add Drill"}</span>
+                </button>
+              </form>
             </div>
-            <div>
-              <label className={vaultLabelClass}>Notes</label>
-              <VaultInput
-                value={customDrillNotes}
-                onChange={(e) => setCustomDrillNotes(e.target.value)}
-                placeholder="Optional setup notes"
-                
-              />
-            </div>
-            <div>
-              <label className={vaultLabelClass}>Mode</label>
-              <VaultSelect value={customDrillMode} onChange={(e) => setCustomDrillMode(e.target.value as DrillPerformanceMode)} >
-                <option value="both">Time + Accuracy</option>
-                <option value="time">Time only</option>
-                <option value="accuracy">Accuracy only</option>
-              </VaultSelect>
-            </div>
-            <button
-              type="submit"
-              className="h-10 px-4 rounded-md text-sm bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20"
-            >
-              <span className="inline-flex items-center gap-2"><BookPlus className="w-4 h-4" />{editingDrillId ? "Save Drill" : "Add Drill"}</span>
-            </button>
-          </form>
+          </div>
 
           <div className="grid md:grid-cols-2 gap-4">
             <div className="space-y-2">
@@ -1403,14 +1489,9 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
               ) : (
                 <div className="space-y-2">
                   {drillLibrary.map((template) => (
-                    <button
+                    <div
                       key={template.id}
-                      type="button"
-                      onClick={() => {
-                        setDrillName(template.name);
-                        router.push(`/range/log-drill?drill=${encodeURIComponent(template.name)}`);
-                      }}
-                      className="w-full text-left bg-vault-bg border border-vault-border rounded px-3 py-2 hover:border-[#00C2FF]/40"
+                      className="w-full text-left bg-vault-bg border border-vault-border rounded px-3 py-2"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div>
@@ -1418,12 +1499,33 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                           <p className="text-xs text-vault-text-faint mt-1 uppercase tracking-widest">{template.mode}</p>
                           {template.notes && <p className="text-xs text-vault-text-muted mt-1 line-clamp-1">{template.notes}</p>}
                         </div>
-                        <div className="flex gap-1">
+                        <div className="flex flex-wrap justify-end gap-1">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDrillName(template.name);
+                              router.push(`/range/log-drill?drill=${encodeURIComponent(template.name)}`);
+                            }}
+                            className="text-[11px] px-2 py-1 rounded border border-vault-border text-vault-text-muted"
+                          >
+                            Select
+                          </button>
                           <Link href={`/range/drill-library?edit=${template.id}`} className="text-[11px] px-2 py-1 rounded border border-vault-border text-vault-text-muted">Edit</Link>
                           <Link href={`/range/drill-performance?drill=${encodeURIComponent(template.name)}`} className="text-[11px] px-2 py-1 rounded border border-[#00C2FF]/30 text-[#00C2FF]">History</Link>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteDrill(template)}
+                            disabled={deletingDrillId === template.id}
+                            className="text-[11px] px-2 py-1 rounded border border-[#E53935]/40 text-[#E53935] disabled:opacity-60"
+                          >
+                            <span className="inline-flex items-center gap-1">
+                              <Trash2 className="h-3 w-3" />
+                              {deletingDrillId === template.id ? "Deleting..." : "Delete"}
+                            </span>
+                          </button>
                         </div>
                       </div>
-                    </button>
+                    </div>
                   ))}
                 </div>
               )}
@@ -1687,16 +1789,31 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           ) : (
             <div className="space-y-2">
               {sessions.slice(0, 8).map((session) => (
-                <button
+                <div
                   key={session.id}
-                  onClick={() => setSelectedSessionId(session.id)}
                   className={`w-full text-left p-3 rounded-md border transition-colors ${
                     session.id === selectedSessionId ? "border-[#00C2FF]/50 bg-[#00C2FF]/10" : "border-vault-border bg-vault-bg hover:border-vault-text-muted/30"
                   }`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-sm font-medium text-vault-text">{new Date(session.sessionDate).toLocaleDateString()} · {session.location}</p>
-                    <p className="text-xs font-mono text-[#F5A623]">{formatNumber(session.roundsFired)} rds</p>
+                    <div className="flex items-center gap-2">
+                      <p className="text-xs font-mono text-[#F5A623]">{formatNumber(session.roundsFired)} rds</p>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedSessionId(session.id)}
+                        className="text-[11px] px-2 py-1 rounded border border-vault-border text-vault-text-muted"
+                      >
+                        View
+                      </button>
+                      <Link
+                        href={`/range/log-session?edit=${session.id}`}
+                        className="text-[11px] px-2 py-1 rounded border border-[#00C2FF]/30 text-[#00C2FF] inline-flex items-center gap-1"
+                      >
+                        <Pencil className="w-3 h-3" />
+                        Edit
+                      </Link>
+                    </div>
                   </div>
                   <p className="text-xs text-vault-text-muted mt-1">
                     {session.firearm.name}{session.build ? ` · ${session.build.name}` : ""} · {session.ammoLinks.map((link) => `${link.ammoStock.brand} (${link.roundsUsed})`).join(", ")}
@@ -1715,13 +1832,24 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                       ))}
                     </div>
                   )}
-                </button>
+                </div>
               ))}
             </div>
           )}
 
           {selectedSession?.sessionDrills?.length ? (
             <p className="text-xs text-vault-text-faint">Selected session has {selectedSession.sessionDrills.length} drill set{selectedSession.sessionDrills.length === 1 ? "" : "s"} logged.</p>
+          ) : null}
+          {selectedSession ? (
+            <div className="pt-1">
+              <Link
+                href={`/range/log-session?edit=${selectedSession.id}`}
+                className="text-xs text-[#00C2FF] hover:underline inline-flex items-center gap-1"
+              >
+                <Pencil className="w-3 h-3" />
+                Edit selected session
+              </Link>
+            </div>
           ) : null}
         </fieldset>
         )}

--- a/src/lib/network/get-local-ip.ts
+++ b/src/lib/network/get-local-ip.ts
@@ -1,6 +1,7 @@
 import os, { NetworkInterfaceInfo } from "os";
 
 function isPrivateLanIpv4(address: string): boolean {
+  if (address.startsWith("169.254.")) return false;
   if (address.startsWith("192.168.")) return true;
   if (address.startsWith("10.")) return true;
   const parts = address.split(".").map((part) => Number.parseInt(part, 10));
@@ -17,15 +18,35 @@ function priorityForAddress(address: string): number {
 
 function isInterfaceCandidate(name: string): boolean {
   const lower = name.toLowerCase();
-  if (lower.includes("docker") || lower.includes("veth") || lower.includes("br-") || lower.includes("lo")) {
+  if (
+    lower.includes("docker") ||
+    lower.includes("veth") ||
+    lower.includes("br-") ||
+    lower.includes("lo") ||
+    lower.includes("cni") ||
+    lower.includes("flannel") ||
+    lower.includes("tailscale") ||
+    lower.includes("utun") ||
+    lower.includes("tap") ||
+    lower.includes("tun") ||
+    lower.includes("vboxnet") ||
+    lower.includes("vmnet")
+  ) {
     return false;
   }
   return true;
 }
 
+function interfacePriority(name: string): number {
+  const lower = name.toLowerCase();
+  if (lower.includes("wlan") || lower.includes("wifi") || lower.includes("wi-fi") || lower === "en0") return 1;
+  if (lower.startsWith("eth") || lower.startsWith("en") || lower.startsWith("eno") || lower.startsWith("ens")) return 2;
+  return 3;
+}
+
 export function getLocalIp(): string | null {
   const interfaces = os.networkInterfaces();
-  const candidates: Array<{ address: string; priority: number }> = [];
+  const candidates: Array<{ address: string; priority: number; interfacePriority: number }> = [];
 
   for (const [name, addresses] of Object.entries(interfaces)) {
     if (!addresses || !isInterfaceCandidate(name)) continue;
@@ -41,10 +62,16 @@ export function getLocalIp(): string | null {
       candidates.push({
         address: address.address,
         priority: priorityForAddress(address.address),
+        interfacePriority: interfacePriority(name),
       });
     }
   }
 
-  candidates.sort((a, b) => a.priority - b.priority || a.address.localeCompare(b.address));
+  candidates.sort(
+    (a, b) =>
+      a.priority - b.priority ||
+      a.interfacePriority - b.interfacePriority ||
+      a.address.localeCompare(b.address)
+  );
   return candidates[0]?.address ?? null;
 }


### PR DESCRIPTION
### Motivation
- Ship a small, low-risk V1 cleanup pass that fixes remaining UX and operational gaps in range workflows and settings without broad refactors. 
- Provide clear, honest behaviors for backups and LAN access for self-hosted deployments and avoid silent failures or risky cascades.

### Description
- Drill library: added a compact `Delete` action on drill cards with confirmation, prevented deletion when a template has linked logged history, and preserved existing `Select` / `Edit` / `History` flows; UI polish for the Create New Drill area with clearer grouping and helper text. (`src/components/range/RangeWorkspace.tsx`)
- Session editing: added a safe `PUT /api/range/sessions/[id]` API to update top-level session metadata and wired `?edit=<sessionId>` into the `log-session` screen so users can edit session date/location/firearm/build/rounds/notes while preserving existing ammo links and drill logs for V1 safety. (`src/app/api/range/sessions/[id]/route.ts`, `RangeWorkspace` changes)
- Settings / backup destination: added `backupDestinationPath` to `AppSettings` (Prisma schema + migration) and exposed it end-to-end via `GET`/`PUT /api/settings` with validation and an honest settings UI field labeled as a reference/preference path. (`prisma/schema.prisma`, `prisma/migrations/*`, `src/app/api/settings/route.ts`, `src/app/settings/page.tsx`)
- LAN & mobile fixes: hardened LAN IP selection to filter out loopback/container/tunnel interfaces and prioritized usable private IPv4 candidates; fixed mobile menu open/overlay behavior (pointer-events, transform/z-index, accessibility attributes) for reliable portrait operation. (`src/lib/network/get-local-ip.ts`, `src/components/layout/Sidebar.tsx`, `src/components/layout/MobileHeader.tsx`)

### Testing
- Ran unit tests: `npx vitest run src/app/api/settings/route.test.ts` — all tests passed (7/7). 
- Lint: `npm run lint` — completed with non-blocking warnings only (no errors). 
- Full build: `npm run build` (includes `prisma generate`, `prisma migrate deploy`, and Next.js build) — completed successfully and applied the new migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ad5d9f1c8326b5d021f5ab55b777)