### PR TITLE
Handle invalid route params, improve mobile sidebar/menu behavior, sanitize documents list and responsive action buttons

### DIFF
--- a/src/app/accessories/[id]/edit/page.tsx
+++ b/src/app/accessories/[id]/edit/page.tsx
@@ -41,10 +41,11 @@ function toDateInputValue(dateStr: string | null): string {
 export default function EditAccessoryPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
-  const accessoryId = params.id;
+  const accessoryId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const invalidRoute = !accessoryId;
 
   const [accessory, setAccessory] = useState<Accessory | null>(null);
-  const [dataLoading, setDataLoading] = useState(true);
+  const [dataLoading, setDataLoading] = useState(!invalidRoute);
   const [dataError, setDataError] = useState<string | null>(null);
 
   const [loading, setLoading] = useState(false);
@@ -60,6 +61,8 @@ export default function EditAccessoryPage() {
   );
 
   useEffect(() => {
+    if (!accessoryId) return;
+
     fetch(`/api/accessories/${accessoryId}`)
       .then((r) => r.json())
       .then((data) => {
@@ -133,6 +136,18 @@ export default function EditAccessoryPage() {
     return (
       <div className="flex items-center justify-center min-h-full">
         <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
+      </div>
+    );
+  }
+
+  if (invalidRoute) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+        <AlertCircle className="w-10 h-10 text-[#E53935]" />
+        <p className="text-[#E53935]">Invalid accessory route.</p>
+        <Link href="/accessories" className="text-sm text-[#00C2FF] hover:underline">
+          Back to Accessories
+        </Link>
       </div>
     );
   }
@@ -394,17 +409,17 @@ export default function EditAccessoryPage() {
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href={`/accessories/${accessoryId}`}
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading || success}
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/app/accessories/[id]/page.tsx
+++ b/src/app/accessories/[id]/page.tsx
@@ -89,7 +89,7 @@ function roundCountColor(roundCount: number, slotType: string): string {
 
 export default function AccessoryDetailPage() {
   const params = useParams<{ id: string }>();
-  const id = params.id;
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
 
   const [accessory, setAccessory] = useState<Accessory | null>(null);
   const [loading, setLoading] = useState(true);
@@ -106,6 +106,12 @@ export default function AccessoryDetailPage() {
   const [historyExpanded, setHistoryExpanded] = useState(false);
 
   useEffect(() => {
+    if (!id) {
+      setError("Invalid accessory route.");
+      setLoading(false);
+      return;
+    }
+
     fetch(`/api/accessories/${id}`)
       .then((r) => r.json())
       .then((data) => {

--- a/src/app/accessories/new/page.tsx
+++ b/src/app/accessories/new/page.tsx
@@ -305,14 +305,14 @@ export default function NewAccessoryPage() {
           <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href="/accessories"
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading}
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/app/ammo/new/page.tsx
+++ b/src/app/ammo/new/page.tsx
@@ -302,14 +302,14 @@ export default function NewAmmoStockPage() {
           <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href="/ammo"
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading}
-              className="flex items-center gap-2 bg-[#F5A623]/10 border border-[#F5A623]/30 text-[#F5A623] hover:bg-[#F5A623]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#F5A623]/10 border border-[#F5A623]/30 text-[#F5A623] hover:bg-[#F5A623]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -50,7 +50,15 @@ export default function DocumentLibraryPage() {
       });
   }, []);
 
-  const filtered = documents.filter((doc) => {
+  const safeDocuments = documents.map((doc) => ({
+    ...doc,
+    name: doc.name || "Untitled document",
+    type: doc.type || "OTHER",
+    createdAt: doc.createdAt || new Date(0).toISOString(),
+    fileUrl: doc.fileUrl || "#",
+  }));
+
+  const filtered = safeDocuments.filter((doc) => {
     if (typeFilter !== "ALL" && doc.type !== typeFilter) return false;
     if (entityFilter === "FIREARM" && !doc.firearmId) return false;
     if (entityFilter === "ACCESSORY" && !doc.accessoryId) return false;
@@ -175,9 +183,9 @@ export default function DocumentLibraryPage() {
         ) : filtered.length === 0 ? (
           <EmptyState
             icon={FileText}
-            title={documents.length === 0 ? "No documents yet" : "No documents match current filters"}
+            title={safeDocuments.length === 0 ? "No documents yet" : "No documents match current filters"}
             description={
-              documents.length === 0
+              safeDocuments.length === 0
                 ? "Upload your first receipt or photo to keep evidence attached to your records."
                 : "Adjust filters to view matching files."
             }
@@ -197,9 +205,9 @@ export default function DocumentLibraryPage() {
 
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <p className="truncate text-sm font-medium text-vault-text">{doc.name}</p>
+                      <p className="truncate break-all text-sm font-medium text-vault-text">{doc.name}</p>
                       <span className="rounded border border-vault-border px-1.5 py-0.5 text-[10px] text-vault-text-muted">
-                        {doc.type.replaceAll("_", " ")}
+                        {(doc.type || "OTHER").replaceAll("_", " ")}
                       </span>
                     </div>
                     <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-vault-text-faint">
@@ -214,7 +222,7 @@ export default function DocumentLibraryPage() {
                         </Link>
                       )}
                       {!doc.firearm && !doc.accessory && <span>Unattached</span>}
-                      <span>{new Date(doc.createdAt).toLocaleDateString()}</span>
+                      <span>{new Date(doc.createdAt || 0).toLocaleDateString()}</span>
                       {doc.fileSize && <span>{formatBytes(doc.fileSize)}</span>}
                     </div>
                   </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,9 +29,9 @@ export default function RootLayout({
         <ThemeProvider>
           <div className="flex min-h-svh">
             <Sidebar />
-            <div className="flex flex-col flex-1 min-w-0 min-h-svh">
+            <div className="flex flex-col flex-1 min-w-0 min-h-svh overflow-x-clip">
               <MobileHeader />
-              <main className="flex-1 min-h-0 overflow-y-auto overscroll-contain min-w-0 pb-safe">
+              <main className="flex-1 min-h-0 overflow-y-auto overflow-x-clip overscroll-contain min-w-0 pb-safe">
                 {children}
               </main>
             </div>

--- a/src/app/vault/[id]/builds/new/page.tsx
+++ b/src/app/vault/[id]/builds/new/page.tsx
@@ -28,10 +28,11 @@ interface Firearm {
 export default function NewBuildPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
-  const firearmId = params.id;
+  const firearmId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const invalidRoute = !firearmId;
 
   const [firearm, setFirearm] = useState<Firearm | null>(null);
-  const [firearmLoading, setFirearmLoading] = useState(true);
+  const [firearmLoading, setFirearmLoading] = useState(!invalidRoute);
   const [firearmError, setFirearmError] = useState<string | null>(null);
 
   const [loading, setLoading] = useState(false);
@@ -39,6 +40,8 @@ export default function NewBuildPage() {
   const [isActive, setIsActive] = useState(false);
 
   useEffect(() => {
+    if (!firearmId) return;
+
     fetch(`/api/firearms/${firearmId}`)
       .then((r) => r.json())
       .then((data) => {
@@ -96,6 +99,18 @@ export default function NewBuildPage() {
     return (
       <div className="flex items-center justify-center min-h-full">
         <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
+      </div>
+    );
+  }
+
+  if (invalidRoute) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+        <AlertCircle className="w-10 h-10 text-[#E53935]" />
+        <p className="text-[#E53935]">Invalid firearm route.</p>
+        <Link href="/vault" className="text-sm text-[#00C2FF] hover:underline">
+          Back to Vault
+        </Link>
       </div>
     );
   }
@@ -227,17 +242,17 @@ export default function NewBuildPage() {
             </button>
           </fieldset>
 
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href={`/vault/${firearmId}`}
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading}
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/app/vault/[id]/edit/page.tsx
+++ b/src/app/vault/[id]/edit/page.tsx
@@ -41,10 +41,11 @@ function toDateInputValue(dateStr: string | null): string {
 export default function EditFirearmPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
-  const firearmId = params.id;
+  const firearmId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const invalidRoute = !firearmId;
 
   const [firearm, setFirearm] = useState<Firearm | null>(null);
-  const [dataLoading, setDataLoading] = useState(true);
+  const [dataLoading, setDataLoading] = useState(!invalidRoute);
   const [dataError, setDataError] = useState<string | null>(null);
 
   const [loading, setLoading] = useState(false);
@@ -61,6 +62,8 @@ export default function EditFirearmPage() {
   );
 
   useEffect(() => {
+    if (!firearmId) return;
+
     fetch(`/api/firearms/${firearmId}`)
       .then((r) => r.json())
       .then((data) => {
@@ -134,6 +137,18 @@ export default function EditFirearmPage() {
     return (
       <div className="flex items-center justify-center min-h-full">
         <Loader2 className="w-8 h-8 text-[#00C2FF] animate-spin" />
+      </div>
+    );
+  }
+
+  if (invalidRoute) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+        <AlertCircle className="w-10 h-10 text-[#E53935]" />
+        <p className="text-[#E53935]">Invalid firearm route.</p>
+        <Link href="/vault" className="text-sm text-[#00C2FF] hover:underline">
+          Back to Vault
+        </Link>
       </div>
     );
   }
@@ -419,17 +434,17 @@ export default function EditFirearmPage() {
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href={`/vault/${firearmId}`}
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading || success}
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/app/vault/new/page.tsx
+++ b/src/app/vault/new/page.tsx
@@ -322,17 +322,17 @@ export default function NewFirearmPage() {
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
+          <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
             <Link
               href="/vault"
-              className="px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
+              className="w-full sm:w-auto text-center px-4 py-2 text-sm text-vault-text-muted hover:text-vault-text border border-vault-border rounded-md hover:border-vault-text-muted/30 transition-colors"
             >
               Cancel
             </Link>
             <button
               type="submit"
               disabled={loading}
-              className="flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
+              className="w-full sm:w-auto justify-center flex items-center gap-2 bg-[#00C2FF]/10 border border-[#00C2FF]/30 text-[#00C2FF] hover:bg-[#00C2FF]/20 disabled:opacity-50 disabled:cursor-not-allowed px-5 py-2 rounded-md text-sm font-medium transition-colors"
             >
               {loading ? (
                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -10,18 +10,32 @@ export function MobileHeader() {
   useEffect(() => {
     if (!open) return;
     const previous = document.body.style.overflow;
+    const previousOverscroll = document.body.style.overscrollBehavior;
     document.body.style.overflow = "hidden";
+    document.body.style.overscrollBehavior = "none";
     return () => {
       document.body.style.overflow = previous;
+      document.body.style.overscrollBehavior = previousOverscroll;
     };
   }, [open]);
 
+  useEffect(() => {
+    const onResize = () => {
+      if (window.innerWidth >= 768) {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
   return (
     <>
-      <header className="md:hidden sticky top-0 z-[350] flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface shrink-0">
+      <header className="md:hidden sticky top-0 z-[450] flex items-center gap-3 h-14 px-4 border-b border-vault-border bg-vault-surface/95 backdrop-blur shrink-0">
         <button
           onClick={() => setOpen((prev) => !prev)}
-          className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"
+          className="inline-flex min-h-10 items-center gap-1.5 px-2 py-1.5 rounded-md border border-vault-border text-vault-text-faint hover:text-vault-text-muted hover:bg-vault-border/60 transition-colors"
           aria-label="Open navigation"
           aria-expanded={open}
           aria-controls="mobile-navigation"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -96,7 +96,7 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
           const Icon = item.icon;
           const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
           return (
-            <Link key={item.href} href={item.href} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
+            <Link key={item.href} href={item.href} onClick={() => onMobileClose?.()} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
               {isActive && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
               <Icon className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", isActive ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
               {!collapsed && (
@@ -136,7 +136,7 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
               {RANGE_CHILD_ITEMS.map((item) => {
                 const Icon = item.icon;
                 return (
-                  <Link key={item.href} href={item.href} className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-vault-text-muted hover:text-vault-text hover:bg-vault-border transition-colors">
+                  <Link key={item.href} href={item.href} onClick={() => onMobileClose?.()} className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-vault-text-muted hover:text-vault-text hover:bg-vault-border transition-colors">
                     <Icon className="w-3.5 h-3.5 text-vault-text-faint" />
                     <span>{item.label}</span>
                   </Link>
@@ -151,7 +151,7 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
             const Icon = item.icon;
             const isActive = pathname.startsWith(item.href);
             return (
-              <Link key={item.href} href={item.href} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
+              <Link key={item.href} href={item.href} onClick={() => onMobileClose?.()} title={collapsed ? item.label : undefined} className={cn("flex items-center gap-3 px-2.5 py-2 rounded-md text-sm transition-all duration-150 group relative", isActive ? "bg-[#00C2FF]/10 text-[#00C2FF] border border-[#00C2FF]/20" : "text-vault-text-muted hover:text-vault-text hover:bg-vault-border")}>
                 {isActive && <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-[#00C2FF] rounded-r-full" />}
                 <Icon className={cn("shrink-0 transition-colors", collapsed ? "w-5 h-5" : "w-4 h-4", isActive ? "text-[#00C2FF]" : "text-vault-text-faint group-hover:text-vault-text-muted")} />
                 {!collapsed && (
@@ -182,7 +182,7 @@ export function Sidebar({ mobileOnly = false, mobileOpen = false, onMobileClose 
         </aside>
       )}
 
-      <div className={cn("fixed inset-0 z-[300] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")} aria-hidden={!mobileOpen}>
+      <div className={cn("fixed inset-0 z-[420] md:hidden transition-opacity", mobileOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0")} aria-hidden={!mobileOpen}>
         <div className="absolute inset-0 bg-black/60" onClick={onMobileClose} />
         <aside
           id="mobile-navigation"

--- a/src/components/shared/PageHeader.tsx
+++ b/src/components/shared/PageHeader.tsx
@@ -11,12 +11,12 @@ interface PageHeaderProps {
 export function PageHeader({ title, subtitle, actions, className }: PageHeaderProps) {
   return (
     <div className={cn("border-b border-vault-border px-4 py-5 sm:px-6", className)}>
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-lg font-bold tracking-tight text-vault-text sm:text-xl">{title}</h1>
           {subtitle && <p className="mt-1 text-sm text-vault-text-muted">{subtitle}</p>}
         </div>
-        {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+        {actions && <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">{actions}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and confusing UI when route params are missing or are arrays instead of strings. 
- Improve mobile navigation UX by preventing body scroll/overscroll while the mobile menu is open and closing the menu on navigation or viewport changes. 
- Make document listing resilient to missing/invalid document fields and avoid horizontal overflow and truncation issues across the app. 

### Description
- Normalize route params with `Array.isArray(params.id) ? params.id[0] : params.id` in multiple pages and add an `invalidRoute` early-exit UI and logic to avoid unnecessary fetches and loading states (`accessories/[id]/edit`, `accessories/[id]/page`, `vault/[id]/edit`, `vault/[id]/builds/new`, `vault/[id]/builds/new` and related new/edit pages). 
- Adjust action button layout to stack on small screens and make cancel/submit buttons full width on mobile by changing containers to `flex-col-reverse sm:flex-row` and buttons to `w-full sm:w-auto` in several forms (`new` and `edit` pages for accessories, ammo, vault, builds). 
- Sanitize documents list entries by mapping documents to safe defaults for `name`, `type`, `createdAt`, and `fileUrl`, improve name wrapping (`break-all`) and guard `createdAt` usage and `type` formatting in `documents/page.tsx`. 
- Prevent horizontal overflow by adding `overflow-x-clip` to the main layout and `main` element in `layout.tsx`. 
- Improve mobile header and sidebar behavior: lock both `overflow` and `overscrollBehavior` on open, add a resize listener to close the mobile menu on larger viewports, increase z-index and add backdrop blur on the mobile header, and ensure mobile navigations close the menu when links are clicked in `MobileHeader.tsx` and `Sidebar.tsx`. 
- Tweak `PageHeader` to include `min-w-0` and make actions container responsive so action elements don't cause layout overflow. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d7ae72f883269bfc936c5b883803)