### PR TITLE
Add manual LAN host override for reliable mobile access URL

### DIFF
--- a/prisma/migrations/20260324120000_add_manual_lan_host/migration.sql
+++ b/prisma/migrations/20260324120000_add_manual_lan_host/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AppSettings" ADD COLUMN "manualLanHost" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -287,6 +287,7 @@ model AppSettings {
   autoBackupEnabled       Boolean  @default(false)
   autoBackupCadence       String   @default("weekly")
   backupDestinationPath   String?
+  manualLanHost           String?
   defaultCurrency         String   @default("USD")
   appPassword             String?
   createdAt               DateTime @default(now())

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -33,6 +33,7 @@ describe("/api/settings backup fields", () => {
       autoBackupEnabled: true,
       autoBackupCadence: "monthly",
       backupDestinationPath: "/srv/blackvault/backups",
+      manualLanHost: "192.168.1.74",
       defaultCurrency: "USD",
       appPassword: null,
       createdAt: new Date("2026-03-01T00:00:00.000Z"),
@@ -47,6 +48,7 @@ describe("/api/settings backup fields", () => {
     expect(json.autoBackupEnabled).toBe(true);
     expect(json.autoBackupCadence).toBe("monthly");
     expect(json.backupDestinationPath).toBe("/srv/blackvault/backups");
+    expect(json.manualLanHost).toBe("192.168.1.74");
   });
 
   it("persists backup settings via PUT", async () => {
@@ -58,6 +60,7 @@ describe("/api/settings backup fields", () => {
       autoBackupEnabled: true,
       autoBackupCadence: "weekly",
       backupDestinationPath: "/mnt/blackvault/backups",
+      manualLanHost: null,
       defaultCurrency: "USD",
       appPassword: null,
       createdAt: new Date("2026-03-01T00:00:00.000Z"),
@@ -71,6 +74,7 @@ describe("/api/settings backup fields", () => {
         autoBackupEnabled: true,
         autoBackupCadence: "weekly",
         backupDestinationPath: "/mnt/blackvault/backups",
+        manualLanHost: "192.168.1.74",
       }),
       headers: {
         "Content-Type": "application/json",
@@ -87,6 +91,7 @@ describe("/api/settings backup fields", () => {
     expect(upsertArgs.update.autoBackupEnabled).toBe(true);
     expect(upsertArgs.update.autoBackupCadence).toBe("weekly");
     expect(upsertArgs.update.backupDestinationPath).toBe("/mnt/blackvault/backups");
+    expect(upsertArgs.update.manualLanHost).toBe("192.168.1.74");
     expect(json.autoBackupCadence).toBe("weekly");
   });
 
@@ -186,6 +191,50 @@ describe("/api/settings backup fields", () => {
     expect(upsertArgs.update.defaultCurrency).toBe("EUR");
   });
 
+
+  it("normalizes and validates manualLanHost", async () => {
+    mocks.upsert.mockResolvedValue({
+      id: "singleton",
+      manualLanHost: "192.168.1.74",
+      googleCseApiKey: null,
+      enableImageSearch: false,
+    });
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      body: JSON.stringify({
+        manualLanHost: " 192.168.1.74 ",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(200);
+    const upsertArgs = mocks.upsert.mock.calls[0][0];
+    expect(upsertArgs.update.manualLanHost).toBe("192.168.1.74");
+  });
+
+  it("rejects invalid manualLanHost payloads", async () => {
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      body: JSON.stringify({
+        manualLanHost: 12345,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await PUT(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toMatch(/manualLanHost must be a string/i);
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
   it("rejects empty update payloads", async () => {
     const request = new NextRequest("http://localhost/api/settings", {
       method: "PUT",

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -31,6 +31,13 @@ function normalizeBackupDestinationPath(value: unknown): string | null {
   return normalized.length > 0 ? normalized : "";
 }
 
+function normalizeManualLanHost(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (normalized.length > 255) return null;
+  return normalized.length > 0 ? normalized : "";
+}
+
 // GET /api/settings - Get the singleton AppSettings
 export async function GET() {
   try {
@@ -52,6 +59,7 @@ export async function GET() {
       autoBackupEnabled: settings.autoBackupEnabled,
       autoBackupCadence: settings.autoBackupCadence,
       backupDestinationPath: settings.backupDestinationPath,
+      manualLanHost: settings.manualLanHost,
       defaultCurrency: settings.defaultCurrency,
       createdAt: settings.createdAt,
       updatedAt: settings.updatedAt,
@@ -86,6 +94,7 @@ export async function PUT(request: NextRequest) {
       autoBackupEnabled,
       autoBackupCadence,
       backupDestinationPath,
+      manualLanHost,
       defaultCurrency,
     } = body;
 
@@ -152,6 +161,17 @@ export async function PUT(request: NextRequest) {
       updateData.backupDestinationPath = normalized || null;
     }
 
+    if (manualLanHost !== undefined) {
+      const normalized = normalizeManualLanHost(manualLanHost);
+      if (normalized == null) {
+        return NextResponse.json(
+          { error: "manualLanHost must be a string up to 255 characters." },
+          { status: 400 }
+        );
+      }
+      updateData.manualLanHost = normalized || null;
+    }
+
     if (Object.keys(updateData).length === 0) {
       return NextResponse.json(
         { error: "No valid settings fields provided." },
@@ -174,6 +194,7 @@ export async function PUT(request: NextRequest) {
       autoBackupEnabled: settings.autoBackupEnabled,
       autoBackupCadence: settings.autoBackupCadence,
       backupDestinationPath: settings.backupDestinationPath,
+      manualLanHost: settings.manualLanHost,
       defaultCurrency: settings.defaultCurrency,
       createdAt: settings.createdAt,
       updatedAt: settings.updatedAt,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -19,6 +19,7 @@ export default function SettingsPage() {
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
   const [autoBackupCadence, setAutoBackupCadence] = useState<"daily" | "weekly" | "monthly">("weekly");
   const [backupDestinationPath, setBackupDestinationPath] = useState("");
+  const [manualLanHost, setManualLanHost] = useState("");
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -26,7 +27,6 @@ export default function SettingsPage() {
 
   const [localIp, setLocalIp] = useState<string | null>(null);
   const [localPort, setLocalPort] = useState("3000");
-  const [localUrl, setLocalUrl] = useState<string | null>(null);
   const [localAccessMessage, setLocalAccessMessage] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
 
@@ -41,6 +41,7 @@ export default function SettingsPage() {
           setAutoBackupEnabled(data.autoBackupEnabled ?? false);
           setAutoBackupCadence(data.autoBackupCadence ?? "weekly");
           setBackupDestinationPath(data.backupDestinationPath ?? "");
+          setManualLanHost(data.manualLanHost ?? "");
         }
         setDataLoading(false);
       })
@@ -56,16 +57,18 @@ export default function SettingsPage() {
       .then((data) => {
         setLocalIp(data.ip ?? null);
         setLocalPort(data.port ?? "3000");
-        setLocalUrl(data.url ?? null);
         setLocalAccessMessage(data.message ?? null);
       })
       .catch(() => {
         setLocalIp(null);
         setLocalPort("3000");
-        setLocalUrl(null);
         setLocalAccessMessage("Unable to detect local network IP");
       });
   }, []);
+
+  const normalizedManualLanHost = manualLanHost.trim();
+  const effectiveLanHost = normalizedManualLanHost || localIp || null;
+  const finalLanUrl = effectiveLanHost ? `http://${effectiveLanHost}:${localPort}` : null;
 
   async function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -82,6 +85,7 @@ export default function SettingsPage() {
           autoBackupEnabled,
           autoBackupCadence,
           backupDestinationPath,
+          manualLanHost,
         }),
       });
 
@@ -101,10 +105,10 @@ export default function SettingsPage() {
   }
 
   async function handleCopyLocalUrl() {
-    if (!localUrl || !navigator.clipboard) return;
+    if (!finalLanUrl || !navigator.clipboard) return;
 
     try {
-      await navigator.clipboard.writeText(localUrl);
+      await navigator.clipboard.writeText(finalLanUrl);
       setCopySuccess(true);
       setTimeout(() => setCopySuccess(false), 2000);
     } catch {
@@ -214,7 +218,7 @@ export default function SettingsPage() {
         >
           <div className="space-y-4">
             <div className="rounded-lg border border-vault-border bg-vault-bg p-3">
-              <p className="text-xs uppercase tracking-widest text-vault-text-faint">Device IP</p>
+              <p className="text-xs uppercase tracking-widest text-vault-text-faint">Detected LAN IP (best effort)</p>
               <p className="mt-1 font-mono text-sm text-vault-text">{localIp ?? "Unavailable"}</p>
             </div>
 
@@ -223,18 +227,34 @@ export default function SettingsPage() {
               <p className="mt-1 font-mono text-sm text-vault-text">{localPort}</p>
             </div>
 
+            <FormField
+              label="Mobile Access Host/IP"
+              hint="Enter the LAN IP or hostname other devices on your network should use, for example 192.168.1.74"
+            >
+              <input
+                id="manualLanHost"
+                type="text"
+                value={manualLanHost}
+                onChange={(e) => setManualLanHost(e.target.value)}
+                className={INPUT_CLASS}
+                placeholder="192.168.1.74"
+              />
+            </FormField>
+
             <div className="rounded-lg border border-vault-border bg-vault-bg p-3">
               <p className="text-xs uppercase tracking-widest text-vault-text-faint">Access URL</p>
               <p className="mt-1 break-all font-mono text-sm text-vault-text">
-                {localUrl ?? "Unavailable"}
+                {finalLanUrl ?? "Unavailable"}
               </p>
               <p className="mt-1 text-xs text-vault-text-muted">
-                Make sure your phone is on the same Wi-Fi or LAN. Example:
-                <span className="ml-1 font-mono">http://192.168.1.50:3000</span>
+                {normalizedManualLanHost ? "Using manual Mobile Access Host/IP override." : "Using auto-detected LAN IP when available."}
+              </p>
+              <p className="mt-1 text-xs text-vault-text-muted">
+                Make sure your phone is on the same Wi-Fi or LAN. Manual override is the reliable option when Docker or NAS networking hides the host LAN IP.
               </p>
             </div>
 
-            {localUrl ? (
+            {finalLanUrl ? (
               <div className="flex flex-wrap gap-2">
                 <StandardButton
                   type="button"
@@ -248,7 +268,7 @@ export default function SettingsPage() {
             ) : (
               <StatusMessage
                 tone="error"
-                message={localAccessMessage ?? "Unable to detect local network IP."}
+                message={localAccessMessage ?? "Set Mobile Access Host/IP to your host LAN IP or hostname to enable mobile access."}
               />
             )}
 
@@ -296,8 +316,8 @@ export default function SettingsPage() {
             />
             <StatusRow
               label="LAN URL Available"
-              value={localUrl ? "Yes" : "No"}
-              ok={Boolean(localUrl)}
+              value={finalLanUrl ? "Yes" : "No"}
+              ok={Boolean(finalLanUrl)}
             />
           </div>
         </SectionCard>


### PR DESCRIPTION
### Motivation
- Auto-detected LAN IP can be wrong in containerized or NAS setups and produces unreliable mobile access URLs. 
- Provide a simple, always-winning manual override while keeping current auto-detection as a best-effort fallback. 
- Keep changes minimal, persisted, and safe for self-hosted Docker/laptop/NAS installs.

### Description
- Add a nullable `manualLanHost` field to the `AppSettings` Prisma model and a SQL migration to add the column. 
- Extend `/api/settings` GET/PUT to include, validate (trim + max length), normalize, and persist `manualLanHost`. 
- Update the Settings UI (`/settings`) to add a `Mobile Access Host/IP` input with helper text and compute the final LAN URL as `manualLanHost` (if non-empty) otherwise detected LAN IP, always including the configured port, and keep copy-to-clipboard behavior tied to this final URL. 
- Add API tests for `manualLanHost` normalization, persistence, and invalid-payload rejection; keep auto-detect logic unchanged as fallback.

### Testing
- Ran lint with `npm run lint`; command completed (project has unrelated existing warnings). 
- Ran unit tests with `npx vitest run src/app/api/settings/route.test.ts` and all tests passed (`9 passed`). 
- Performed a full build with `npm run build`; build completed and migrations (including the new migration) were applied successfully. 
- Attempted `docker build -t projectblackvault:test .` but it failed in this environment with `docker: command not found` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2bc53ef908326bf3bef2371d7b74b)