### PR TITLE
feat: working backup/restore system

### DIFF
--- a/src/app/api/backup/restore/route.ts
+++ b/src/app/api/backup/restore/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/server/auth";
+
+const REQUIRED_ARRAY_KEYS = [
+  "firearms",
+  "builds",
+  "buildSlots",
+  "accessories",
+  "documents",
+  "roundCountLogs",
+  "ammoStocks",
+  "ammoTransactions",
+  "rangeSessions",
+  "rangeSessionAmmoLinks",
+  "sessionDrills",
+  "imageCache",
+] as const;
+
+type BackupBody = { meta: { version: string } } & Record<
+  (typeof REQUIRED_ARRAY_KEYS)[number],
+  unknown[]
+>;
+
+function isValidBackup(body: unknown): body is BackupBody {
+  if (typeof body !== "object" || body === null) return false;
+  const b = body as Record<string, unknown>;
+  if (!b.meta || typeof (b.meta as Record<string, unknown>).version !== "string") return false;
+  return REQUIRED_ARRAY_KEYS.every((k) => Array.isArray(b[k]));
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth();
+  if (auth) return auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isValidBackup(body)) {
+    return NextResponse.json(
+      { error: "Invalid backup file. Missing required fields or wrong format." },
+      { status: 400 }
+    );
+  }
+
+  const {
+    firearms,
+    builds,
+    buildSlots,
+    accessories,
+    documents,
+    roundCountLogs,
+    ammoStocks,
+    ammoTransactions,
+    rangeSessions,
+    rangeSessionAmmoLinks,
+    sessionDrills,
+    imageCache,
+  } = body;
+
+  try {
+    await prisma.$transaction(
+      async (tx) => {
+        // Delete in FK-safe order (children before parents — mirrors reset-db.ts)
+        await tx.sessionDrill.deleteMany();
+        await tx.rangeSessionAmmoLink.deleteMany();
+        await tx.ammoTransaction.deleteMany();
+        await tx.rangeSession.deleteMany();
+        await tx.roundCountLog.deleteMany();
+        await tx.buildSlot.deleteMany();
+        await tx.build.deleteMany();
+        await tx.document.deleteMany();
+        await tx.imageCache.deleteMany();
+        await tx.accessory.deleteMany();
+        await tx.ammoStock.deleteMany();
+        await tx.firearm.deleteMany();
+        // AppSettings intentionally NOT touched — preserve LAN/path config
+
+        // Insert in parent-first order
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (firearms.length) await tx.firearm.createMany({ data: firearms as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (accessories.length) await tx.accessory.createMany({ data: accessories as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (ammoStocks.length) await tx.ammoStock.createMany({ data: ammoStocks as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (builds.length) await tx.build.createMany({ data: builds as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (buildSlots.length) await tx.buildSlot.createMany({ data: buildSlots as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (documents.length) await tx.document.createMany({ data: documents as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (imageCache.length) await tx.imageCache.createMany({ data: imageCache as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (rangeSessions.length) await tx.rangeSession.createMany({ data: rangeSessions as any[] });
+        if (rangeSessionAmmoLinks.length)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.rangeSessionAmmoLink.createMany({ data: rangeSessionAmmoLinks as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (ammoTransactions.length) await tx.ammoTransaction.createMany({ data: ammoTransactions as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (roundCountLogs.length) await tx.roundCountLog.createMany({ data: roundCountLogs as any[] });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (sessionDrills.length) await tx.sessionDrill.createMany({ data: sessionDrills as any[] });
+      },
+      { timeout: 30000 }
+    );
+
+    return NextResponse.json({
+      success: true,
+      counts: Object.fromEntries(REQUIRED_ARRAY_KEYS.map((k) => [k, body[k].length])),
+    });
+  } catch (error) {
+    console.error("POST /api/backup/restore error:", error);
+    return NextResponse.json(
+      { error: "Restore failed. Your data has not been modified." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/server/auth";
+import fs from "fs";
+import path from "path";
+
+export async function POST() {
+  const auth = await requireAuth();
+  if (auth) return auth;
+
+  try {
+    // Sequential queries — connection_limit=1 means Promise.all would deadlock
+    const firearms             = await prisma.firearm.findMany({ orderBy: { createdAt: "asc" } });
+    const builds               = await prisma.build.findMany({ orderBy: { createdAt: "asc" } });
+    const buildSlots           = await prisma.buildSlot.findMany();
+    const accessories          = await prisma.accessory.findMany({ orderBy: { createdAt: "asc" } });
+    const documents            = await prisma.document.findMany({ orderBy: { createdAt: "asc" } });
+    const roundCountLogs       = await prisma.roundCountLog.findMany({ orderBy: { loggedAt: "asc" } });
+    const ammoStocks           = await prisma.ammoStock.findMany({ orderBy: { createdAt: "asc" } });
+    const ammoTransactions     = await prisma.ammoTransaction.findMany({ orderBy: { transactedAt: "asc" } });
+    const rangeSessions        = await prisma.rangeSession.findMany({ orderBy: { sessionDate: "asc" } });
+    const rangeSessionAmmoLinks = await prisma.rangeSessionAmmoLink.findMany();
+    const sessionDrills        = await prisma.sessionDrill.findMany({ orderBy: { createdAt: "asc" } });
+    const imageCache           = await prisma.imageCache.findMany();
+    const settings             = await prisma.appSettings.findUnique({ where: { id: "singleton" } });
+
+    const now = new Date();
+    const timestamp = now.toISOString().replace(/[-:]/g, "").replace("T", "-").slice(0, 15);
+
+    const backupData = {
+      firearms,
+      builds,
+      buildSlots,
+      accessories,
+      documents,
+      roundCountLogs,
+      ammoStocks,
+      ammoTransactions,
+      rangeSessions,
+      rangeSessionAmmoLinks,
+      sessionDrills,
+      imageCache,
+    };
+
+    const meta = {
+      version: "1.0",
+      createdAt: now.toISOString(),
+      includeUploads: settings?.includeUploadsInBackup ?? true,
+      counts: Object.fromEntries(Object.entries(backupData).map(([k, v]) => [k, v.length])),
+    };
+
+    const payload = { meta, ...backupData };
+    const json = JSON.stringify(payload, null, 2);
+    const sizeMB = (Buffer.byteLength(json, "utf8") / 1_048_576).toFixed(2);
+
+    const filename = `blackvault-backup-${timestamp}.json`;
+
+    // Optional server-side save — non-fatal if it fails
+    let savedToPath: string | undefined;
+    if (settings?.backupDestinationPath) {
+      try {
+        const destDir = settings.backupDestinationPath;
+        if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+        const fullPath = path.join(destDir, filename);
+        fs.writeFileSync(fullPath, json, "utf8");
+        savedToPath = fullPath;
+      } catch (fsErr) {
+        console.warn("Could not write backup to disk:", fsErr);
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      filename,
+      meta,
+      data: backupData,
+      savedToPath,
+      sizeMB,
+    });
+  } catch (error) {
+    console.error("POST /api/backup error:", error);
+    return NextResponse.json({ error: "Failed to generate backup" }, { status: 500 });
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Archive, Copy, Download, Files, Settings } from "lucide-react";
+import { Archive, Copy, Download, Files, HardDriveDownload, RotateCcw, Settings, Upload } from "lucide-react";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusMessage } from "@/components/shared/StatusMessage";
@@ -30,6 +30,15 @@ export default function SettingsPage() {
   const [isDocker, setIsDocker] = useState(false);
   const [copySuccess, setCopySuccess] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState<string>("");
+
+  const [backupStatus, setBackupStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [backupResult, setBackupResult] = useState<{ filename: string; savedToPath?: string; sizeMB: string } | null>(null);
+  const [backupError, setBackupError] = useState<string | null>(null);
+  const [restoreStatus, setRestoreStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+  const [pendingRestoreFile, setPendingRestoreFile] = useState<File | null>(null);
+  const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
+  const [restoreCounts, setRestoreCounts] = useState<Record<string, number> | null>(null);
 
   useEffect(() => {
     fetch("/api/settings")
@@ -129,6 +138,80 @@ export default function SettingsPage() {
     }
   }
 
+  async function handleBackupNow() {
+    setBackupStatus("loading");
+    setBackupError(null);
+    setBackupResult(null);
+    try {
+      const res = await fetch("/api/backup", { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setBackupStatus("error");
+        setBackupError(json.error ?? "Backup failed.");
+        return;
+      }
+      const filename = json.filename as string;
+      const blob = new Blob([JSON.stringify({ meta: json.meta, ...json.data }, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setBackupResult({ filename, savedToPath: json.savedToPath, sizeMB: json.sizeMB });
+      setBackupStatus("success");
+      setTimeout(() => { setBackupStatus("idle"); setBackupResult(null); }, 8000);
+    } catch {
+      setBackupStatus("error");
+      setBackupError("Network error. Could not reach the backup endpoint.");
+    }
+  }
+
+  function handleRestoreFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setPendingRestoreFile(e.target.files?.[0] ?? null);
+    setShowRestoreConfirm(false);
+    setRestoreStatus("idle");
+    setRestoreError(null);
+    setRestoreCounts(null);
+  }
+
+  async function handleRestoreConfirm() {
+    if (!pendingRestoreFile) return;
+    setShowRestoreConfirm(false);
+    setRestoreStatus("loading");
+    setRestoreError(null);
+    try {
+      const text = await pendingRestoreFile.text();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        setRestoreStatus("error");
+        setRestoreError("The selected file is not valid JSON. Please select a .json backup file.");
+        return;
+      }
+      const res = await fetch("/api/backup/restore", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setRestoreStatus("error");
+        setRestoreError(json.error ?? "Restore failed. Your data was not modified.");
+        return;
+      }
+      setRestoreCounts(json.counts);
+      setRestoreStatus("success");
+      setPendingRestoreFile(null);
+    } catch {
+      setRestoreStatus("error");
+      setRestoreError("Network error during restore.");
+    }
+  }
+
   if (dataLoading) {
     return (
       <div className="mx-auto max-w-4xl p-4 sm:p-6">
@@ -211,7 +294,7 @@ export default function SettingsPage() {
 
             <FormField
               label="Preferred Backup Destination Path"
-              hint="Saved as a reference path for your backup process. Exports are still downloaded through your browser in V1."
+              hint="If set, Backup Now will also save the file here on the server in addition to downloading it."
             >
               <input
                 id="backupDestinationPath"
@@ -221,7 +304,130 @@ export default function SettingsPage() {
                 className={INPUT_CLASS}
                 placeholder="/srv/blackvault/backups or D:\\Backups\\BlackVault"
               />
+              <p className="mt-1 text-xs text-vault-text-muted">
+                When running in Docker, this path must be inside a mounted volume (e.g.{" "}
+                <span className="font-mono">/app/data/backups</span>).
+              </p>
             </FormField>
+
+            {/* Backup Now */}
+            <div className="rounded-lg border border-vault-border bg-vault-bg p-4 flex flex-col gap-3">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-vault-text">Backup Now</p>
+                  <p className="mt-0.5 text-xs text-vault-text-muted">
+                    Downloads a complete JSON backup of all vault data.
+                    {backupDestinationPath && " Also saves to your configured destination."}
+                  </p>
+                </div>
+                <StandardButton
+                  type="button"
+                  variant="primary"
+                  onClick={handleBackupNow}
+                  disabled={backupStatus === "loading"}
+                  loading={backupStatus === "loading"}
+                  loadingLabel="Backing up…"
+                  icon={<HardDriveDownload className="h-4 w-4" />}
+                >
+                  Backup Now
+                </StandardButton>
+              </div>
+              {backupStatus === "success" && backupResult && (
+                <div className="rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2 flex flex-col gap-0.5">
+                  <p className="text-xs font-medium text-[#00C853]">Backup complete</p>
+                  <p className="font-mono text-xs text-[#00C853]/80">{backupResult.filename}</p>
+                  <p className="text-xs text-[#00C853]/70">{backupResult.sizeMB} MB</p>
+                  {backupResult.savedToPath && (
+                    <p className="text-xs text-[#00C853]/70">
+                      Also saved to: <span className="font-mono">{backupResult.savedToPath}</span>
+                    </p>
+                  )}
+                </div>
+              )}
+              {backupStatus === "error" && backupError && (
+                <StatusMessage tone="error" message={backupError} />
+              )}
+            </div>
+
+            {/* Restore from Backup */}
+            <div className="rounded-lg border border-vault-border bg-vault-bg p-4 flex flex-col gap-3">
+              <div>
+                <p className="text-sm font-medium text-vault-text">Restore from Backup</p>
+                <p className="mt-0.5 text-xs text-vault-text-muted">
+                  Replaces ALL current data with the contents of a backup file. This cannot be undone.
+                </p>
+              </div>
+              <div className="flex items-center gap-3 flex-wrap">
+                <label
+                  htmlFor="restore-file-input"
+                  className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-vault-border bg-vault-surface px-3 py-2 text-sm text-vault-text-muted hover:text-vault-text transition-colors"
+                >
+                  <Upload className="h-4 w-4" />
+                  {pendingRestoreFile ? pendingRestoreFile.name : "Choose .json backup file"}
+                </label>
+                <input
+                  id="restore-file-input"
+                  type="file"
+                  accept=".json,application/json"
+                  className="sr-only"
+                  onChange={handleRestoreFileChange}
+                />
+                {pendingRestoreFile && !showRestoreConfirm && restoreStatus === "idle" && (
+                  <StandardButton
+                    type="button"
+                    variant="danger"
+                    onClick={() => setShowRestoreConfirm(true)}
+                    icon={<RotateCcw className="h-4 w-4" />}
+                  >
+                    Restore
+                  </StandardButton>
+                )}
+              </div>
+              {showRestoreConfirm && pendingRestoreFile && (
+                <div className="rounded-lg border border-[#E53935]/30 bg-[#E53935]/10 p-3 flex flex-col gap-2">
+                  <p className="text-sm font-medium text-[#E53935]">
+                    This will wipe all current data and replace it with the backup. Are you sure?
+                  </p>
+                  <p className="text-xs text-[#E53935]/70">File: {pendingRestoreFile.name}</p>
+                  <p className="text-xs text-[#E53935]/70">Do not navigate away while restore is in progress.</p>
+                  <div className="flex gap-2">
+                    <StandardButton
+                      type="button"
+                      variant="danger"
+                      onClick={handleRestoreConfirm}
+                      disabled={restoreStatus === "loading"}
+                      loading={restoreStatus === "loading"}
+                      loadingLabel="Restoring…"
+                      icon={<RotateCcw className="h-4 w-4" />}
+                    >
+                      Yes, Restore
+                    </StandardButton>
+                    <StandardButton
+                      type="button"
+                      variant="secondary"
+                      onClick={() => { setShowRestoreConfirm(false); setPendingRestoreFile(null); }}
+                    >
+                      Cancel
+                    </StandardButton>
+                  </div>
+                </div>
+              )}
+              {restoreStatus === "loading" && (
+                <p className="text-xs text-vault-text-muted">Restoring data, please wait…</p>
+              )}
+              {restoreStatus === "success" && restoreCounts && (
+                <div className="rounded-md border border-[#00C853]/30 bg-[#00C853]/10 px-3 py-2 flex flex-col gap-0.5">
+                  <p className="text-xs font-medium text-[#00C853]">Restore complete. Data has been replaced.</p>
+                  <p className="text-xs text-[#00C853]/70">
+                    {restoreCounts.firearms ?? 0} firearms · {restoreCounts.accessories ?? 0} accessories ·{" "}
+                    {restoreCounts.ammoStocks ?? 0} ammo stocks · {restoreCounts.rangeSessions ?? 0} range sessions
+                  </p>
+                </div>
+              )}
+              {restoreStatus === "error" && restoreError && (
+                <StatusMessage tone="error" message={restoreError} />
+              )}
+            </div>
           </div>
         </SectionCard>
 


### PR DESCRIPTION
## Summary

- **Backup Now button** in Settings → Backup section: triggers `POST /api/backup`, downloads `blackvault-backup-YYYYMMDD-HHmmss.json` to the browser, and saves a copy server-side if `backupDestinationPath` is configured
- **Restore from Backup**: file picker → inline red confirmation → `POST /api/backup/restore` wipes all data atomically and re-imports from the JSON file; `AppSettings` is preserved across restore
- Green success state shows filename (server-generated, consistent), file size, and server save path if applicable; auto-dismisses after 8s
- Restore is fully transactional — any failure rolls back and data is unchanged

## API

- `POST /api/backup` — queries all 12 Prisma tables sequentially (safe with `connection_limit=1`), returns flat JSON backup + metadata
- `POST /api/backup/restore` — validates structure, runs `$transaction` with FK-safe delete order then parent-first insert order

## Test plan

- [x] Go to `/settings` → click **Backup Now** → browser downloads `.json` file, green success state appears with filename and size
- [x] Set `Preferred Backup Destination Path` (e.g. `/tmp/bv-test`), save settings, click **Backup Now** → `savedToPath` shown in success state, file exists at that path
- [x] Pick the downloaded `.json` in **Restore from Backup** → click Restore → confirm → success state shows row counts → navigate to `/vault` and verify data matches backup
- [x] Try restoring a non-JSON file → client-side "not valid JSON" error shown before any fetch
- [x] Try restoring `package.json` → "Invalid backup file" 400 error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)