### PR TITLE
fix: normalize Uint8Array for Blob to resolve Docker TS build error

### DIFF
--- a/src/lib/exports/full-armory-pdf.ts
+++ b/src/lib/exports/full-armory-pdf.ts
@@ -398,7 +398,8 @@ export async function generateFullArmoryPdf(
   }
 
   const mergedBytes = await mergedDoc.save();
-  const blob = new Blob([mergedBytes], { type: "application/pdf" });
+  const safeBytes = new Uint8Array(mergedBytes); // normalize to concrete ArrayBuffer
+  const blob = new Blob([safeBytes], { type: "application/pdf" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;


### PR DESCRIPTION
## Summary
- Fixes TypeScript build error in `src/lib/exports/full-armory-pdf.ts` line 401
- `mergedDoc.save()` returns `Uint8Array<ArrayBufferLike>`, which stricter TS 5.x compilers reject as `BlobPart`
- Inserts `const safeBytes = new Uint8Array(mergedBytes)` to normalize to a concrete buffer before passing to `Blob`

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors in this file
- [ ] Docker production build completes without TypeScript errors
- [ ] Full Armory PDF export still generates and downloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)