### PR TITLE
Mobile hardening: stable drawer nav, responsive forms, and runtime guards

### DIFF
--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -31,6 +31,8 @@ export default function NewAccessoryPage() {
     const form = e.currentTarget;
     const data = new FormData(form);
 
+    const parsedPurchasePrice = Number(data.get("purchasePrice"));
+    const parsedReplacementInterval = Number(data.get("replacementIntervalDays"));
     const payload = {
       name: data.get("name") as string,
       manufacturer: data.get("manufacturer") as string,
@@ -38,14 +40,17 @@ export default function NewAccessoryPage() {
       type: data.get("type") as string,
       caliber: caliberInput || null,
       acquisitionDate: (data.get("acquisitionDate") as string) || null,
-      purchasePrice: data.get("purchasePrice") ? Number(data.get("purchasePrice")) : null,
+      purchasePrice: Number.isFinite(parsedPurchasePrice) && parsedPurchasePrice >= 0 ? parsedPurchasePrice : null,
       notes: (data.get("notes") as string) || null,
       imageUrl: imageUrl || null,
       imageSource: imageUrl ? "uploaded" : null,
       hasBattery: data.get("hasBattery") === "on",
       batteryType: (data.get("batteryType") as string) || null,
       lastBatteryChangeDate: (data.get("lastBatteryChangeDate") as string) || null,
-      replacementIntervalDays: data.get("replacementIntervalDays") ? Number(data.get("replacementIntervalDays")) : null,
+      replacementIntervalDays:
+        Number.isFinite(parsedReplacementInterval) && parsedReplacementInterval > 0
+          ? parsedReplacementInterval
+          : null,
     };
 
     try {
@@ -73,7 +78,7 @@ export default function NewAccessoryPage() {
   return (
     <div className="min-h-full">
       {/* Breadcrumb header */}
-      <div className="flex items-center gap-4 px-6 py-4 border-b border-vault-border">
+      <div className="flex flex-wrap items-center gap-2 sm:gap-4 px-4 sm:px-6 py-4 border-b border-vault-border">
         <Link
           href="/accessories"
           className="flex items-center gap-1.5 text-vault-text-muted hover:text-vault-text text-sm transition-colors"
@@ -87,7 +92,7 @@ export default function NewAccessoryPage() {
         </h1>
       </div>
 
-      <div className="max-w-2xl mx-auto px-6 py-8">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
         <div className="mb-8">
           <h2 className="text-xl font-bold text-vault-text mb-1">New Accessory Entry</h2>
           <p className="text-sm text-vault-text-muted">Register a new part or attachment in the arsenal.</p>
@@ -297,7 +302,7 @@ export default function NewAccessoryPage() {
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href="/accessories"
               className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"

--- a/src/app/accessories/page.tsx
+++ b/src/app/accessories/page.tsx
@@ -98,9 +98,9 @@ export default async function AccessoriesPage() {
         }
       />
 
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         {/* Summary bar */}
-        <div className="flex items-center gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-5 py-3">
+        <div className="flex flex-wrap items-center gap-4 sm:gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-4 sm:px-5 py-3">
           <div>
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Total Parts</p>
             <p className="text-lg font-bold font-mono text-vault-text">{formatNumber(accessories.length)}</p>
@@ -131,7 +131,49 @@ export default async function AccessoriesPage() {
             </Link>
           </div>
         ) : (
-          <div className="bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
+          <>
+            <div className="space-y-3 md:hidden">
+              {accessories.map((accessory) => (
+                <Link
+                  key={accessory.id}
+                  href={`/accessories/${accessory.id}`}
+                  className="block rounded-lg border border-vault-border bg-vault-surface p-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="w-11 h-11 rounded bg-vault-bg border border-vault-border overflow-hidden flex items-center justify-center shrink-0">
+                      {accessory.imageUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={accessory.imageUrl} alt={accessory.name} className="w-full h-full object-cover" />
+                      ) : (
+                        <Shield className="w-4 h-4 text-vault-text-faint" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold text-vault-text truncate">{accessory.name}</p>
+                      <p className="text-xs text-vault-text-faint truncate">
+                        {SLOT_TYPE_LABELS[accessory.type] ?? accessory.type}
+                        {accessory.manufacturer ? ` · ${accessory.manufacturer}` : ""}
+                      </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <RoundCountBadge roundCount={accessory.roundCount} className="text-xs" />
+                        <span className="text-xs font-mono text-vault-text-muted">
+                          {formatCurrency(accessory.purchasePrice)}
+                        </span>
+                        {accessory.currentBuild ? (
+                          <span className="text-xs text-[#00C853] truncate">
+                            {accessory.currentBuild.firearm.name}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-vault-text-faint">Uninstalled</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            <div className="hidden md:block bg-vault-surface border border-vault-border rounded-lg overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -267,6 +309,7 @@ export default async function AccessoriesPage() {
               </table>
             </div>
           </div>
+          </>
         )}
       </div>
     </div>

--- a/src/app/ammo/new/page.tsx
+++ b/src/app/ammo/new/page.tsx
@@ -73,7 +73,7 @@ export default function NewAmmoStockPage() {
   return (
     <div className="min-h-full">
       {/* Breadcrumb header */}
-      <div className="flex items-center gap-4 px-6 py-4 border-b border-vault-border">
+      <div className="flex flex-wrap items-center gap-2 sm:gap-4 px-4 sm:px-6 py-4 border-b border-vault-border">
         <Link
           href="/ammo"
           className="flex items-center gap-1.5 text-vault-text-muted hover:text-vault-text text-sm transition-colors"
@@ -87,7 +87,7 @@ export default function NewAmmoStockPage() {
         </h1>
       </div>
 
-      <div className="max-w-2xl mx-auto px-6 py-8">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
         <div className="mb-8">
           <h2 className="text-xl font-bold text-vault-text mb-1">New Ammo Stock</h2>
           <p className="text-sm text-vault-text-muted">Add a new ammunition stock to the depot.</p>
@@ -299,7 +299,7 @@ export default function NewAmmoStockPage() {
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href="/ammo"
               className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"

--- a/src/app/ammo/page.tsx
+++ b/src/app/ammo/page.tsx
@@ -73,12 +73,17 @@ function AddRoundsModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const parsedQty = Number.parseInt(qty, 10);
+    if (!Number.isFinite(parsedQty) || parsedQty <= 0) {
+      setError("Enter a valid quantity greater than zero.");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     const res = await fetch(`/api/ammo/${stock.id}/transactions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: "PURCHASE", quantity: parseInt(qty), note: note || undefined }),
+      body: JSON.stringify({ type: "PURCHASE", quantity: parsedQty, note: note || undefined }),
     });
     const json = await res.json();
     if (!res.ok) {
@@ -166,12 +171,17 @@ function LogUseModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const parsedQty = Number.parseInt(qty, 10);
+    if (!Number.isFinite(parsedQty) || parsedQty <= 0) {
+      setError("Enter a valid rounds-used value greater than zero.");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     const res = await fetch(`/api/ammo/${stock.id}/transactions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: "RANGE_USE", quantity: parseInt(qty), note: note || undefined }),
+      body: JSON.stringify({ type: "RANGE_USE", quantity: parsedQty, note: note || undefined }),
     });
     const json = await res.json();
     if (!res.ok) {
@@ -255,7 +265,7 @@ export default function AmmoPage() {
       .then((res) => res.json())
       .then((data) => {
         if (!isMounted) return;
-        setGroups(data.grouped ?? []);
+        setGroups(Array.isArray(data.grouped) ? data.grouped : []);
       })
       .finally(() => {
         if (isMounted) {
@@ -313,9 +323,9 @@ export default function AmmoPage() {
         }
       />
 
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         {/* Summary */}
-        <div className="flex items-center gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-5 py-3">
+        <div className="flex flex-wrap items-center gap-4 sm:gap-6 mb-6 bg-vault-surface border border-vault-border rounded-lg px-4 sm:px-5 py-3">
           <div>
             <p className="text-[10px] uppercase tracking-widest text-vault-text-faint mb-0.5">Calibers</p>
             <p className="text-lg font-bold font-mono text-vault-text">{groups.length}</p>

--- a/src/app/exports/full-armory/page.tsx
+++ b/src/app/exports/full-armory/page.tsx
@@ -88,7 +88,7 @@ export default function FullArmoryExportPage() {
   return (
     <div className="min-h-full">
       <PageHeader title="FULL ARMORY EXPORT" subtitle="CSV + PDF export with explicit include controls" />
-      <div className="p-6 space-y-6">
+      <div className="p-4 sm:p-6 space-y-6">
         <div className="bg-vault-surface border border-vault-border rounded-lg p-4 space-y-4">
           <div>
             <p className="text-xs uppercase tracking-widest text-vault-text-faint mb-2">Preset</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,7 @@
 html {
   scrollbar-color: var(--vault-muted) var(--vault-surface);
   scrollbar-width: thin;
+  overflow-x: hidden;
 }
 
 body {
@@ -72,6 +73,7 @@ body {
   color: var(--vault-text);
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   min-height: 100vh;
+  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,11 +27,11 @@ export default function RootLayout({
       </head>
       <body className="antialiased bg-vault-bg text-vault-text">
         <ThemeProvider>
-          <div className="flex h-dvh min-h-dvh overflow-hidden">
+          <div className="flex min-h-svh">
             <Sidebar />
-            <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+            <div className="flex flex-col flex-1 min-w-0 min-h-svh">
               <MobileHeader />
-              <main className="flex-1 overflow-y-auto overscroll-contain min-w-0 pb-safe">
+              <main className="flex-1 min-h-0 overflow-y-auto overscroll-contain min-w-0 pb-safe">
                 {children}
               </main>
             </div>

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,15 +1,24 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Shield, Menu } from "lucide-react";
 import { Sidebar } from "./Sidebar";
 
 export function MobileHeader() {
   const [open, setOpen] = useState(false);
 
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
   return (
     <>
-      <header className="md:hidden sticky top-0 z-[250] flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
+      <header className="md:hidden sticky top-0 z-[350] flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
         <button
           onClick={() => setOpen((prev) => !prev)}
           className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -61,6 +61,14 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
     onMobileClose?.();
   }, [pathname, onMobileClose]);
 
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onMobileClose?.();
+    };
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [mobileOpen, onMobileClose]);
 
   const navContent = (
     <>
@@ -169,12 +177,12 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
   return (
     <>
       {!mobileOnly && (
-        <aside className={cn("hidden md:flex flex-col h-screen border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0", collapsed ? "w-16" : "w-56")}>
+        <aside className={cn("hidden md:flex flex-col h-svh border-r border-vault-border bg-vault-surface transition-all duration-300 ease-in-out shrink-0", collapsed ? "w-16" : "w-56")}>
           {navContent}
         </aside>
       )}
 
-      <div className={cn("fixed inset-0 z-[300] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")}>
+      <div className={cn("fixed inset-0 z-[300] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")} aria-hidden={!mobileOpen}>
         <div className="absolute inset-0 bg-black/60" onClick={onMobileClose} />
         <aside
           id="mobile-navigation"

--- a/src/components/range/RangeWorkspace.tsx
+++ b/src/components/range/RangeWorkspace.tsx
@@ -215,11 +215,12 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     setLoadingSessions(true);
     try {
       const res = await fetch("/api/range/sessions");
-      const data = (await res.json()) as RangeSession[];
+      const data = (await res.json()) as RangeSession[] | { error?: string };
       if (res.ok) {
-        setSessions(data);
-        if (!selectedSessionId && data.length > 0) {
-          setSelectedSessionId(data[0].id);
+        const safeSessions = Array.isArray(data) ? data : [];
+        setSessions(safeSessions);
+        if (!selectedSessionId && safeSessions.length > 0) {
+          setSelectedSessionId(safeSessions[0].id);
         }
       }
     } finally {
@@ -231,7 +232,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     fetch("/api/firearms")
       .then((r) => r.json())
       .then((data) => {
-        setFirearms(data);
+        setFirearms(Array.isArray(data) ? data : []);
         setLoadingFirearms(false);
       })
       .catch(() => setLoadingFirearms(false));
@@ -239,7 +240,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     fetch("/api/ammo")
       .then((r) => r.json())
       .then((data) => {
-        setAmmoStocks(data.all ?? []);
+        setAmmoStocks(Array.isArray(data?.all) ? data.all : []);
         setLoadingAmmo(false);
       })
       .catch(() => setLoadingAmmo(false));
@@ -257,9 +258,10 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
     try {
       const res = await fetch(`/api/builds?firearmId=${firearmId}`);
       const data = (await res.json()) as Build[];
-      setBuilds(data);
+      const safeBuilds = Array.isArray(data) ? data : [];
+      setBuilds(safeBuilds);
 
-      const active = data.find((b) => b.isActive);
+      const active = safeBuilds.find((b) => b.isActive);
       if (active) {
         setSelectedBuild(active.id);
         const autoSelect = new Set<string>();
@@ -267,8 +269,8 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
           if (slot.accessory) autoSelect.add(slot.accessory.id);
         }
         setSelectedAccessories(autoSelect);
-      } else if (data.length > 0) {
-        setSelectedBuild(data[0].id);
+      } else if (safeBuilds.length > 0) {
+        setSelectedBuild(safeBuilds[0].id);
       } else {
         setSelectedBuild("");
       }
@@ -874,7 +876,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
         subtitle="Range session logging, drill tracking, and practical analysis tools"
       />
 
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <div className="max-w-4xl mx-auto w-full overflow-x-hidden px-4 sm:px-6 py-6 sm:py-8 space-y-6">
         {error && (
           <div className="flex items-center gap-3 bg-[#E53935]/10 border border-[#E53935]/30 rounded-lg px-4 py-3">
             <AlertCircle className="w-4 h-4 text-[#E53935] shrink-0" />
@@ -1022,7 +1024,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 <div className="flex items-center gap-2 h-10"><Loader2 className="w-4 h-4 text-[#F5A623] animate-spin" /></div>
               ) : (
                 ammoSelections.map((selection, index) => (
-                  <div key={`ammo-selection-${index}`} className="grid sm:grid-cols-[1fr_160px_auto] gap-2">
+                  <div key={`ammo-selection-${index}`} className="grid grid-cols-1 sm:grid-cols-[1fr_160px_auto] gap-2">
                     <div className="relative">
                       <VaultSelect
                         value={selection.ammoStockId}
@@ -1584,7 +1586,7 @@ export function RangeWorkspace({ view }: RangeWorkspaceProps) {
                 </div>
               </div>
 
-              <div className="grid grid-cols-[1fr_1fr_auto] gap-2 w-full sm:w-auto sm:min-w-[320px]">
+              <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-2 w-full sm:w-auto sm:min-w-[320px]">
                 <VaultInput
                   type="number"
                   min="0"


### PR DESCRIPTION
### Motivation

- Fix unreliable mobile navigation and header overlay issues that prevented the menu from working in portrait on phones.  
- Prevent client-side crashes and invalid submissions on critical mobile routes (ammo, accessories, range/session flows).  
- Make key pages and forms reliably usable on narrow viewports without broad refactors so V1 can ship stable.

### Description

- Stabilize app shell and mobile drawer: convert the root container from viewport-locked `h-dvh` to `min-h-svh`/`min-h-0` so header and scrolling behave on mobile, raise mobile header z-index, add body scroll lock while the drawer is open, and support Escape-to-close plus overlay semantics; changes in `src/app/layout.tsx`, `src/components/layout/MobileHeader.tsx`, and `src/components/layout/Sidebar.tsx`.  
- Add global horizontal overflow guardrails by disabling `overflow-x` on `html` and `body` to prevent sideways scroll on narrow devices; change in `src/app/globals.css`.  
- Improve accessories mobile UX by rendering stacked card/list items on small screens and preserving the desktop table at md+ breakpoints, and tighten summary spacing; change in `src/app/accessories/page.tsx`.  
- Harden ammo flows and modals: validate and parse numeric inputs before submitting ammo transactions and guard API response shapes when loading grouped ammo data; changes in `src/app/ammo/page.tsx` and `src/app/ammo/new/page.tsx`.  
- Standardize mobile-first form responsiveness and action layout (stacked action rows and tighter padding) for new accessory and new ammo forms; changes in `src/app/accessories/new/page.tsx` and `src/app/ammo/new/page.tsx`.  
- Make Range/Drill workspace more defensive and mobile-safe by validating fetch shapes for sessions/firearms/ammo/builds, restricting certain fixed-grid controls to single-column on narrow viewports, and adding local overflow guards; change in `src/components/range/RangeWorkspace.tsx`.  
- Minor spacing safety for exports page to avoid cramped controls on phones; change in `src/app/exports/full-armory/page.tsx`.

### Testing

- Ran `npm run lint` and it completed with no errors (only non-blocking warnings remain).  
- Ran `npm run build` and the Next.js production build completed successfully with pages/routes generated.  
- No automated test suites were added or changed; build + lint are the automated validations executed and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d3d6db9c83268801b55434f6823a)