### PR TITLE
Stabilize mobile portrait nav and harden affected V1 routes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,11 +27,11 @@ export default function RootLayout({
       </head>
       <body className="antialiased bg-vault-bg text-vault-text">
         <ThemeProvider>
-          <div className="flex h-screen overflow-hidden">
+          <div className="flex h-dvh min-h-dvh overflow-hidden">
             <Sidebar />
             <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
               <MobileHeader />
-              <main className="flex-1 overflow-y-auto min-w-0 pb-safe">
+              <main className="flex-1 overflow-y-auto overscroll-contain min-w-0 pb-safe">
                 {children}
               </main>
             </div>

--- a/src/app/vault/[id]/builds/[buildId]/page.tsx
+++ b/src/app/vault/[id]/builds/[buildId]/page.tsx
@@ -537,7 +537,7 @@ function WeaponCanvas({ build, onSlotClick, onRemoveSlot }: WeaponCanvasProps) {
   }
 
   return (
-    <div className="h-full overflow-y-auto p-4 md:p-5 bg-vault-canvas">
+    <div className="bg-vault-canvas p-4 md:h-full md:overflow-y-auto md:p-5">
       <div className="bg-vault-surface border border-vault-border rounded-xl p-4 md:p-5">
         <p className="text-[10px] text-vault-text-faint uppercase tracking-widest font-mono mb-1">
           Build Configurator
@@ -686,7 +686,7 @@ function SlotPanel({
   const customSlotCount = customSlots.length;
 
   return (
-    <div className="h-full flex flex-col bg-vault-surface border-t md:border-t-0 border-l-0 md:border-l border-vault-border">
+    <div className="flex flex-col bg-vault-surface border-t md:h-full md:border-t-0 border-l-0 md:border-l border-vault-border">
       {/* Panel header */}
       <div className="px-4 py-4 border-b border-vault-border shrink-0">
         <p className="text-[10px] text-vault-text-faint uppercase tracking-widest font-mono mb-1">
@@ -785,7 +785,7 @@ function SlotPanel({
       </div>
 
       {/* Slot list */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="md:flex-1 md:overflow-y-auto">
         {availableSlots.map((slotType) => {
           const slot = slotMap[slotType];
           const hasAccessory = !!slot?.accessory;
@@ -859,8 +859,8 @@ function SlotPanel({
 export default function BuildConfiguratorPage() {
   const params = useParams<{ id: string; buildId: string }>();
   const router = useRouter();
-  const firearmId = params.id;
-  const buildId = params.buildId;
+  const firearmId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const buildId = Array.isArray(params.buildId) ? params.buildId[0] : params.buildId;
 
   const [build, setBuild] = useState<Build | null>(null);
   const [allBuilds, setAllBuilds] = useState<Build[]>([]);
@@ -874,6 +874,11 @@ export default function BuildConfiguratorPage() {
   const [browserSlot, setBrowserSlot] = useState<string | null>(null);
 
   const fetchBuild = useCallback(async () => {
+    if (!firearmId || !buildId) {
+      setError("Invalid build route.");
+      setLoading(false);
+      return;
+    }
     try {
       const [buildRes, allBuildsRes] = await Promise.all([
         fetch(`/api/builds/${buildId}`),
@@ -990,7 +995,7 @@ export default function BuildConfiguratorPage() {
 
   // ── Main layout ────────────────────────────────────────────
   return (
-    <div className="flex flex-col h-screen bg-vault-canvas overflow-hidden">
+    <div className="flex min-h-full flex-col bg-vault-canvas">
       {/* Thin header bar */}
       <div className="flex items-center justify-between px-4 py-2.5 border-b border-vault-border bg-vault-bg shrink-0 z-20">
         <div className="flex items-center gap-3">
@@ -1052,9 +1057,9 @@ export default function BuildConfiguratorPage() {
       )}
 
       {/* Main split layout — vertical on mobile, side-by-side on md+ */}
-      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
+      <div className="flex flex-1 flex-col md:min-h-0 md:flex-row">
         {/* Config tiles */}
-        <div className="min-h-0 md:[flex:0_0_65%] border-b md:border-b-0 border-vault-border">
+        <div className="md:min-h-0 md:[flex:0_0_65%] border-b md:border-b-0 border-vault-border">
           <WeaponCanvas
             build={build}
             onSlotClick={(slotType) => setBrowserSlot(slotType)}
@@ -1063,7 +1068,7 @@ export default function BuildConfiguratorPage() {
         </div>
 
         {/* Slot Panel — flex below canvas on mobile, 35% on desktop */}
-        <div className="flex-1 md:[flex:0_0_35%] overflow-hidden">
+        <div className="md:min-h-0 md:[flex:0_0_35%] md:overflow-hidden">
           <SlotPanel
             build={build}
             allBuilds={allBuilds}

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -9,7 +9,7 @@ export function MobileHeader() {
 
   return (
     <>
-      <header className="md:hidden sticky top-0 z-40 flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
+      <header className="md:hidden sticky top-0 z-[250] flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
         <button
           onClick={() => setOpen((prev) => !prev)}
           className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -174,12 +174,12 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
         </aside>
       )}
 
-      <div className={cn("fixed inset-0 z-[130] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")}>
+      <div className={cn("fixed inset-0 z-[300] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")}>
         <div className="absolute inset-0 bg-black/60" onClick={onMobileClose} />
         <aside
           id="mobile-navigation"
           className={cn(
-            "absolute inset-y-0 left-0 flex h-screen max-h-screen w-72 max-w-[88vw] flex-col border-r border-vault-border bg-vault-surface shadow-2xl transition-transform duration-200",
+            "absolute inset-y-0 left-0 flex h-[100dvh] max-h-[100dvh] w-72 max-w-[88vw] flex-col overflow-hidden border-r border-vault-border bg-vault-surface shadow-2xl transition-transform duration-200",
             mobileOpen ? "translate-x-0" : "-translate-x-full"
           )}
         >

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -823,7 +823,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     } else {
       setDrillLibrary((prev) => [
         {
-          id: crypto.randomUUID(),
+          id: safeId("drill-template"),
           name,
           notes: customDrillNotes.trim() || null,
           mode: customDrillMode,


### PR DESCRIPTION
### Motivation
- Fix release-blocking mobile portrait issues where the mobile menu was hidden or untappable and several routes crashed on narrow viewports. 
- Address shared causes (overlay/viewport sizing, z-index, overflow traps, unguarded client-only APIs) that made `configurator`, `add accessories`, `ammo`, and `log session` brittle on mobile. 
- Prefer small, safe changes that improve reliability in portrait without adding features or broad refactors. 

### Description
- Make the app shell mobile-safe by switching the root container to use `dvh` (`h-dvh min-h-dvh`) and add `overscroll-contain` to the main scroll area to avoid portrait viewport clipping. 
- Ensure mobile drawer shows above content by raising z-indexes and rendering the nav drawer with `h-[100dvh] max-h-[100dvh] overflow-hidden` so the panel is visible, scrollable, and tappable in portrait. 
- Harden configurator route handling by normalizing `useParams()` (array-safe) and returning an early error state when route IDs are invalid to prevent client-side exceptions and dead interaction zones on mobile. 
- Replace direct `crypto.randomUUID()` use in the range workspace drill-creation path with the existing `safeId()` helper to avoid mobile environment fragility. 
- Files changed: `src/app/layout.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/layout/MobileHeader.tsx`, `src/app/vault/[id]/builds/[buildId]/page.tsx`, and `src/components/range/RangeWorkspace.tsx`. 

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran `npm run lint` which completed and returned only pre-existing warnings (no new lint errors). 
- Attempted `npm run build` which failed in this environment due to external Prisma engine download errors (403 from `binaries.prisma.sh`), preventing a full production build here. 
- Tried `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm run build` which remained blocked by Prisma engine fetch errors in this environment. 
- Ran `npx tsc --noEmit` which surfaced pre-existing repository TypeScript issues unrelated to these changes, so typecheck is not green in this environment. 
- `docker build` could not be executed here because Docker is not available in the runtime (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c69600d48326828caacd2b2bb15f)